### PR TITLE
add fixes for windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 
         Changing these version requires approval for a new third party dependency!
         -->
-        <version.lib.asciidoctorj>1.6.0-alpha.6</version.lib.asciidoctorj>
+        <version.lib.asciidoctorj>1.6.0-RC.2</version.lib.asciidoctorj>
         <version.lib.asciidoctorj-diagram>1.5.4.1</version.lib.asciidoctorj-diagram>
         <version.lib.checkstyle>7.4</version.lib.checkstyle>
         <version.lib.diffutils>2.2</version.lib.diffutils>
@@ -442,6 +442,11 @@
             </dependency>
             <dependency>
                 <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctorj-api</artifactId>
+                <version>${version.lib.asciidoctorj}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj</artifactId>
                 <version>${version.lib.asciidoctorj}</version>
             </dependency>
@@ -458,6 +463,11 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
+                <version>${version.lib.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
                 <version>${version.lib.slf4j}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <properties>
         <java.version>8</java.version>
 
-        <surefire.argLine>-Xmx1024m -Dfile.encoding=UTF8</surefire.argLine>
+        <surefire.argLine>-Xmx1024m -Dfile.encoding=UTF-8</surefire.argLine>
         <surefire.coverage.argline />
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sitegen/pom.xml
+++ b/sitegen/pom.xml
@@ -76,6 +76,11 @@
         </dependency>
         <dependency>
             <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
         </dependency>
         <dependency>
@@ -85,6 +90,10 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/sitegen/src/main/java/io/helidon/sitegen/Helper.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/Helper.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 
 import io.helidon.sitegen.asciidoctor.AsciidocConverter;
+import java.nio.file.Paths;
 
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +90,7 @@ public abstract class Helper {
                 templatesDir = fs.getPath(relativePath);
                 break;
             case "file":
-                templatesDir = new File(templatesDirURI).toPath();
+                templatesDir = Paths.get(templatesDirURI);
                 break;
             default:
                 throw new IllegalStateException(templatesDirURI.toASCIIString()

--- a/sitegen/src/main/java/io/helidon/sitegen/Helper.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/Helper.java
@@ -28,11 +28,11 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 
 import io.helidon.sitegen.asciidoctor.AsciidocConverter;
-import java.nio.file.Paths;
 
 import org.slf4j.LoggerFactory;
 

--- a/sitegen/src/main/java/io/helidon/sitegen/Helper.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/Helper.java
@@ -277,6 +277,6 @@ public abstract class Helper {
     public static String getRelativePath(File sourcedir, File source) {
         return sourcedir.toPath().relativize(source.toPath()).toString()
                 // force UNIX style path on windows
-                .replace("\\","/");
+                .replace("\\", "/");
     }
 }

--- a/sitegen/src/main/java/io/helidon/sitegen/Helper.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/Helper.java
@@ -89,8 +89,7 @@ public abstract class Helper {
                 templatesDir = fs.getPath(relativePath);
                 break;
             case "file":
-                templatesDir = FileSystems.getDefault().getPath(
-                        templatesDirURI.getSchemeSpecificPart());
+                templatesDir = new File(templatesDirURI).toPath();
                 break;
             default:
                 throw new IllegalStateException(templatesDirURI.toASCIIString()
@@ -275,6 +274,6 @@ public abstract class Helper {
      * @return the relative path of the source file
      */
     public static String getRelativePath(File sourcedir, File source) {
-        return sourcedir.toPath().relativize(source.toPath()).toString();
+        return sourcedir.toURI().relativize(source.toURI()).toString();
     }
 }

--- a/sitegen/src/main/java/io/helidon/sitegen/Helper.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/Helper.java
@@ -275,6 +275,8 @@ public abstract class Helper {
      * @return the relative path of the source file
      */
     public static String getRelativePath(File sourcedir, File source) {
-        return sourcedir.toURI().relativize(source.toURI()).toString();
+        return sourcedir.toPath().relativize(source.toPath()).toString()
+                // force UNIX style path on windows
+                .replace("\\","/");
     }
 }

--- a/sitegen/src/main/java/io/helidon/sitegen/SiteEngine.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/SiteEngine.java
@@ -83,6 +83,15 @@ public class SiteEngine {
     }
 
     /**
+     * Remove the {@link SiteEngine} registered for the given backend.
+     * @param backend the backend to remove
+     */
+    public static void deregister(String backend) {
+        checkNonNullNonEmpty(backend, BACKEND_PROP);
+        REGISTRY.remove(backend);
+    }
+
+    /**
      * Get a {@link SiteEngine} from the registry.
      * @param backend the backend name identifying the registered {@link SiteEngine}
      * @return instance of {@link SiteEngine}, never {@code null}

--- a/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/AsciidocEngine.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/AsciidocEngine.java
@@ -39,9 +39,9 @@ import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.ast.Document;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import static io.helidon.sitegen.Helper.checkNonNull;
 import static io.helidon.sitegen.Helper.checkNonNullNonEmpty;
@@ -91,7 +91,7 @@ public class AsciidocEngine {
         this.attributes = attributes == null ? Collections.emptyMap() : attributes;
         this.libraries = libraries == null ? Collections.emptyList() : libraries;
         this.imagesdir = imagesdir == null ? DEFAULT_IMAGESDIR : imagesdir;
-        if(asciidoctorInstance == null){
+        if (asciidoctorInstance == null) {
             asciidoctorInstance = Asciidoctor.Factory.create();
         }
         this.asciidoctor = asciidoctorInstance;

--- a/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/CardBlockProcessor.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/CardBlockProcessor.java
@@ -17,14 +17,14 @@
 package io.helidon.sitegen.asciidoctor;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.Contexts;
 import org.asciidoctor.extension.Reader;
-
-import static org.asciidoctor.extension.Contexts.OPEN;
 
 /**
  * A {@link BlockProcessor} implementation that provides custom asciidoc syntax
@@ -35,12 +35,15 @@ import static org.asciidoctor.extension.Contexts.OPEN;
 public class CardBlockProcessor extends BlockProcessor {
 
     /**
+     * This block is of type open (delimited by --).
+     */
+    private static final Map<String, Object> CONFIG = createConfig(Contexts.OPEN);
+
+    /**
      * Create a new instance of {@link CardBlockProcessor}.
      */
     public CardBlockProcessor() {
-        super("CARD");
-        // this block is of type open (delimited by --)
-        config.put(CONTEXTS, Arrays.asList(OPEN));
+        super("CARD", CONFIG);
         setConfigFinalized();
     }
 
@@ -50,8 +53,19 @@ public class CardBlockProcessor extends BlockProcessor {
                           Map<String, Object> attributes) {
 
         // create a block with context "card", and put the parsed content into it
-        Block block = this.createBlock(parent, "card", reader.readLines(),
+        Block block = this.createBlock(parent, "CARD", reader.readLines(),
                 attributes);
         return block;
+    }
+
+    /**
+     * Create a block processor configuration.
+     * @param blockType the type of block
+     * @return map
+     */
+    private static Map<String, Object> createConfig(String ... blockTypes){
+        Map<String, Object> config = new HashMap<>();
+        config.put(Contexts.KEY, Arrays.asList(blockTypes));
+        return config;
     }
 }

--- a/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/CardBlockProcessor.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/CardBlockProcessor.java
@@ -53,7 +53,7 @@ public class CardBlockProcessor extends BlockProcessor {
                           Map<String, Object> attributes) {
 
         // create a block with context "card", and put the parsed content into it
-        Block block = this.createBlock(parent, "CARD", reader.readLines(),
+        Block block = this.createBlock(parent, "card", reader.readLines(),
                 attributes);
         return block;
     }

--- a/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/PillarsBlockProcessor.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/PillarsBlockProcessor.java
@@ -57,7 +57,7 @@ public class PillarsBlockProcessor extends BlockProcessor {
         // means it can have nested blocks
         opts.put("content_model", "compound");
         // create an empty block with context "pillars"
-        Block block = this.createBlock(parent, "PILLARS",
+        Block block = this.createBlock(parent, "pillars",
                 Collections.emptyList(), attributes, opts);
         return block;
     }

--- a/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/PillarsBlockProcessor.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/asciidoctor/PillarsBlockProcessor.java
@@ -24,10 +24,8 @@ import java.util.Map;
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.Contexts;
 import org.asciidoctor.extension.Reader;
-
-import static org.asciidoctor.extension.BlockProcessor.CONTEXTS;
-import static org.asciidoctor.extension.Contexts.EXAMPLE;
 
 /**
  * A {@link BlockProcessor} implementation that provides custom asciidoc syntax
@@ -38,12 +36,15 @@ import static org.asciidoctor.extension.Contexts.EXAMPLE;
 public class PillarsBlockProcessor extends BlockProcessor {
 
     /**
+     * This block is of type example (delimited by ====).
+     */
+    private static final Map<String, Object> CONFIG = createConfig(Contexts.EXAMPLE);
+
+    /**
      * Create a new instance of {@link PillarsBlockProcessor}.
      */
     public PillarsBlockProcessor() {
-        super("PILLARS");
-        // this block is of type example (delimited by ====)
-        config.put(CONTEXTS, Arrays.asList(EXAMPLE));
+        super("PILLARS", CONFIG);
         setConfigFinalized();
     }
 
@@ -56,8 +57,19 @@ public class PillarsBlockProcessor extends BlockProcessor {
         // means it can have nested blocks
         opts.put("content_model", "compound");
         // create an empty block with context "pillars"
-        Block block = this.createBlock(parent, "pillars",
+        Block block = this.createBlock(parent, "PILLARS",
                 Collections.emptyList(), attributes, opts);
         return block;
+    }
+
+    /**
+     * Create a block processor configuration.
+     * @param blockType the type of block
+     * @return map
+     */
+    private static Map<String, Object> createConfig(String ... blockTypes){
+        Map<String, Object> config = new HashMap<>();
+        config.put(Contexts.KEY, Arrays.asList(blockTypes));
+        return config;
     }
 }

--- a/sitegen/src/main/java/io/helidon/sitegen/maven/GenerateMojo.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/maven/GenerateMojo.java
@@ -101,7 +101,7 @@ public class GenerateMojo extends AbstractMojo {
                 .build();
 
         // enable jruby verbose mode on debugging
-        if(getLog().isDebugEnabled()){
+        if (getLog().isDebugEnabled()) {
             System.setProperty("jruby.cli.verbose", "true");
         }
 

--- a/sitegen/src/main/java/io/helidon/sitegen/maven/GenerateMojo.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/maven/GenerateMojo.java
@@ -100,6 +100,11 @@ public class GenerateMojo extends AbstractMojo {
                 .config(siteConfigFile, properties)
                 .build();
 
+        // enable jruby verbose mode on debugging
+        if(getLog().isDebugEnabled()){
+            System.setProperty("jruby.cli.verbose", "true");
+        }
+
         try {
             site.generate(siteSourceDirectory, siteOutputDirectory);
         } catch (RenderingException ex) {

--- a/sitegen/src/test/java/io/helidon/sitegen/PageMetadataTest.java
+++ b/sitegen/src/test/java/io/helidon/sitegen/PageMetadataTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.sitegen.TestHelper.SOURCE_DIR_PREFIX;
 import static io.helidon.sitegen.TestHelper.assertString;
 import static io.helidon.sitegen.TestHelper.getFile;
+import org.junit.jupiter.api.AfterAll;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -40,15 +41,21 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class PageMetadataTest {
 
     private static final File SOURCEDIR = getFile(SOURCE_DIR_PREFIX + "testmetadata");
+    private static final String BACKEND_NAME = "dummy";
     private static AsciidocPageRenderer pageRenderer;
 
     @BeforeAll
     public static void init(){
-        final String backendName = "dummy";
-        SiteEngine.register(backendName, new SiteEngine(
-                new FreemarkerEngine(backendName, null, null),
-                new AsciidocEngine(backendName, null, null, null)));
-        pageRenderer = new AsciidocPageRenderer(backendName);
+        SiteEngine.register(BACKEND_NAME, new SiteEngine(
+                new FreemarkerEngine(BACKEND_NAME, null, null),
+                new AsciidocEngine(BACKEND_NAME, null, null, null)));
+        pageRenderer = new AsciidocPageRenderer(BACKEND_NAME);
+    }
+
+    @AfterAll
+    public static void cleanup(){
+        SiteEngine.get(BACKEND_NAME).asciidoc().unregister();
+        SiteEngine.deregister(BACKEND_NAME);
     }
 
     private static Metadata readMetadata(String fname){

--- a/sitegen/src/test/java/io/helidon/sitegen/TestHelper.java
+++ b/sitegen/src/test/java/io/helidon/sitegen/TestHelper.java
@@ -28,10 +28,6 @@ import com.github.difflib.patch.Patch;
 import freemarker.cache.FileTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
-import io.helidon.sitegen.maven.GenerateMojo;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -53,7 +49,7 @@ public abstract class TestHelper {
         if (basedirPath == null) {
             basedirPath = new File("").getAbsolutePath();
         }
-        return basedirPath;
+        return basedirPath.replace("\\","/");
     }
 
     /**
@@ -124,7 +120,7 @@ public abstract class TestHelper {
         // compare expected and rendered
         Patch<String> patch = DiffUtils.diff(expectedLines, actualLines);
         if (patch.getDeltas().size() > 0) {
-            fail("rendered file differs from expected" + patch.toString());
+            fail("rendered file differs from expected: " + patch.toString());
         }
     }
 }

--- a/sitegen/src/test/resources/testbasic2/_expected.ftl
+++ b/sitegen/src/test/resources/testbasic2/_expected.ftl
@@ -39,7 +39,7 @@ $ mvn
 <dl>
 <dt>asciidoctor-version</dt>
 <dd>
-1.5.6.1
+1.5.8
 </dd>
 <dt>safe-mode-name</dt>
 <dd>


### PR DESCRIPTION
Add fixes for windows.
- Use `URI.relativize` instead of `Path.relativize` to compute the relative path of pages. This always produces a UNIX style path since it's based on URI.
- Use `String.replace("\\","/")` in the test to align with how asciidoctor computes the docdir attribute `{docdir}` 