### PR TITLE
Add open block support

### DIFF
--- a/sitegen/src/main/resources/helidon-sitegen-templates/basic/block_open.ftl
+++ b/sitegen/src/main/resources/helidon-sitegen-templates/basic/block_open.ftl
@@ -1,0 +1,24 @@
+<#--
+  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ -->
+<div>
+<span>example:</span>
+<#if title??><span>${title}</span>
+<#else>
+<#assign _caption = getString("caption") >
+<#if _caption??><span>${_caption}</span></#if>
+</#if>
+${content}
+</div>

--- a/sitegen/src/main/resources/helidon-sitegen-templates/vuetify/block_open.ftl
+++ b/sitegen/src/main/resources/helidon-sitegen-templates/vuetify/block_open.ftl
@@ -1,0 +1,25 @@
+<#--
+  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ -->
+<#switch parent.context>
+<#case "preambule">
+${content}
+<#break>
+<#case "section">
+<div<#if attributes["id"]??> id="${attributes["id"]}"</#if>>${content}</div>
+<#break>
+<#default>
+<div<#if attributes["id"]??> id="${attributes["id"]}"</#if>>${content}</div>
+</#switch>


### PR DESCRIPTION
The guides use some fairly complicated use of `[source]` blocks in numbered lists. The numbering and/or formatting wasn't proper, and using AsciiDoc open blocks resolved it.

Our basic and vuetify backends do not support open blocks. These changes add that support.