### PR TITLE
Support for standalone CLI native image

### DIFF
--- a/dev-loop/src/main/java/io/helidon/build/dev/maven/ForkedMavenExecutor.java
+++ b/dev-loop/src/main/java/io/helidon/build/dev/maven/ForkedMavenExecutor.java
@@ -58,7 +58,7 @@ public class ForkedMavenExecutor extends BuildExecutor {
         // Make sure we use the current JDK by forcing it first in the path and setting JAVA_HOME. This might be required
         // if we're in an IDE whose process was started with a different JDK.
 
-        final String javaHome = System.getProperty("java.home");
+        final String javaHome = Constants.javaHome();
         final String javaHomeBin = javaHome + File.separator + "bin";
         final ProcessBuilder processBuilder = new ProcessBuilder().directory(projectDirectory().toFile())
                                                                   .command(command);

--- a/dev-loop/src/main/java/io/helidon/build/dev/mode/ProjectExecutor.java
+++ b/dev-loop/src/main/java/io/helidon/build/dev/mode/ProjectExecutor.java
@@ -37,7 +37,7 @@ public class ProjectExecutor {
     private static final String MAVEN_EXEC = Constants.OS.mavenExec();
     private static final List<String> EXEC_COMMAND = List.of(MAVEN_EXEC, "exec:java");
     private static final String JAVA_EXEC = Constants.OS.javaExecutable();
-    private static final String JAVA_HOME = System.getProperty("java.home");
+    private static final String JAVA_HOME = Constants.javaHome();
     private static final String JAVA_HOME_BIN = JAVA_HOME + File.separator + "bin";
     private static final String JIT_LEVEL_ONE = "-XX:TieredStopAtLevel=1";
     private static final String JIT_TWO_COMPILER_THREADS = "-XX:CICompilerCount=2";

--- a/dev-loop/src/test/java/io/helidon/build/dev/clidemo/HelidonCliDemo.java
+++ b/dev-loop/src/test/java/io/helidon/build/dev/clidemo/HelidonCliDemo.java
@@ -31,7 +31,7 @@ import io.helidon.build.util.Constants;
 import io.helidon.build.util.HelidonVariant;
 import io.helidon.build.util.Log;
 import io.helidon.build.util.ProcessMonitor;
-import io.helidon.build.util.QuickstartGenerator;
+import io.helidon.build.util.SimpleQuickstartGenerator;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
@@ -59,7 +59,7 @@ public class HelidonCliDemo {
 
     private static final String MAVEN_EXEC = Constants.OS.mavenExec();
     private static final String MAVEN_PLUGIN_GOAL = "io.helidon.build-tools:helidon-maven-plugin:1.1.2-SNAPSHOT:dev";
-    private static final String JAVA_HOME = System.getProperty("java.home");
+    private static final String JAVA_HOME = Constants.javaHome();
     private static final String JAVA_HOME_BIN = JAVA_HOME + File.separator + "bin";
     private static final long SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
     private static final boolean FORK_MAVEN = "true".equals(System.getProperty("dev.fork"));
@@ -134,7 +134,7 @@ public class HelidonCliDemo {
             // Generate project
             Path dir = null;
             try {
-                dir = QuickstartGenerator.generator()
+                dir = SimpleQuickstartGenerator.generator()
                         .parentDirectory(CWD)
                         .helidonVariant(variant)
                         .helidonVersion(version)

--- a/helidon-cli/impl/pom.xml
+++ b/helidon-cli/impl/pom.xml
@@ -161,12 +161,7 @@
                                         <argument>-H:+ReportExceptionStackTraces</argument>
                                         <argument>-H:-ParseRuntimeOptions</argument>
                                         <argument>--no-server</argument>
-                                        <!--
-                                          - Helidon CLI requires a JDK and Maven to run, so it is OK to create
-                                          - a 'fallback' image that requires a JDK. We have problems without
-                                          - this flag at this point (e.g. looking for 'java.home' property).
-                                          -->
-                                        <argument>--force-fallback</argument>
+                                        <argument>--no-fallback</argument>
                                         <argument>-jar</argument>
                                         <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
                                     </arguments>

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
@@ -49,7 +49,7 @@ public abstract class BaseCommand {
     static final String HELIDON_PROPERTIES = "helidon.properties";
     static final String HELIDON_VERSION = "helidon.version";
     static final String MAVEN_EXEC = Constants.OS.mavenExec();
-    static final String JAVA_HOME = System.getProperty("java.home");
+    static final String JAVA_HOME = Constants.javaHome();
     static final String JAVA_HOME_BIN = JAVA_HOME + File.separator + "bin";
     static final long SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
 

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
@@ -31,8 +31,8 @@ import io.helidon.build.util.Constants;
 import io.helidon.build.util.HelidonVariant;
 import io.helidon.build.util.ProjectConfig;
 import io.helidon.build.util.ProjectDependency;
-
 import io.helidon.build.util.SimpleQuickstartGenerator;
+
 import org.apache.maven.model.Extension;
 import org.apache.maven.model.Model;
 

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
@@ -31,8 +31,8 @@ import io.helidon.build.util.Constants;
 import io.helidon.build.util.HelidonVariant;
 import io.helidon.build.util.ProjectConfig;
 import io.helidon.build.util.ProjectDependency;
-import io.helidon.build.util.QuickstartGenerator;
 
+import io.helidon.build.util.SimpleQuickstartGenerator;
 import org.apache.maven.model.Extension;
 import org.apache.maven.model.Model;
 
@@ -111,10 +111,10 @@ public final class InitCommand extends BaseCommand implements CommandExecution {
         }
 
         // Generate project using Maven archetype
-        Path dir = null;
+        Path dir;
         Path parentDirectory = commonOptions.project().toPath();
         try {
-            dir = QuickstartGenerator.generator()
+            dir = SimpleQuickstartGenerator.generator()
                     .parentDirectory(parentDirectory)
                     .helidonVariant(HelidonVariant.parse(flavor.name()))
                     .helidonVersion(version)

--- a/helidon-linker/src/test/java/io/helidon/linker/ClassDataSharingTest.java
+++ b/helidon-linker/src/test/java/io/helidon/linker/ClassDataSharingTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import io.helidon.build.test.TestFiles;
 
+import io.helidon.build.util.Constants;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,7 +37,7 @@ import static org.hamcrest.Matchers.nullValue;
  * Unit test for class {@link ClassDataSharing}.
  */
 class ClassDataSharingTest {
-    private static final Path JAVA_HOME = Paths.get(System.getProperty("java.home"));
+    private static final Path JAVA_HOME = Path.of(Constants.javaHome());
     private static final String APP_CLASS = "org/jboss/weld/environment/deployment/discovery/BeanArchiveScanner";
 
     @Test

--- a/utils/src/main/java/io/helidon/build/util/Constants.java
+++ b/utils/src/main/java/io/helidon/build/util/Constants.java
@@ -40,6 +40,24 @@ public final class Constants {
      */
     public static final String DIR_SEP = File.separator;
 
+    /**
+     * Gets location of Java's home directory by checking the (@code java.home} property
+     * followed by the {@code JAVA_HOME} environment variable.
+     *
+     * @return Java's home directory.
+     * @throws RuntimeException If unable to find home directory.
+     */
+    public static String javaHome() {
+        String javaHome = System.getProperty("java.home");
+        if (javaHome == null) {
+            javaHome = System.getenv("JAVA_HOME");
+            if (javaHome == null) {
+                throw new RuntimeException("Unable to find Java installation, please set JAVA_HOME");
+            }
+        }
+        return javaHome;
+    }
+
     private Constants() {
     }
 }

--- a/utils/src/main/java/io/helidon/build/util/FileUtils.java
+++ b/utils/src/main/java/io/helidon/build/util/FileUtils.java
@@ -42,7 +42,7 @@ public final class FileUtils {
     /**
      * The Java Home directory for the running JVM.
      */
-    public static final Path CURRENT_JAVA_HOME_DIR = Paths.get(System.getProperty("java.home"));
+    public static final Path CURRENT_JAVA_HOME_DIR = Paths.get(Constants.javaHome());
 
     /**
      * The working directory.

--- a/utils/src/main/java/io/helidon/build/util/SimpleQuickstartGenerator.java
+++ b/utils/src/main/java/io/helidon/build/util/SimpleQuickstartGenerator.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static io.helidon.build.util.FileUtils.assertDir;
+
+/**
+ * Simple generator for a quickstart project. This class does not import any Maven classes
+ * and is currently used to avoid problems with Graal native compilation.
+ */
+public class SimpleQuickstartGenerator {
+
+    /**
+     * Maven executable.
+     */
+    protected static final String MAVEN_EXEC = Constants.OS.mavenExec();
+
+    /**
+     * Groud ID for archetypes.
+     */
+    protected static final String ARCHETYPES_GROUP_ID = "io.helidon.archetypes";
+
+    /**
+     * Helidon quickstart prefix.
+     */
+    protected static final String HELIDON_QUICKSTART_PREFIX = "helidon-quickstart-";
+
+    /**
+     * Quickstart package prefix.
+     */
+    protected static final String QUICKSTART_PACKAGE_PREFIX = "io.helidon.examples.quickstart.";
+
+    private Path parentDirectory;
+    private HelidonVariant variant;
+    private boolean quiet;
+    private String id;
+    private String version;
+
+    /**
+     * Returns a new generator.
+     *
+     * @return The generator.
+     */
+    public static SimpleQuickstartGenerator generator() {
+        return new SimpleQuickstartGenerator();
+    }
+
+    protected SimpleQuickstartGenerator() {
+    }
+
+    protected Path parentDirectory() {
+        return parentDirectory;
+    }
+
+    protected HelidonVariant variant() {
+        return variant;
+    }
+
+    protected String id() {
+        return id;
+    }
+
+    protected void id(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Sets the Helidon version to use.
+     *
+     * @param version The version.
+     * @return This instance, for chaining.
+     */
+    public SimpleQuickstartGenerator helidonVersion(String version) {
+        Objects.requireNonNull(version);
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Sets the Helidon variant to use.
+     *
+     * @param helidonVariant The variant.
+     * @return This instance, for chaining.
+     */
+    public SimpleQuickstartGenerator helidonVariant(HelidonVariant helidonVariant) {
+        this.variant = helidonVariant;
+        return this;
+    }
+
+    /**
+     * Sets whether or not log messages should be suppressed. Default is {@code false}.
+     *
+     * @param quiet {@code true} if log messages should not be written.
+     * @return This instance, for chaining.
+     */
+    public SimpleQuickstartGenerator quiet(boolean quiet) {
+        this.quiet = quiet;
+        return this;
+    }
+
+    /**
+     * Sets the directory in which to generate the project.
+     *
+     * @param parentDirectory The parent directory.
+     * @return This instance, for chaining.
+     */
+    public SimpleQuickstartGenerator parentDirectory(Path parentDirectory) {
+        this.parentDirectory = assertDir(parentDirectory);
+        return this;
+    }
+
+    /**
+     * Generate the project.
+     *
+     * @return The path to the project.
+     */
+    public Path generate() {
+        initialize();
+        final String pkg = QUICKSTART_PACKAGE_PREFIX + variant.toString();
+        Log.info("Generating %s from archetype %s", id, version);
+        execute(new ProcessBuilder().directory(parentDirectory.toFile())
+                                    .command(List.of(MAVEN_EXEC,
+                                                     "archetype:generate",
+                                                     "-DinteractiveMode=false",
+                                                     "-DarchetypeGroupId=" + ARCHETYPES_GROUP_ID,
+                                                     "-DarchetypeArtifactId=" + id,
+                                                     "-DarchetypeVersion=" + version,
+                                                     "-DgroupId=test",
+                                                     "-DartifactId=" + id,
+                                                     "-Dpackage=" + pkg
+                                    )));
+        final Path result = assertDir(parentDirectory.resolve(id));
+        log("Generated %s", result);
+        return result;
+    }
+
+    private void initialize() {
+        if (version == null) {
+            throw new IllegalStateException("version required.");
+        }
+        if (variant == null) {
+            throw new IllegalStateException("helidonVariant required.");
+        }
+        if (parentDirectory == null) {
+            throw new IllegalStateException("projectDirectory required.");
+        }
+        this.id = HELIDON_QUICKSTART_PREFIX + variant.toString();
+        final Path projectDir = parentDirectory.resolve(id);
+        if (Files.exists(projectDir)) {
+            throw new IllegalStateException(projectDir + " already exists");
+        }
+    }
+
+    protected void log(String message, Object... args) {
+        if (!quiet) {
+            Log.info(message, args);
+        }
+    }
+
+    protected static void execute(ProcessBuilder builder) {
+        try {
+            ProcessMonitor.builder()
+                          .processBuilder(builder)
+                          .capture(true)
+                          .build()
+                          .execute(5, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/utils/src/test/java/io/helidon/build/test/TestFiles.java
+++ b/utils/src/test/java/io/helidon/build/test/TestFiles.java
@@ -317,7 +317,7 @@ public class TestFiles implements BeforeAllCallback {
 
         final ProcessBuilder builder = new ProcessBuilder().directory(projectDir.toFile())
                                                            .command(List.of(MAVEN_EXEC, "clean", "package", "-DskipTests"));
-        final String javaHome = System.getProperty("java.home");
+        final String javaHome = Constants.javaHome();
         final String javaHomeBin = javaHome + File.separator + "bin";
         final Map<String, String> env = builder.environment();
         final String path = javaHomeBin + File.pathSeparatorChar + env.get("PATH");

--- a/utils/src/test/java/io/helidon/build/util/QuickstartGeneratorTest.java
+++ b/utils/src/test/java/io/helidon/build/util/QuickstartGeneratorTest.java
@@ -65,11 +65,6 @@ class QuickstartGeneratorTest {
     }
 
     @Test
-    void testSeGenerationSpecificVersion() {
-        testGeneration(HelidonVariant.SE, version -> version.toString().equals("1.4.1"));
-    }
-
-    @Test
     void testSeGenerationLatestVersion() {
         testGeneration(HelidonVariant.SE, LATEST_RELEASE);
     }


### PR DESCRIPTION
New simplified quickstart generator that does not depend on Maven classes. Look up JAVA_HOME if property java.home is not available. CLI's native image is now standalone with these changes. Still requires Java and Maven to run, but no additional jar files.