### PR TITLE
[WIP] h1 page title has parent group title instead of parent path element

### DIFF
--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/VuetifyNavigation.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/VuetifyNavigation.java
@@ -505,7 +505,7 @@ public class VuetifyNavigation implements Model {
             try {
                 this.urlSafeTitle = URLEncoder.encode(title, "UTF-8");
             } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException("Cannot url encode group title",e);
+                throw new RuntimeException("Cannot url encode group title", e);
             }
         }
 

--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/VuetifyNavigation.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/VuetifyNavigation.java
@@ -16,6 +16,8 @@
 
 package io.helidon.build.sitegen;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -26,7 +28,6 @@ import java.util.stream.Stream;
 
 import io.helidon.config.Config;
 
-import static io.helidon.build.sitegen.AbstractBuilder.asType;
 import static io.helidon.build.sitegen.Helper.checkNonNull;
 import static io.helidon.build.sitegen.Helper.checkNonNullNonEmpty;
 
@@ -38,6 +39,7 @@ public class VuetifyNavigation implements Model {
     private static final String GLYPH_PROP = "glyph";
     private static final String TITLE_PROP = "title";
     private static final String ITEMS_PROP = "items";
+    private static final String URL_SAFE_TITLE_PROP = "urlSafeTitle";
     private static final String PATHPREFIX_PROP = "pathprefix";
     private static final String HREF_PROP = "href";
     private static final String INCLUDES_PROP = "includes";
@@ -488,6 +490,7 @@ public class VuetifyNavigation implements Model {
     public static class Group extends Item {
 
         private final List<Item> items;
+        private final String urlSafeTitle;
 
         /**
          * Create a new instance of {@link Group}.
@@ -499,6 +502,11 @@ public class VuetifyNavigation implements Model {
             super(title, glyph);
             checkNonNull(items, ITEMS_PROP);
             this.items = items;
+            try {
+                this.urlSafeTitle = URLEncoder.encode(title, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException("Cannot url encode group title",e);
+            }
         }
 
         /**
@@ -516,6 +524,10 @@ public class VuetifyNavigation implements Model {
          */
         public List<Item> getItems() {
             return items;
+        }
+
+        public String getUrlSafeTitle() {
+            return urlSafeTitle;
         }
 
         private Group resolve(Collection<Page> allPages) {
@@ -540,6 +552,8 @@ public class VuetifyNavigation implements Model {
         public Object get(String attr) {
             switch (attr) {
                 case (ITEMS_PROP):
+                    return items;
+                case (URL_SAFE_TITLE_PROP):
                     return items;
                 default:
                     return super.get(attr);
@@ -690,6 +704,7 @@ public class VuetifyNavigation implements Model {
                 String title = null;
                 Glyph glyph = null;
                 String pathprefix = null;
+                String parenttitle = null;
                 List<Item> items = null;
                 for (Map.Entry<String, Object> entry : values()) {
                     String attr = entry.getKey();

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/mainView.js
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/mainView.js
@@ -72,11 +72,12 @@ window.allComponents["mainView"] = {
                 setMeta() {
                     if (typeof document === 'undefined') return;
                     const metaData = this.$route.meta || {};
-                    const section = this.$route.path.split('/');
                     let h1 = metaData.h1;
 
-                    if (section.length > 2) {
-                        h1 = `${section[1].charAt(0).toUpperCase()}${section[1].slice(1)} &nbsp;&mdash;&nbsp; ${h1}`;
+                    let rawParentTitle = this.$route.params.parentTitle;
+                    if (typeof rawParentTitle === "string" && rawParentTitle.length > 0) {
+                        let parentTitle = decodeURIComponent(rawParentTitle).replace(/\+/g, ' ');
+                        h1 = `${parentTitle} &nbsp;&mdash;&nbsp; ${h1}`;
                     }
 
                     document.title = `${metaData.title}`;

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
@@ -52,7 +52,7 @@ function createRoutes(){
 <#assign pageId = page.target?remove_beginning("/")?replace("/","-") />
 <#assign pageBindings = bindings[source]?has_content />
         {
-            path: '${page.target}',
+            path: '${page.target}/:parentTitle?',
             meta: {
                 h1: '${page.metadata.h1?js_string}',
                 title: '${page.metadata.title?js_string}',
@@ -91,7 +91,7 @@ function createNav(){
             items: [
 <#list groupitem.items as subgroupitem>
 <#if subgroupitem.islink>
-                { href: '${subgroupitem.href}', title: '${subgroupitem.title?js_string}' }<#sep>,</#sep>
+                { href: '${subgroupitem.href}/${groupitem.urlSafeTitle?js_string}', title: '${subgroupitem.title?js_string}' }<#sep>,</#sep>
 </#if>
 </#list>
             ]


### PR DESCRIPTION
When referencing documents from shared folder, h1 title parent is derived from parent path element:
![image](https://user-images.githubusercontent.com/1773630/78017513-acadc700-734c-11ea-9616-ecc6445e5dd2.png)
Use parent group title from navigation like this:
![image](https://user-images.githubusercontent.com/1773630/78017582-c6e7a500-734c-11ea-8fcf-e4bc7324bcdd.png)


Signed-off-by: Daniel Kec <daniel.kec@oracle.com>