### PR TITLE
Improve error message when `sitegen` `preprocess` goal with `check` option fails

### DIFF
--- a/sitegen/pom.xml
+++ b/sitegen/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>slf4j-simple</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.wumpz</groupId>
+            <artifactId>diffutils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
             <scope>test</scope>
@@ -120,11 +124,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.wumpz</groupId>
-            <artifactId>diffutils</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sitegen/src/main/java/io/helidon/sitegen/maven/PreprocessAsciiDocMojo.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/maven/PreprocessAsciiDocMojo.java
@@ -16,10 +16,6 @@
  */
 package io.helidon.sitegen.maven;
 
-import com.github.difflib.DiffUtils;
-import com.github.difflib.algorithm.DiffException;
-import com.github.difflib.patch.Delta;
-import com.github.difflib.patch.Patch;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,12 +25,14 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.algorithm.DiffException;
+import com.github.difflib.patch.Delta;
 
 import static io.helidon.sitegen.maven.Constants.PROPERTY_PREFIX;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/sitegen/src/main/java/io/helidon/sitegen/maven/PreprocessAsciiDocMojo.java
+++ b/sitegen/src/main/java/io/helidon/sitegen/maven/PreprocessAsciiDocMojo.java
@@ -16,6 +16,10 @@
  */
 package io.helidon.sitegen.maven;
 
+import com.github.difflib.DiffUtils;
+import com.github.difflib.algorithm.DiffException;
+import com.github.difflib.patch.Delta;
+import com.github.difflib.patch.Patch;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +31,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 import static io.helidon.sitegen.maven.Constants.PROPERTY_PREFIX;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -95,12 +103,19 @@ public class PreprocessAsciiDocMojo extends AbstractAsciiDocMojo {
             byte[] outputDigest = digest(pathB);
             if (!Arrays.equals(inputDigest, outputDigest)) {
                 throw new MojoFailureException(String.format(
-                        "file %s does not match its expected pre-included form; "
-                                + "the commit might need an up-to-date file from running 'preprocess-adoc' ",
-                        pathA.toString()));
+                        "file %s does not match its expected pre-processed form; "
+                                + "the commit might need an up-to-date file from running 'preprocess-adoc'%n%s ",
+                        pathA.toString(),
+                        formatDiffs(pathA, pathB)));
             }
         } catch (NoSuchAlgorithmException e) {
             throw new MojoExecutionException("error checking for matching input and output files", e);
+        } catch (DiffException ex) {
+            throw new MojoExecutionException(
+                String.format("Error comparing %s and %s",
+                        pathA.toString(),
+                        pathB.toString()),
+                ex);
         }
     }
 
@@ -113,5 +128,13 @@ public class PreprocessAsciiDocMojo extends AbstractAsciiDocMojo {
             while (dis.read(buffer) != -1) {}
         }
         return md.digest();
+    }
+
+    private String formatDiffs(Path pathA, Path pathB) throws IOException, DiffException {
+        List<String> contentA = Files.readAllLines(pathA);
+        List<String> contentB = Files.readAllLines(pathB);
+        return DiffUtils.diff(contentA, contentB).getDeltas().stream()
+                .map(Delta::toString)
+                .collect(Collectors.joining(System.lineSeparator()));
     }
 }


### PR DESCRIPTION
Previously a failed check would identify the problem file but the user would have to investigate separately to see what the differences in the expected vs. actual file content was.

This change adds some diff output to the error message. 

Note that up until now the `DiffUtils` were used only in tests. With this change the class is used in the main code also so it has to be in compile scope, not test.