### PR TITLE
Move OpenAPI-specific logic out of plug-in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <version.plugin.deploy>2.8.2</version.plugin.deploy>
         <version.plugin.directory>0.1</version.plugin.directory>
         <version.plugin.enforcer>3.0.0-M1</version.plugin.enforcer>
-        <version.plugin.glassfish-copyright>1.48</version.plugin.glassfish-copyright>
+        <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
         <version.plugin.gpg>1.6</version.plugin.gpg>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.javadoc>3.1.1</version.plugin.javadoc>

--- a/snakeyaml-codegen-maven-plugin/README.md
+++ b/snakeyaml-codegen-maven-plugin/README.md
@@ -7,22 +7,27 @@ The source code in the consuming project can then use a generated factory method
 then access the generated SnakeYAML type descriptions using the helper class instance methods. The application can 
 updates any of these type descriptions before passing them to SnakeYAML.   
 
-* [Goal: generate](#goal-generate
+* [Goal: generate](#goal-generate)
 ## Goal: `generate`
 
 Generates a class containing SnakeYAML helper code for particular interfaces to be parsed
 
 ### Required Parameters
 
-| Property | Type | User Property | Description |
+| Property | Type | Description |
 | --- | --- | --- | --- |
-| `outputDirectory` | `File` | `snakeyamlgen.outputDirectory` | Directory to contain the generated source file |
-| `outputClass` | `String` | `snakeyamlgen.outputClass` | Fully-qualfied class name for the generated class
+| `implementationPrefix` | `String` |  Prefix common to all implementation classes |
+| `interfacePrefix` | `String` | Prefix common to all interface classes |
 
+The plug-in uses the prefix parameters to group generated `import` statements for implementation classes together and to group 
+`import` statements for interfaces together.
+ 
 ### Optional Parameters
 
 | Property | Type | Default<br/>Value | Description |
 | --- | --- | --- | --- |
+| `outputDirectory` | `File` | `${project.build.directory}/generated-sources` | Directory to contain the generated source file |
+| `outputClass` | `String` | `io.helidon.snakeyaml.SnakeYAMLParserHelper` | Fully-qualified class name for the generated class |
 | `interfacesConfig` | `CompilerConfig` (see below) | `**/*.java` from `${project.build.dir}/interfaces` | Where to find interface classes to analyze
 | `implementationsConfig` | `CompilerConfig` (see below) | `**/*.java` from `${project.build.dir}/implementations` | Where to find implementation classes to analyze
 | `debug` | `boolean` | `false` | turns on debug output from the plug-in 
@@ -33,8 +38,10 @@ All parameters are mapped to user properties of the form `snakeyamlgen.PROPERTY`
 Describes which Java classes to compile for analysis as either interfaces or implementations.
 
 `inputDirectory` - directory from which to read the `.java` files
+
 `includes` - zero or more expressions selecting files to process (default: `**/*.java`)
-`excludes` - zero or more expressions selecting files to exclude from processing
+
+`excludes` - zero or more expressions selecting files to exclude from processing (default: none)
   
 ## Life-cycle Mapping: `generate-sources`
 

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/CodeGenModel.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/CodeGenModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/CodeGenModel.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/CodeGenModel.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Data model used from the code generation template.
+ */
 class CodeGenModel {
 
     private String generatedPackageName;

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/CodeGenModel.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/CodeGenModel.java
@@ -27,13 +27,17 @@ class CodeGenModel {
     private String generatedClassName;
     private Collection<Type> types;
     private Set<SnakeYAMLMojo.Import> imports;
+    private String interfacePrefix;
+    private String implementationPrefix;
 
     CodeGenModel(String generatedPackageName, String generatedClassName, Collection<Type> types,
-            Set<SnakeYAMLMojo.Import> imports) {
+            Set<SnakeYAMLMojo.Import> imports, String interfacePrefix, String implementationPrefix) {
         this.generatedClassName = generatedClassName;
         this.generatedPackageName = generatedPackageName;
         this.types = types;
         this.imports = imports;
+        this.interfacePrefix = interfacePrefix;
+        this.implementationPrefix = implementationPrefix;
     }
 
     String generatedPackageName() {
@@ -53,11 +57,11 @@ class CodeGenModel {
     }
 
     List<SnakeYAMLMojo.Import> implImports() {
-        return filteredImports("io.smallrye");
+        return filteredImports(implementationPrefix);
     }
 
     List<SnakeYAMLMojo.Import> openAPIImports() {
-        return filteredImports("org.eclipse.microprofile.openapi");
+        return filteredImports(interfacePrefix);
     }
 
     private List<SnakeYAMLMojo.Import> filteredImports(String namePrefix) {

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -225,57 +224,6 @@ public class SnakeYAMLMojo extends AbstractMojo {
             return result;
         }
     }
-
-    public static class TypeRefinement {
-        private String typeName;
-        private List<PropertyRefinement> propertyRefinements;
-
-        String typeName() {
-            return typeName;
-        }
-
-        List<PropertyRefinement> propertyRefinements() {
-            return propertyRefinements;
-        }
-    }
-
-    public static class PropertyRefinement {
-        private String propertyName;
-        private List<PropertySubstitution> propertySubstitutions;
-
-        String propertyName() {
-            return propertyName;
-        }
-
-        List<PropertySubstitution> propertySubstitutions() {
-            return propertySubstitutions;
-        }
-    }
-
-    public static class PropertySubstitution {
-
-        private String propertyName;
-        private String propertyType;
-        private String getter;
-        private String setter;
-
-        String propertyName() {
-            return propertyName;
-        }
-
-        String propertyType() {
-            return propertyType;
-        }
-
-        String getter() {
-            return getter;
-        }
-
-        String setter() {
-            return setter;
-        }
-    }
-    /// name, type, getter, setter
 
     /**
      * Sets the compiler config for analyzing the interfaces.
@@ -487,7 +435,8 @@ public class SnakeYAMLMojo extends AbstractMojo {
             Collection<Path> pathsToCommpile, String note) {
         /*
          * There should not be compilation errors, but without our own diagnostic listener any compilation errors will
-         * appear in the build output.
+         * appear in the build output. We want to suppress those because we want to gather information about the interfaces
+         * and classes, not actually compile them into .class files.
          */
         DiagnosticListener<JavaFileObject> diagListener = diagnostic -> {
             debugLog(() -> diagnostic.toString());
@@ -538,26 +487,6 @@ public class SnakeYAMLMojo extends AbstractMojo {
                     + typeToIncompleteEnums.toString());
         }
     }
-
-//    private void applyTypeRefinements(Map<String, Type> types, List<TypeRefinement> typeRefinements) {
-//        List<String> unmatchedTypes = new ArrayList<>();
-//        for (TypeRefinement typeRefinement : typeRefinements) {
-//            Type t = types.get(typeRefinement.typeName());
-//            if (t == null) {
-//                unmatchedTypes.add(typeRefinement.typeName);
-//                continue;
-//            }
-//            for (PropertyRefinement propertyRefinement : typeRefinement.propertyRefinements()) {
-//                for (PropertySubstitution propertySubsitution : propertyRefinement.propertySubstitutions()) {
-//                    t.propertySubstitution(propertyRefinement.propertyName(), propertySubsitution.propertyType(),
-//                            propertySubsitution.getter(), propertySubsitution.setter());
-//                }
-//            }
-//        }
-//        if (!unmatchedTypes.isEmpty()) {
-//            throw new IllegalArgumentException("Specified refined types were not found: " + unmatchedTypes.toString());
-//        }
-//    }
 
     private void addImportsForTypes(Map<String, Type> types, Set<Import> imports) {
         types.forEach((name, type) -> imports.add(new Import(type.fullName(), false)));

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
@@ -46,7 +46,6 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
@@ -595,7 +595,6 @@ public class SnakeYAMLMojo extends AbstractMojo {
             return super.visitClass(node, type);
         }
 
-
         @Override
         public Type visitImport(ImportTree node, Type type) {
             imports.add(new Import(node.getQualifiedIdentifier().toString(), node.isStatic()));

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
@@ -611,23 +611,7 @@ public class SnakeYAMLMojo extends AbstractMojo {
                 VariableTree propertyTree = node.getParameters().get(0);
                 addPropertyParametersIfNeeded(propertyTree, type, propName);
             }
-
             return super.visitMethod(node, type);
-        }
-
-        private static boolean implementsMapOrList(ClassTree classTree) {
-            for (Tree t : classTree.getImplementsClause()) {
-                if (!(t instanceof ParameterizedTypeTree)) {
-                    continue;
-                }
-                ParameterizedTypeTree pTree = ParameterizedTypeTree.class.cast(t);
-                String typeString = pTree.getType().toString();
-                if ("Map".equals(typeString) || "java.util.Map".equals(typeString) || "List".equals(typeString)
-                            || "java.util.List".equals(typeString)) {
-                    return true;
-                }
-            }
-            return false;
         }
 
         private static void addPropertyParametersIfNeeded(VariableTree node, Type type, String propName) {

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
@@ -386,6 +386,7 @@ public class SnakeYAMLMojo extends AbstractMojo {
         result.add(new Import(java.util.List.class));
         result.add(new Import(java.util.HashMap.class));
         result.add(new Import(java.util.Map.class));
+        result.add(new Import(java.util.Set.class));
         return result;
     }
 
@@ -574,9 +575,9 @@ public class SnakeYAMLMojo extends AbstractMojo {
         }
         @Override
         public Type visitClass(ClassTree node, Type type) {
-            String typeName = fullyQualifiedPath(getCurrentPath());
+            String typeName = fullyQualifiedPath(getCurrentPath()); // null for anon. inner class
             Tree.Kind kind = node.getKind();
-            if (kind == Tree.Kind.CLASS || kind == Tree.Kind.INTERFACE) {
+            if ((kind == Tree.Kind.CLASS || kind == Tree.Kind.INTERFACE) && typeName != null) {
                 List<String> interfaces = SnakeYAMLMojo.treesToStrings(node.getImplementsClause());
                 final Type newType = new Type(typeName, node.getSimpleName().toString(), kind == Tree.Kind.INTERFACE,
                         interfaces);
@@ -709,9 +710,12 @@ public class SnakeYAMLMojo extends AbstractMojo {
                     leafName = ((ClassTree) path.getLeaf()).getSimpleName().toString();
                 }
             }
-            if (leafName != null) {
+
+            // leafName can be empty for anonymous inner classes, for example.
+            boolean isUsefulLeaf = leafName != null && !leafName.isEmpty();
+            if (isUsefulLeaf) {
                 result.append(".").append(leafName);
             }
-            return leafName != null ? result.toString() : null;
+            return isUsefulLeaf ? result.toString() : null;
         }
 }

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/SnakeYAMLMojo.java
@@ -642,16 +642,9 @@ public class SnakeYAMLMojo extends AbstractMojo {
                         + methodName.subSequence(4, methodName.length()).toString();
                 VariableTree propertyTree = node.getParameters().get(0);
                 updateEnumIfNeeded(propertyTree, type, propName);
-                updateHasDefaultPropertyIfNeeded(type, propName);
                 addPropertyParametersIfNeeded(propertyTree, type, propName);
             }
             return super.visitMethod(node, type);
-        }
-
-        private void updateHasDefaultPropertyIfNeeded(Type type, String propName) {
-            if ("defaultValue".equals(propName)) {
-                type.hasDefaultProperty(true);
-            }
         }
 
         private void updateEnumIfNeeded(VariableTree node, Type type, String propName) {

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
@@ -50,7 +50,7 @@ class Type {
     private boolean isRef = false;
     private boolean isExtensible = false;
 
-    private final Map<String, TypeEnum> typeEnumsByType = new HashMap<>();
+//    private final Map<String, TypeEnum> typeEnumsByType = new HashMap<>();
     private final List<PropertyParameter> propertyParameters = new ArrayList<>();
 
     // Prop subs are recorded here but are set from the caller, not by the compilation/analysis.
@@ -63,10 +63,10 @@ class Type {
         this.interfacesImplemented = interfacesImplemented;
     }
 
-    Type typeEnumByType(String type) {
-        typeEnumsByType.computeIfAbsent(type, TypeEnum::byType);
-        return this;
-    }
+//    Type typeEnumByType(String type) {
+//        typeEnumsByType.computeIfAbsent(type, TypeEnum::byType);
+//        return this;
+//    }
 
     String fullName() {
         return fullName;
@@ -96,13 +96,9 @@ class Type {
         return isExtensible;
     }
 
-    Collection<TypeEnum> typeEnumsByType() {
-        return typeEnumsByType.values();
-    }
-
-    void removeTypeEnum(TypeEnum typeEnum) {
-        typeEnumsByType.remove(typeEnum.enumType());
-    }
+//    void removeTypeEnum(TypeEnum typeEnum) {
+//        typeEnumsByType.remove(typeEnum.enumType());
+//    }
 
     List<PropertyParameter> propertyParameters() {
         return propertyParameters;
@@ -112,9 +108,9 @@ class Type {
         return substitutions;
     }
 
-    Optional<TypeEnum> getTypeEnum(String type) {
-        return Optional.ofNullable(typeEnumsByType.get(type));
-    }
+//    Optional<TypeEnum> getTypeEnum(String type) {
+//        return Optional.ofNullable(typeEnumsByType.get(type));
+//    }
 
     Type propertyParameter(String name, List<String> types) {
         propertyParameters.add(new PropertyParameter(name, types));
@@ -151,56 +147,56 @@ class Type {
                 + ", isExtensible=" + isExtensible
                 + ", implementationType='" + implementationType + '\''
                 + ", isRef=" + isRef
-                + ", typeEnumsByType=" + typeEnumsByType
+//                + ", typeEnumsByType=" + typeEnumsByType
                 + ", propertyParameters=" + propertyParameters
                 + ", substitutions=" + substitutions
                 + '}';
     }
 
-    static class TypeEnum {
-        private String enumName;
-        private String enumType;
-
-        static TypeEnum byType(String enumType) {
-            TypeEnum result = new TypeEnum();
-            result.enumType = enumType;
-            return result;
-        }
-
-        static TypeEnum fromName(String name) {
-            TypeEnum result = new TypeEnum();
-            result.enumName = name;
-            return result;
-        }
-
-        private TypeEnum() {}
-
-        TypeEnum name(String name) {
-            enumName = name;
-            return this;
-        }
-
-        TypeEnum type(String type) {
-            enumType = type;
-            return this;
-        }
-
-        String enumName() {
-            return enumName;
-        }
-
-        String enumType() {
-            return enumType;
-        }
-
-        @Override
-        public String toString() {
-            return "TypeEnum{"
-                    + "enumName='" + enumName + '\''
-                    + ", enumType='" + enumType + '\''
-                    + '}';
-        }
-    }
+//    static class TypeEnum {
+//        private String enumName;
+//        private String enumType;
+//
+//        static TypeEnum byType(String enumType) {
+//            TypeEnum result = new TypeEnum();
+//            result.enumType = enumType;
+//            return result;
+//        }
+//
+//        static TypeEnum fromName(String name) {
+//            TypeEnum result = new TypeEnum();
+//            result.enumName = name;
+//            return result;
+//        }
+//
+//        private TypeEnum() {}
+//
+//        TypeEnum name(String name) {
+//            enumName = name;
+//            return this;
+//        }
+//
+//        TypeEnum type(String type) {
+//            enumType = type;
+//            return this;
+//        }
+//
+//        String enumName() {
+//            return enumName;
+//        }
+//
+//        String enumType() {
+//            return enumType;
+//        }
+//
+//        @Override
+//        public String toString() {
+//            return "TypeEnum{"
+//                    + "enumName='" + enumName + '\''
+//                    + ", enumType='" + enumType + '\''
+//                    + '}';
+//        }
+//    }
 
     static class PropertyParameter {
         private final String parameterName;

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
@@ -49,6 +49,8 @@ class Type {
     // Prop subs are recorded here but are set from the caller, not by the compilation/analysis.
     private final List<PropertySubstitution> substitutions = new ArrayList<>();
 
+    private final List<ParameterizedProperty> parameterizedProperties = new ArrayList<>();
+
     /**
      * Creates a new {@code Type}.
      *
@@ -108,6 +110,15 @@ class Type {
         return this;
     }
 
+    Type addParameterizedProperty(String propertyName, Class<?> groupingType, List<String> typeParameters) {
+        parameterizedProperties.add(new ParameterizedProperty(propertyName, groupingType.getName(), typeParameters));
+        return this;
+    }
+
+    List<ParameterizedProperty> parameterizedProperties() {
+        return parameterizedProperties;
+    }
+
     @Override
     public String toString() {
         return "Type{"
@@ -118,6 +129,7 @@ class Type {
                 + ", implementationType='" + implementationType + '\''
                 + ", propertyParameters=" + propertyParameters
                 + ", substitutions=" + substitutions
+                + ", parameterized parameters" + parameterizedProperties
                 + '}';
     }
 
@@ -230,4 +242,28 @@ class Type {
         }
     }
 
+    static class ParameterizedProperty {
+
+        private final String parameterizedPropertyName;
+        private final String parameterizedGroupingType; // java.util.Map or java.util.List
+        private final List<String> typeParameters;
+
+        ParameterizedProperty(String propertyName, String groupingType, List<String> typeParameters) {
+            parameterizedPropertyName = propertyName;
+            parameterizedGroupingType = groupingType;
+            this.typeParameters = typeParameters;
+        }
+
+        String parameterizedPropertyName() {
+            return parameterizedPropertyName;
+        }
+
+        String parameterizedGroupingType() {
+            return parameterizedGroupingType;
+        }
+
+        List<String> parameterizedTypes() {
+            return typeParameters;
+        }
+    }
 }

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,9 @@ class Type {
 
     private String implementationType;
     private boolean isRef = false;
+    private boolean isExtensible = false;
+    private boolean hasDefaultProperty = false;
+
     private final Map<String, TypeEnum> typeEnumsByType = new HashMap<>();
     private final List<PropertyParameter> propertyParameters = new ArrayList<>();
 
@@ -90,8 +93,16 @@ class Type {
         return isRef;
     }
 
+    boolean isExtensible() {
+        return isExtensible;
+    }
+
     Collection<TypeEnum> typeEnumsByType() {
         return typeEnumsByType.values();
+    }
+
+    void removeTypeEnum(TypeEnum typeEnum) {
+        typeEnumsByType.remove(typeEnum.enumType());
     }
 
     List<PropertyParameter> propertyParameters() {
@@ -121,9 +132,23 @@ class Type {
         return this;
     }
 
+    Type extensible(boolean isExtensible) {
+        this.isExtensible = isExtensible;
+        return this;
+    }
+
     Type implementationType(String implType) {
         implementationType = implType;
         return this;
+    }
+
+    Type hasDefaultProperty(boolean value) {
+        this.hasDefaultProperty = value;
+        return this;
+    }
+
+    boolean hasDefaultProperty() {
+        return hasDefaultProperty;
     }
 
     @Override
@@ -133,11 +158,13 @@ class Type {
                 + ", simpleName='" + simpleName + '\''
                 + ", interfacesImplemented=" + interfacesImplemented
                 + ", isInterface=" + isInterface
+                + ", isExtensible=" + isExtensible
                 + ", implementationType='" + implementationType + '\''
                 + ", isRef=" + isRef
                 + ", typeEnumsByType=" + typeEnumsByType
                 + ", propertyParameters=" + propertyParameters
                 + ", substitutions=" + substitutions
+                + ", hasDefaultProperty=" + hasDefaultProperty
                 + '}';
     }
 

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
@@ -49,8 +49,6 @@ class Type {
     // Prop subs are recorded here but are set from the caller, not by the compilation/analysis.
     private final List<PropertySubstitution> substitutions = new ArrayList<>();
 
-    private final List<ParameterizedProperty> parameterizedProperties = new ArrayList<>();
-
     /**
      * Creates a new {@code Type}.
      *
@@ -110,15 +108,6 @@ class Type {
         return this;
     }
 
-    Type addParameterizedProperty(String propertyName, Class<?> groupingType, List<String> typeParameters) {
-        parameterizedProperties.add(new ParameterizedProperty(propertyName, groupingType.getName(), typeParameters));
-        return this;
-    }
-
-    List<ParameterizedProperty> parameterizedProperties() {
-        return parameterizedProperties;
-    }
-
     @Override
     public String toString() {
         return "Type{"
@@ -129,7 +118,6 @@ class Type {
                 + ", implementationType='" + implementationType + '\''
                 + ", propertyParameters=" + propertyParameters
                 + ", substitutions=" + substitutions
-                + ", parameterized parameters" + parameterizedProperties
                 + '}';
     }
 
@@ -239,31 +227,6 @@ class Type {
                     + ", getter='" + getter + '\''
                     + ", setter='" + setter + '\''
                     + '}';
-        }
-    }
-
-    static class ParameterizedProperty {
-
-        private final String parameterizedPropertyName;
-        private final String parameterizedGroupingType; // java.util.Map or java.util.List
-        private final List<String> typeParameters;
-
-        ParameterizedProperty(String propertyName, String groupingType, List<String> typeParameters) {
-            parameterizedPropertyName = propertyName;
-            parameterizedGroupingType = groupingType;
-            this.typeParameters = typeParameters;
-        }
-
-        String parameterizedPropertyName() {
-            return parameterizedPropertyName;
-        }
-
-        String parameterizedGroupingType() {
-            return parameterizedGroupingType;
-        }
-
-        List<String> parameterizedTypes() {
-            return typeParameters;
         }
     }
 }

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
@@ -18,6 +18,7 @@ package io.helidon.codegen.snakeyaml;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,15 +90,15 @@ class Type {
         return isRef;
     }
 
-    Map<String, TypeEnum> typeEnumsByType() {
-        return typeEnumsByType;
+    Collection<TypeEnum> typeEnumsByType() {
+        return typeEnumsByType.values();
     }
 
     List<PropertyParameter> propertyParameters() {
         return propertyParameters;
     }
 
-    List<PropertySubstitution> substitutions() {
+    List<PropertySubstitution> propertySubstitutions() {
         return substitutions;
     }
 

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
@@ -18,11 +18,7 @@ package io.helidon.codegen.snakeyaml;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -47,26 +43,27 @@ class Type {
     private final boolean isInterface;
 
     private String implementationType;
-    private boolean isRef = false;
-    private boolean isExtensible = false;
 
-//    private final Map<String, TypeEnum> typeEnumsByType = new HashMap<>();
     private final List<PropertyParameter> propertyParameters = new ArrayList<>();
 
     // Prop subs are recorded here but are set from the caller, not by the compilation/analysis.
     private final List<PropertySubstitution> substitutions = new ArrayList<>();
 
+    /**
+     * Creates a new {@code Type}.
+     *
+     * @param fullName fully-qualified name of the type
+     * @param simpleName short name of the type
+     * @param isInterface whether the type represents an interface
+     * @param interfacesImplemented names of all interfaces directly implemented (if the type is a class) or extended (if the
+     *                              type is an interface)
+     */
     Type(String fullName, String simpleName, boolean isInterface, List<String> interfacesImplemented) {
         this.fullName = fullName;
         this.simpleName = simpleName;
         this.isInterface = isInterface;
         this.interfacesImplemented = interfacesImplemented;
     }
-
-//    Type typeEnumByType(String type) {
-//        typeEnumsByType.computeIfAbsent(type, TypeEnum::byType);
-//        return this;
-//    }
 
     String fullName() {
         return fullName;
@@ -88,18 +85,6 @@ class Type {
         return implementationType;
     }
 
-    boolean isRef() {
-        return isRef;
-    }
-
-    boolean isExtensible() {
-        return isExtensible;
-    }
-
-//    void removeTypeEnum(TypeEnum typeEnum) {
-//        typeEnumsByType.remove(typeEnum.enumType());
-//    }
-
     List<PropertyParameter> propertyParameters() {
         return propertyParameters;
     }
@@ -108,10 +93,6 @@ class Type {
         return substitutions;
     }
 
-//    Optional<TypeEnum> getTypeEnum(String type) {
-//        return Optional.ofNullable(typeEnumsByType.get(type));
-//    }
-
     Type propertyParameter(String name, List<String> types) {
         propertyParameters.add(new PropertyParameter(name, types));
         return this;
@@ -119,16 +100,6 @@ class Type {
 
     Type propertySubstitution(String name, String type, String getter, String setter) {
         substitutions.add(new PropertySubstitution(name, type, getter, setter));
-        return this;
-    }
-
-    Type ref(boolean isRef) {
-        this.isRef = isRef;
-        return this;
-    }
-
-    Type extensible(boolean isExtensible) {
-        this.isExtensible = isExtensible;
         return this;
     }
 
@@ -144,60 +115,19 @@ class Type {
                 + ", simpleName='" + simpleName + '\''
                 + ", interfacesImplemented=" + interfacesImplemented
                 + ", isInterface=" + isInterface
-                + ", isExtensible=" + isExtensible
                 + ", implementationType='" + implementationType + '\''
-                + ", isRef=" + isRef
-//                + ", typeEnumsByType=" + typeEnumsByType
                 + ", propertyParameters=" + propertyParameters
                 + ", substitutions=" + substitutions
                 + '}';
     }
 
-//    static class TypeEnum {
-//        private String enumName;
-//        private String enumType;
-//
-//        static TypeEnum byType(String enumType) {
-//            TypeEnum result = new TypeEnum();
-//            result.enumType = enumType;
-//            return result;
-//        }
-//
-//        static TypeEnum fromName(String name) {
-//            TypeEnum result = new TypeEnum();
-//            result.enumName = name;
-//            return result;
-//        }
-//
-//        private TypeEnum() {}
-//
-//        TypeEnum name(String name) {
-//            enumName = name;
-//            return this;
-//        }
-//
-//        TypeEnum type(String type) {
-//            enumType = type;
-//            return this;
-//        }
-//
-//        String enumName() {
-//            return enumName;
-//        }
-//
-//        String enumType() {
-//            return enumType;
-//        }
-//
-//        @Override
-//        public String toString() {
-//            return "TypeEnum{"
-//                    + "enumName='" + enumName + '\''
-//                    + ", enumType='" + enumType + '\''
-//                    + '}';
-//        }
-//    }
-
+    /**
+     * Models the need for a SnakeYAML {@code PropertyParameter} to be added to a {@code TypeDescription}.
+     * <p>
+     *     A property parameter allows us to specify the type parameter(s) for a parameterized type such as a {@code List} or
+     *     {@code Map}.
+     * </p>
+     */
     static class PropertyParameter {
         private final String parameterName;
         private final List<PropertyParameterType> parameterTypes = new ArrayList<>();
@@ -252,6 +182,14 @@ class Type {
         }
     }
 
+    /**
+     * Models the need for a property substitution on a type description.
+     * <p>
+     *     If the serialized property name (in YAML or JSON) does not match the property name derived from the type according
+     *     to the bean pattern, then SnakeYAML provides a {@code PropertySubstitution} to prescribe the name of the property,
+     *     its type, and its getter and setter method names.
+     * </p>
+     */
     static class PropertySubstitution {
         private final String propertySubName;
         private final String propertySubType;

--- a/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
+++ b/snakeyaml-codegen-maven-plugin/src/main/java/io/helidon/codegen/snakeyaml/Type.java
@@ -49,7 +49,6 @@ class Type {
     private String implementationType;
     private boolean isRef = false;
     private boolean isExtensible = false;
-    private boolean hasDefaultProperty = false;
 
     private final Map<String, TypeEnum> typeEnumsByType = new HashMap<>();
     private final List<PropertyParameter> propertyParameters = new ArrayList<>();
@@ -142,15 +141,6 @@ class Type {
         return this;
     }
 
-    Type hasDefaultProperty(boolean value) {
-        this.hasDefaultProperty = value;
-        return this;
-    }
-
-    boolean hasDefaultProperty() {
-        return hasDefaultProperty;
-    }
-
     @Override
     public String toString() {
         return "Type{"
@@ -164,7 +154,6 @@ class Type {
                 + ", typeEnumsByType=" + typeEnumsByType
                 + ", propertyParameters=" + propertyParameters
                 + ", substitutions=" + substitutions
-                + ", hasDefaultProperty=" + hasDefaultProperty
                 + '}';
     }
 

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -34,7 +34,6 @@ class {{generatedClassName}}<T extends TypeDescription> {
 
     private final Map<Class<?>, T> types = new HashMap<>();
     private final BiFunction<T, EnumType<?>, T> enumAdder;
-    private final Function<T, T> hasDefaultPropertyMarker;
 
     static class EnumType<E extends Enum<E>> {
         private final String propertyName;
@@ -64,9 +63,8 @@ class {{generatedClassName}}<T extends TypeDescription> {
 
     static <T extends TypeDescription> {{generatedClassName}}<T> create(
                                 BiFunction<Class<?>, Class<?>, T> factoryFunction,
-                                BiFunction<T, EnumType<?>, T> enumAdder,
-                                Function<T, T> hasDefaultPropertyMarker) {
-            return new {{generatedClassName}}<T>(factoryFunction, enumAdder, hasDefaultPropertyMarker);
+                                BiFunction<T, EnumType<?>, T> enumAdder) {
+            return new {{generatedClassName}}<T>(factoryFunction, enumAdder);
         }
 
         Map<Class<?>, T> types() {
@@ -90,9 +88,8 @@ class {{generatedClassName}}<T extends TypeDescription> {
     }
 
     private {{generatedClassName}}(BiFunction<Class<?>, Class<?>, T> factoryFunction,
-            BiFunction<T, EnumType<?>, T> enumAdder, Function<T, T> hasDefaultPropertyMarker) {
+            BiFunction<T, EnumType<?>, T> enumAdder) {
         this.enumAdder = enumAdder;
-        this.hasDefaultPropertyMarker = hasDefaultPropertyMarker;
 {{#typesToAugment}}
         T td_{{simpleName}} = factoryFunction.apply({{simpleName}}.class, {{implementationType}}.class);
         {{#typeEnumsByType}}

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -33,47 +33,18 @@ import org.yaml.snakeyaml.TypeDescription;
 class {{generatedClassName}}<T extends TypeDescription> {
 
     private final Map<Class<?>, T> types = new HashMap<>();
-    private final BiFunction<T, EnumType<?>, T> enumAdder;
-
-    static class EnumType<E extends Enum<E>> {
-        private final String propertyName;
-        private final Class<E> enumType;
-
-        static <E extends Enum<E>> EnumType create(String propertyName, Class<E> enumType) {
-            return new EnumType<E>(propertyName, enumType);
-        }
-
-        String propertyName() {
-            return propertyName;
-        }
-
-        Class<E> enumType() {
-            return enumType;
-        }
-
-        E valueOf(String value) {
-            return Enum.valueOf(enumType, value);
-        }
-
-        private EnumType(String propertyName, Class<E> enumType) {
-            this.propertyName = propertyName;
-            this.enumType = enumType;
-        }
+    static <T extends TypeDescription> {{generatedClassName}}<T> create(
+                            BiFunction<Class<?>, Class<?>, T> factoryFunction) {
+        return new {{generatedClassName}}<T>(factoryFunction);
     }
 
-    static <T extends TypeDescription> {{generatedClassName}}<T> create(
-                                BiFunction<Class<?>, Class<?>, T> factoryFunction,
-                                BiFunction<T, EnumType<?>, T> enumAdder) {
-            return new {{generatedClassName}}<T>(factoryFunction, enumAdder);
-        }
+    Map<Class<?>, T> types() {
+        return types;
+    }
 
-        Map<Class<?>, T> types() {
-            return types;
-        }
-
-        Set<Map.Entry<Class<?>, T>> entrySet() {
-            return types.entrySet();
-        }
+    Set<Map.Entry<Class<?>, T>> entrySet() {
+        return types.entrySet();
+    }
 
     Set<Class<?>> keySet() {
         return types.keySet();
@@ -87,14 +58,9 @@ class {{generatedClassName}}<T extends TypeDescription> {
         return types.get(clazz);
     }
 
-    private {{generatedClassName}}(BiFunction<Class<?>, Class<?>, T> factoryFunction,
-            BiFunction<T, EnumType<?>, T> enumAdder) {
-        this.enumAdder = enumAdder;
+    private {{generatedClassName}}(BiFunction<Class<?>, Class<?>, T> factoryFunction) {
 {{#typesToAugment}}
         T td_{{simpleName}} = factoryFunction.apply({{simpleName}}.class, {{implementationType}}.class);
-        {{#typeEnumsByType}}
-        addEnum(td_{{simpleName}}, "{{enumName}}", {{simpleName}}.{{enumType}}.class);
-        {{/typeEnumsByType}}
         {{#propertyParameters}}
         td_{{simpleName}}.addPropertyParameters("{{parameterName}}"{{#parameterTypes}}, {{parameterType}}.class{{/parameterTypes}});
         {{/propertyParameters}}
@@ -108,9 +74,5 @@ class {{generatedClassName}}<T extends TypeDescription> {
         types.put(td_{{simpleName}}.getType(), td_{{simpleName}});
 
 {{/typesToAugment}}
-    }
-
-    private <E extends Enum<E>> void addEnum(T td, String propertyName, Class<E> enumType) {
-        enumAdder.apply(td, EnumType.create(propertyName, enumType));
     }
 }

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -98,9 +98,6 @@ class {{generatedClassName}}<T extends TypeDescription> {
         {{#typeEnumsByType}}
         addEnum(td_{{simpleName}}, "{{enumName}}", {{simpleName}}.{{enumType}}.class);
         {{/typeEnumsByType}}
-        {{#hasDefaultProperty}}
-        markHasDefaultProperty(td_{{simpleName}});
-        {{/hasDefaultProperty}}
         {{#propertyParameters}}
         td_{{simpleName}}.addPropertyParameters("{{parameterName}}"{{#parameterTypes}}, {{parameterType}}.class{{/parameterTypes}});
         {{/propertyParameters}}
@@ -118,9 +115,5 @@ class {{generatedClassName}}<T extends TypeDescription> {
 
     private <E extends Enum<E>> void addEnum(T td, String propertyName, Class<E> enumType) {
         enumAdder.apply(td, EnumType.create(propertyName, enumType));
-    }
-
-    private void markHasDefaultProperty(T td) {
-        hasDefaultPropertyMarker.apply(td);
     }
 }

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -71,6 +71,7 @@ class {{generatedClassName}}<T extends TypeDescription> {
         td_{{simpleName}}.substituteProperty("{{propertySubName}}", {{propertySubType}}.class, "{{getter}}", "{{setter}}");
         {{/propertySubstitutions}}
         types.put(td_{{simpleName}}.getType(), td_{{simpleName}});
+
 {{/typesToAugment}}
     }
 }

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -33,6 +33,10 @@ import org.yaml.snakeyaml.TypeDescription;
 class {{generatedClassName}}<T extends TypeDescription> {
 
     private final Map<Class<?>, T> types = new HashMap<>();
+    private final Map<String, List<ParameterizedGrouping>> parameterizedProperties = new HashMap<>();
+    private final Map<Class<?>, Class<?>> mapImplementingTypes = new HashMap<>();
+    private final Map<Class<?>, Class<?>> listImplementingTypes = new HashMap<>();
+
     static <T extends TypeDescription> {{generatedClassName}}<T> create(
                             BiFunction<Class<?>, Class<?>, T> factoryFunction) {
         return new {{generatedClassName}}<T>(factoryFunction);
@@ -40,6 +44,14 @@ class {{generatedClassName}}<T extends TypeDescription> {
 
     Map<Class<?>, T> types() {
         return types;
+    }
+
+    List<String> parameterizedParameter(String parentTypeName) {
+        List<ParameterizedGrouping> groups = parameterizedProperties.get(parentTypeName);
+        if (groups == null || groups.size() == 0) {
+            return null;
+        }
+        return groups.get(0).typeParameters();
     }
 
     Set<Map.Entry<Class<?>, T>> entrySet() {
@@ -58,6 +70,38 @@ class {{generatedClassName}}<T extends TypeDescription> {
         return types.get(clazz);
     }
 
+    static class ParameterizedGrouping {
+
+        private final String propertyName;
+        private final Class<?> groupingType;
+        private final List<String> typeParameters;;
+
+        ParameterizedGrouping(String propertyName, Class<?> groupingType, String... typeParameters) {
+            this.propertyName = propertyName;
+            this.groupingType = groupingType;
+            this.typeParameters = java.util.Arrays.asList(typeParameters);;
+        }
+
+        String propertyName() {
+            return propertyName;
+        }
+
+        Class<?> groupingType() {
+            return groupingType;
+        }
+
+        List<String> typeParameters() {
+            return typeParameters;
+        }
+    }
+
+    private void addParameterizedParameter(String parentTypeName, String propertyName, Class<?> groupingType,
+                String... typeParameters) {
+        List<ParameterizedGrouping> groupings = parameterizedProperties.computeIfAbsent(parentTypeName, k -> new ArrayList<>());
+        ParameterizedGrouping newGrouping = new ParameterizedGrouping(propertyName, groupingType, typeParameters);
+        groupings.add(newGrouping);
+    }
+
     private {{generatedClassName}}(BiFunction<Class<?>, Class<?>, T> factoryFunction) {
 {{#typesToAugment}}
         T td_{{simpleName}} = factoryFunction.apply({{simpleName}}.class, {{implementationType}}.class);
@@ -68,6 +112,9 @@ class {{generatedClassName}}<T extends TypeDescription> {
         td_{{simpleName}}.substituteProperty("{{propertySubName}}", {{propertySubType}}.class, "{{getter}}", "{{setter}}");
         {{/propertySubstitutions}}
         types.put(td_{{simpleName}}.getType(), td_{{simpleName}});
+        {{#parameterizedProperties}}
+        addParameterizedParameter("{{fullName}}", "{{parameterizedPropertyName}}", {{parameterizedGroupingType}}.class {{#parameterizedTypes}}, "{{{toString}}}"{{/parameterizedTypes}});
+        {{/parameterizedProperties}}
 
 {{/typesToAugment}}
     }

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -56,19 +56,19 @@ class {{generatedClassName}} {
 
     private {{generatedClassName}}() {
 {{#typesToAugment}}
-        TypeDescription td_{{simpleName}} = ExpandedTypeDescription.create({{simpleName}}.class, {{implementationType}}.class);
-        {{#typeEnums}}
-        td_{{simpleName}}.addEnum("{{enumName}}", {{enumType}}::valueOf);
-        {{/typeEnums}}
+        ExpandedTypeDescription td_{{simpleName}} = ExpandedTypeDescription.create({{simpleName}}.class, {{implementationType}}.class);
+        {{#typeEnumsByType}}
+        td_{{simpleName}}.addEnum("{{enumName}}", {{simpleName}}.{{enumType}}::valueOf);
+        {{/typeEnumsByType}}
         {{#ref}}
         td_{{simpleName}}.addRef();
         {{/ref}}
         {{#propertyParameters}}
         td_{{simpleName}}.addPropertyParameters("{{parameterName}}"{{#parameterTypes}}, {{parameterType}}.class{{/parameterTypes}});
         {{/propertyParameters}}
-        {{#substitutions}}
+        {{#propertySubstitutions}}
         td_{{simpleName}}.substituteProperty("{{propertySubName}}", {{propertySubType}}.class, "{{getter}}", "{{setter}}");
-        {{/substitutions}}
+        {{/propertySubstitutions}}
         types.put(td_{{simpleName}}.getType(), td_{{simpleName}});
 
 {{/typesToAugment}}

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -30,17 +30,52 @@ import {{#isStatic}} static {{/isStatic}}{{name}};
 
 import org.yaml.snakeyaml.TypeDescription;
 
-class {{generatedClassName}} {
+class {{generatedClassName}}<T extends TypeDescription> {
 
-    private final Map<Class<?>, TypeDescription> types = new HashMap<>();
+    private final Map<Class<?>, T> types = new HashMap<>();
+    private final BiFunction<T, EnumType<?>, T> enumAdder;
+    private final Function<T, T> hasDefaultPropertyMarker;
 
-    static {{generatedClassName}} create() {
-        return new {{generatedClassName}}();
+    static class EnumType<E extends Enum<E>> {
+        private final String propertyName;
+        private final Class<E> enumType;
+
+        static <E extends Enum<E>> EnumType create(String propertyName, Class<E> enumType) {
+            return new EnumType<E>(propertyName, enumType);
+        }
+
+        String propertyName() {
+            return propertyName;
+        }
+
+        Class<E> enumType() {
+            return enumType;
+        }
+
+        E valueOf(String value) {
+            return Enum.valueOf(enumType, value);
+        }
+
+        private EnumType(String propertyName, Class<E> enumType) {
+            this.propertyName = propertyName;
+            this.enumType = enumType;
+        }
     }
 
-    Set<Map.Entry<Class<?>, TypeDescription>> entrySet() {
-        return types.entrySet();
-    }
+    static <T extends TypeDescription> {{generatedClassName}}<T> create(
+                                BiFunction<Class<?>, Class<?>, T> factoryFunction,
+                                BiFunction<T, EnumType<?>, T> enumAdder,
+                                Function<T, T> hasDefaultPropertyMarker) {
+            return new {{generatedClassName}}<T>(factoryFunction, enumAdder, hasDefaultPropertyMarker);
+        }
+
+        Map<Class<?>, T> types() {
+            return types;
+        }
+
+        Set<Map.Entry<Class<?>, T>> entrySet() {
+            return types.entrySet();
+        }
 
     Set<Class<?>> keySet() {
         return types.keySet();
@@ -50,28 +85,42 @@ class {{generatedClassName}} {
         return types.containsKey(type);
     }
 
-    TypeDescription get(Class<?> clazz) {
+    T get(Class<?> clazz) {
         return types.get(clazz);
     }
 
-    private {{generatedClassName}}() {
+    private {{generatedClassName}}(BiFunction<Class<?>, Class<?>, T> factoryFunction,
+            BiFunction<T, EnumType<?>, T> enumAdder, Function<T, T> hasDefaultPropertyMarker) {
+        this.enumAdder = enumAdder;
+        this.hasDefaultPropertyMarker = hasDefaultPropertyMarker;
 {{#typesToAugment}}
-        ExpandedTypeDescription td_{{simpleName}} = ExpandedTypeDescription.create({{simpleName}}.class, {{implementationType}}.class);
+        T td_{{simpleName}} = factoryFunction.apply({{simpleName}}.class, {{implementationType}}.class);
         {{#typeEnumsByType}}
-        td_{{simpleName}}.addEnum("{{enumName}}", {{simpleName}}.{{enumType}}::valueOf);
+        addEnum(td_{{simpleName}}, "{{enumName}}", {{simpleName}}.{{enumType}}.class);
         {{/typeEnumsByType}}
-        {{#ref}}
-        td_{{simpleName}}.addRef();
-        {{/ref}}
+        {{#hasDefaultProperty}}
+        markHasDefaultProperty(td_{{simpleName}});
+        {{/hasDefaultProperty}}
         {{#propertyParameters}}
         td_{{simpleName}}.addPropertyParameters("{{parameterName}}"{{#parameterTypes}}, {{parameterType}}.class{{/parameterTypes}});
         {{/propertyParameters}}
         {{#propertySubstitutions}}
         td_{{simpleName}}.substituteProperty("{{propertySubName}}", {{propertySubType}}.class, "{{getter}}", "{{setter}}");
         {{/propertySubstitutions}}
+        {{#isExtensible}}
+        td_{{simpleName}}.substituteProperty("extensions", Map.class, "setExtensions", "getExtensions");
+        td_{{simpleName}}.addPropertyParameters("extensions", String.class, Object.class);
+        {{/isExtensible}}
         types.put(td_{{simpleName}}.getType(), td_{{simpleName}});
 
 {{/typesToAugment}}
     }
-}
 
+    private <E extends Enum<E>> void addEnum(T td, String propertyName, Class<E> enumType) {
+        enumAdder.apply(td, EnumType.create(propertyName, enumType));
+    }
+
+    private void markHasDefaultProperty(T td) {
+        hasDefaultPropertyMarker.apply(td);
+    }
+}

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -67,10 +67,6 @@ class {{generatedClassName}}<T extends TypeDescription> {
         {{#propertySubstitutions}}
         td_{{simpleName}}.substituteProperty("{{propertySubName}}", {{propertySubType}}.class, "{{getter}}", "{{setter}}");
         {{/propertySubstitutions}}
-        {{#isExtensible}}
-        td_{{simpleName}}.substituteProperty("extensions", Map.class, "setExtensions", "getExtensions");
-        td_{{simpleName}}.addPropertyParameters("extensions", String.class, Object.class);
-        {{/isExtensible}}
         types.put(td_{{simpleName}}.getType(), td_{{simpleName}});
 
 {{/typesToAugment}}

--- a/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
+++ b/snakeyaml-codegen-maven-plugin/src/main/resources/typeClassTemplate.mustache
@@ -33,7 +33,6 @@ import org.yaml.snakeyaml.TypeDescription;
 class {{generatedClassName}}<T extends TypeDescription> {
 
     private final Map<Class<?>, T> types = new HashMap<>();
-    private final Map<String, List<ParameterizedGrouping>> parameterizedProperties = new HashMap<>();
     private final Map<Class<?>, Class<?>> mapImplementingTypes = new HashMap<>();
     private final Map<Class<?>, Class<?>> listImplementingTypes = new HashMap<>();
 
@@ -44,14 +43,6 @@ class {{generatedClassName}}<T extends TypeDescription> {
 
     Map<Class<?>, T> types() {
         return types;
-    }
-
-    List<String> parameterizedParameter(String parentTypeName) {
-        List<ParameterizedGrouping> groups = parameterizedProperties.get(parentTypeName);
-        if (groups == null || groups.size() == 0) {
-            return null;
-        }
-        return groups.get(0).typeParameters();
     }
 
     Set<Map.Entry<Class<?>, T>> entrySet() {
@@ -70,38 +61,6 @@ class {{generatedClassName}}<T extends TypeDescription> {
         return types.get(clazz);
     }
 
-    static class ParameterizedGrouping {
-
-        private final String propertyName;
-        private final Class<?> groupingType;
-        private final List<String> typeParameters;;
-
-        ParameterizedGrouping(String propertyName, Class<?> groupingType, String... typeParameters) {
-            this.propertyName = propertyName;
-            this.groupingType = groupingType;
-            this.typeParameters = java.util.Arrays.asList(typeParameters);;
-        }
-
-        String propertyName() {
-            return propertyName;
-        }
-
-        Class<?> groupingType() {
-            return groupingType;
-        }
-
-        List<String> typeParameters() {
-            return typeParameters;
-        }
-    }
-
-    private void addParameterizedParameter(String parentTypeName, String propertyName, Class<?> groupingType,
-                String... typeParameters) {
-        List<ParameterizedGrouping> groupings = parameterizedProperties.computeIfAbsent(parentTypeName, k -> new ArrayList<>());
-        ParameterizedGrouping newGrouping = new ParameterizedGrouping(propertyName, groupingType, typeParameters);
-        groupings.add(newGrouping);
-    }
-
     private {{generatedClassName}}(BiFunction<Class<?>, Class<?>, T> factoryFunction) {
 {{#typesToAugment}}
         T td_{{simpleName}} = factoryFunction.apply({{simpleName}}.class, {{implementationType}}.class);
@@ -112,10 +71,6 @@ class {{generatedClassName}}<T extends TypeDescription> {
         td_{{simpleName}}.substituteProperty("{{propertySubName}}", {{propertySubType}}.class, "{{getter}}", "{{setter}}");
         {{/propertySubstitutions}}
         types.put(td_{{simpleName}}.getType(), td_{{simpleName}});
-        {{#parameterizedProperties}}
-        addParameterizedParameter("{{fullName}}", "{{parameterizedPropertyName}}", {{parameterizedGroupingType}}.class {{#parameterizedTypes}}, "{{{toString}}}"{{/parameterizedTypes}});
-        {{/parameterizedProperties}}
-
 {{/typesToAugment}}
     }
 }

--- a/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/codegen/snakeyaml/TestSnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/codegen/snakeyaml/TestSnakeYAMLMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/codegen/snakeyaml/TestSnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/codegen/snakeyaml/TestSnakeYAMLMojo.java
@@ -60,6 +60,9 @@ public class TestSnakeYAMLMojo {
         Type topLevelType = mojo.types().get("org.eclipse.microprofile.openapi.models.TopLevel");
         assertNotNull(topLevelType, "Expected Type for org.eclipse.microprofile.openapi.models.TopLevel not found");
 
+        // Test the ability to set property subs after the type defs have been built.
+        topLevelType.propertySubstitution("item", String.class.getName(), "getThing", "setThing");
+
         Type.PropertySubstitution sub = null;
         for (Type.PropertySubstitution s : topLevelType.propertySubstitutions()) {
             if (s.propertySubName().equals("item")) {

--- a/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/codegen/snakeyaml/TestSnakeYAMLMojo.java
+++ b/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/codegen/snakeyaml/TestSnakeYAMLMojo.java
@@ -18,15 +18,13 @@ package io.helidon.codegen.snakeyaml;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static io.helidon.codegen.snakeyaml.TestHelper.getFile;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestSnakeYAMLMojo {
 
@@ -51,5 +49,30 @@ public class TestSnakeYAMLMojo {
         assertTrue(imports.contains(referenceImport), "Missing Reference import");
         assertTrue(imports.contains(topLevelImplImport), "Missing TopLevelImpl import");
         assertTrue(imports.contains(topLevelImport), "Missing TopLevel import");
+    }
+
+    @Test
+    public void testPropSub() throws Exception {
+        SnakeYAMLMojo mojo = MavenPluginHelper.getInstance().getMojo("simpleTest/pom-prop-sub.xml",
+                OUTPUT_DIR, "generate", SnakeYAMLMojo.class);
+        mojo.execute();
+
+        Type topLevelType = mojo.types().get("org.eclipse.microprofile.openapi.models.TopLevel");
+        assertNotNull(topLevelType, "Expected Type for org.eclipse.microprofile.openapi.models.TopLevel not found");
+
+        Type.PropertySubstitution sub = null;
+        for (Type.PropertySubstitution s : topLevelType.propertySubstitutions()) {
+            if (s.propertySubName().equals("item")) {
+                sub = s;
+                break;
+            }
+        }
+        assertNotNull(sub, "Expected property substitution for 'item' not found");
+        assertEquals("java.lang.String", sub.propertySubType(),
+                "Expected replacement property type 'java.lang.String'; found '" + sub.propertySubType() + "' instead");
+        assertEquals("getThing", sub.getter(),
+                "Expected replacement getter 'getThing'; found '" + sub.getter() + "' instead");
+        assertEquals("setThing", sub.setter(),
+                "Expected replacement setter 'getThing'; found '" + sub.setter() + "' instead");
     }
 }

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/interfaces/org/eclipse/microprofile/openapi/models/TopLevel.java
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/interfaces/org/eclipse/microprofile/openapi/models/TopLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/interfaces/org/eclipse/microprofile/openapi/models/TopLevel.java
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/interfaces/org/eclipse/microprofile/openapi/models/TopLevel.java
@@ -39,5 +39,9 @@ public interface TopLevel extends Reference {
 
     public void setStuffMap(Map<String, Stuff> map);
 
+    public void setThing(String thing);
+
+    public String getThing();
+
 
 }

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-one-class.xml
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-one-class.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-one-class.xml
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-one-class.xml
@@ -19,12 +19,18 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.build-tools</groupId>
+        <artifactId>snakeyaml-codegen-maven-plugin</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+
     <groupId>test.group</groupId>
     <artifactId>test-artifact</artifactId>
-    <version>test-version</version>
 
     <properties>
-        <version.plugin.openapicodegen>1.0.11-SNAPSHOT</version.plugin.openapicodegen>
+        <version.plugin.snakeyamlcodegen>${project.version}</version.plugin.snakeyamlcodegen>
         <version.lib.microprofile.openapi>1.1.2</version.lib.microprofile.openapi>
     </properties>
 
@@ -41,7 +47,7 @@
             <plugin>
                 <groupId>io.helidon.build-tools</groupId>
                 <artifactId>snakeyaml-codegen-maven-plugin</artifactId>
-                <version>${version.plugin.openapicodegen}</version>
+                <version>${version.plugin.snakeyamlcodegen}</version>
                 <configuration>
                     <interfacesConfig>
                         <inputDirectory>interfaces</inputDirectory>

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
@@ -19,12 +19,18 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.build-tools</groupId>
+        <artifactId>snakeyaml-codegen-maven-plugin</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+
     <groupId>test.group</groupId>
     <artifactId>test-artifact</artifactId>
-    <version>test-version</version>
 
     <properties>
-        <version.plugin.openapicodegen>1.0.11-SNAPSHOT</version.plugin.openapicodegen>
+        <version.plugin.snakeyamlcodegen>${project.version}</version.plugin.snakeyamlcodegen>
         <version.lib.microprofile.openapi>1.1.2</version.lib.microprofile.openapi>
     </properties>
 
@@ -41,7 +47,7 @@
             <plugin>
                 <groupId>io.helidon.build-tools</groupId>
                 <artifactId>snakeyaml-codegen-maven-plugin</artifactId>
-                <version>${version.plugin.openapicodegen}</version>
+                <version>${version.plugin.snakeyamlcodegen}</version>
                 <configuration>
                     <interfacesConfig>
                         <inputDirectory>interfaces</inputDirectory>

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
@@ -51,9 +51,26 @@
                         <inputDirectory>implementations</inputDirectory>
                         <includes>**/*.java</includes>
                     </implementationsConfig>
-                    <outputClass>io.helidon.codegen.snakeyaml.test.Helper</outputClass>
+                    <outputClass>io.helidon.codegen.snakeyaml.test.PropSubHelper</outputClass>
                     <implementationPrefix>io.smallrye</implementationPrefix>
                     <interfacePrefix>org.eclipse.microprofile.openapi</interfacePrefix>
+                    <typeRefinements>
+                        <typeRefinement>
+                            <typeName>org.eclipse.microprofile.openapi.models.TopLevel</typeName>
+                            <propertyRefinements>
+                                <propertyRefinement>
+                                    <propertyName>item</propertyName>
+                                    <propertySubstitutions>
+                                        <propertySubstitution>
+                                            <propertyType>java.lang.String</propertyType>
+                                            <getter>getThing</getter>
+                                            <setter>setThing</setter>
+                                        </propertySubstitution>
+                                    </propertySubstitutions>
+                                </propertyRefinement>
+                            </propertyRefinements>
+                        </typeRefinement>
+                    </typeRefinements>
                 </configuration>
             </plugin>
         </plugins>

--- a/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
+++ b/snakeyaml-codegen-maven-plugin/src/test/resources/simpleTest/pom-prop-sub.xml
@@ -54,23 +54,6 @@
                     <outputClass>io.helidon.codegen.snakeyaml.test.PropSubHelper</outputClass>
                     <implementationPrefix>io.smallrye</implementationPrefix>
                     <interfacePrefix>org.eclipse.microprofile.openapi</interfacePrefix>
-                    <typeRefinements>
-                        <typeRefinement>
-                            <typeName>org.eclipse.microprofile.openapi.models.TopLevel</typeName>
-                            <propertyRefinements>
-                                <propertyRefinement>
-                                    <propertyName>item</propertyName>
-                                    <propertySubstitutions>
-                                        <propertySubstitution>
-                                            <propertyType>java.lang.String</propertyType>
-                                            <getter>getThing</getter>
-                                            <setter>setThing</setter>
-                                        </propertySubstitution>
-                                    </propertySubstitutions>
-                                </propertyRefinement>
-                            </propertyRefinements>
-                        </typeRefinement>
-                    </typeRefinements>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The main point of most of these changes is to move some remaining OpenAPI-specific logic out of the plug-in and into the Helidon OpenAPI module.

There is some other clean-up, additions of comments and tests, etc. as well.

This is part of the resolution of Helidon issue oracle/helidon#1109  