### PR TITLE
Configure the asciidoc engine properly with attributes in AsciidocEng…

### DIFF
--- a/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/AsciidocEngine.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/AsciidocEngine.java
@@ -39,7 +39,6 @@ import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.ast.Document;
-import org.asciidoctor.ast.DocumentHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,13 +142,24 @@ public class AsciidocEngine {
      */
     public Map<String, Object> readDocumentHeader(File source){
         checkValidFile(source, "source");
-        DocumentHeader header = asciidoctor.readDocumentHeader(source);
+        final OptionsBuilder optionsBuilder = OptionsBuilder.options()
+                .attributes(
+                        AttributesBuilder
+                                .attributes()
+                                .attributes(attributes))
+                .backend(this.backend)
+                .safe(SafeMode.UNSAFE)
+                .headerFooter(false)
+                .eruby("")
+                .baseDir(source.getParentFile())
+                .option("parse_header_only", true);
+        Document doc = asciidoctor.loadFile(source, optionsBuilder.asMap());
         Map<String, Object> headerMap = new HashMap<>();
         String h1 = parseSection0Title(source);
         if (h1 != null) {
             headerMap.put("h1", h1);
         }
-        headerMap.putAll(header.getAttributes());
+        headerMap.putAll(doc.getAttributes());
         return headerMap;
     }
 

--- a/sitegen/src/main/java/io/helidon/sitegen/maven/GenerateMojo.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/maven/GenerateMojo.java
@@ -89,10 +89,12 @@ public class GenerateMojo extends AbstractMojo {
 
         project.addCompileSourceRoot(siteSourceDirectory.getAbsolutePath());
 
-        Properties properties = new Properties(project.getProperties());
+        Properties properties = new Properties();
+        properties.putAll(project.getProperties());
         properties.setProperty("project.groupId", project.getGroupId());
         properties.setProperty("project.artifactId", project.getArtifactId());
         properties.setProperty("project.version", project.getVersion());
+        properties.setProperty("project.basedir", project.getBasedir().getAbsolutePath());
 
         site = Site.builder()
                 .config(siteConfigFile, properties)


### PR DESCRIPTION
…ine.readDocumentHeader

This fixes warning(s) about unknown attribute(s)

Update GenerateMojo to inject all project properties correctly.
I.e do new Properties().putAll(project.getProperties()) instead of new Properties(project.getProperties())
The latter does create empty properties with default.

Add a property mapping for project.basedir.