### PR TITLE
Add parentTitle header param support

### DIFF
--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Page.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Page.java
@@ -172,12 +172,12 @@ public class Page implements Model {
         private static final String KEYWORDS_PROP = "keywords";
         private static final String H1_PROP = "h1";
         private static final String TITLE_PROP = "title";
-        private static final String PARENT_TITLE_PROP = "parentTitle";
+        private static final String H1_PREFIX = "h1Prefix";
         private final String description;
         private final String keywords;
         private final String h1;
         private final String title;
-        private final String parentTitle;
+        private final String h1Prefix;
 
         /**
          * Create a new {@link Metadata} instance.
@@ -185,19 +185,19 @@ public class Page implements Model {
          * @param keywords the {@link Page} keywords
          * @param h1 the {@link Page} alternative title
          * @param title  the {@link Page} title
-         * @param parentTitle  the {@link Page} custom parent title
+         * @param h1Prefix  the {@link Page} custom h1 prefix
          */
         public Metadata(String description,
                         String keywords,
                         String h1,
                         String title,
-                        String parentTitle) {
+                        String h1Prefix) {
             checkNonNullNonEmpty(title, TITLE_PROP);
             this.description = description;
             this.keywords = keywords;
             this.h1 = h1;
             this.title = title;
-            this.parentTitle = parentTitle;
+            this.h1Prefix = h1Prefix;
         }
 
         /**
@@ -236,8 +236,8 @@ public class Page implements Model {
          * Get the {@link Page} parent title.
          * @return the parent title
          */
-        public String getParentTitle() {
-            return parentTitle;
+        public String getH1Prefix() {
+            return h1Prefix;
         }
 
         @Override
@@ -251,8 +251,8 @@ public class Page implements Model {
                     return h1;
                 case (TITLE_PROP):
                     return title;
-                case (PARENT_TITLE_PROP):
-                    return parentTitle;
+                case (H1_PREFIX):
+                    return h1Prefix;
                 default:
                     throw new IllegalStateException(
                             "Unkown attribute: " + attr);

--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Page.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Page.java
@@ -172,10 +172,12 @@ public class Page implements Model {
         private static final String KEYWORDS_PROP = "keywords";
         private static final String H1_PROP = "h1";
         private static final String TITLE_PROP = "title";
+        private static final String PARENT_TITLE_PROP = "parentTitle";
         private final String description;
         private final String keywords;
         private final String h1;
         private final String title;
+        private final String parentTitle;
 
         /**
          * Create a new {@link Metadata} instance.
@@ -187,12 +189,14 @@ public class Page implements Model {
         public Metadata(String description,
                         String keywords,
                         String h1,
-                        String title) {
+                        String title,
+                        String parentTitle) {
             checkNonNullNonEmpty(title, TITLE_PROP);
             this.description = description;
             this.keywords = keywords;
             this.h1 = h1;
             this.title = title;
+            this.parentTitle = parentTitle;
         }
 
         /**
@@ -227,6 +231,14 @@ public class Page implements Model {
             return title;
         }
 
+        /**
+         * Get the {@link Page} parent title.
+         * @return the parent title
+         */
+        public String getParentTitle() {
+            return parentTitle;
+        }
+
         @Override
         public Object get(String attr) {
             switch (attr) {
@@ -238,6 +250,8 @@ public class Page implements Model {
                     return h1;
                 case (TITLE_PROP):
                     return title;
+                case (PARENT_TITLE_PROP):
+                    return parentTitle;
                 default:
                     throw new IllegalStateException(
                             "Unkown attribute: " + attr);

--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Page.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Page.java
@@ -185,6 +185,7 @@ public class Page implements Model {
          * @param keywords the {@link Page} keywords
          * @param h1 the {@link Page} alternative title
          * @param title  the {@link Page} title
+         * @param parentTitle  the {@link Page} custom parent title
          */
         public Metadata(String description,
                         String keywords,

--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/asciidoctor/AsciidocPageRenderer.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/asciidoctor/AsciidocPageRenderer.java
@@ -44,6 +44,7 @@ public class AsciidocPageRenderer implements PageRenderer {
 
     /**
      * Create a new instance of {@link AsciidocPageRenderer}.
+     *
      * @param backendName the name of the backend
      */
     public AsciidocPageRenderer(String backendName) {
@@ -60,7 +61,7 @@ public class AsciidocPageRenderer implements PageRenderer {
         File target = new File(pagesdir, page.getTargetPath() + "." + ext);
         siteEngine.asciidoc().render(page, ctx, target,
                 mapOf("page", page,
-                      "pages", ctx.getPages()));
+                        "pages", ctx.getPages()));
     }
 
     @Override
@@ -73,6 +74,7 @@ public class AsciidocPageRenderer implements PageRenderer {
                 asString(docHeader.get("description")),
                 asString(docHeader.get("keywords")),
                 asString(docHeader.get("h1")),
-                asString(docHeader.get("doctitle")));
+                asString(docHeader.get("doctitle")),
+                asString(docHeader.get("parenttitle")));
     }
 }

--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/asciidoctor/AsciidocPageRenderer.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/asciidoctor/AsciidocPageRenderer.java
@@ -75,6 +75,6 @@ public class AsciidocPageRenderer implements PageRenderer {
                 asString(docHeader.get("keywords")),
                 asString(docHeader.get("h1")),
                 asString(docHeader.get("doctitle")),
-                asString(docHeader.get("parenttitle")));
+                asString(docHeader.get("h1prefix")));
     }
 }

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/mainView.js
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/mainView.js
@@ -45,8 +45,8 @@ window.allComponents["mainView"] = {
                     h1Prefix = capitalize(section[1]);
                 }
 
-                if (metaData.parentTitle) {
-                    h1Prefix = metaData.parentTitle;
+                if (metaData.h1Prefix) {
+                    h1Prefix = metaData.h1Prefix;
                 }
 
                 if (h1Prefix) {
@@ -89,8 +89,8 @@ window.allComponents["mainView"] = {
                         h1Prefix = capitalize(section[1]);
                     }
 
-                    if (metaData.parentTitle) {
-                        h1Prefix = metaData.parentTitle;
+                    if (metaData.h1Prefix) {
+                        h1Prefix = metaData.h1Prefix;
                     }
 
                     if (h1Prefix) {

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/mainView.js
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/mainView.js
@@ -39,10 +39,19 @@ window.allComponents["mainView"] = {
                 const metaData = this.$route.meta || {};
                 const section = this.$route.path.split('/');
                 let h1 = metaData.h1;
+                let h1Prefix = null;
 
                 if (section.length > 2) {
+                    h1Prefix = capitalize(section[1]);
+                }
+
+                if (metaData.parentTitle) {
+                    h1Prefix = metaData.parentTitle;
+                }
+
+                if (h1Prefix) {
                     h1 = `
-                  <div class="hidden-sm-and-down">${section[1].charAt(0).toUpperCase()}${section[1].slice(1)} &nbsp;&mdash;&nbsp;&nbsp;
+                  <div class="hidden-sm-and-down">${h1Prefix} &nbsp;&mdash;&nbsp;&nbsp;
                   </div><div>${h1}</div>
                 `;
                 }
@@ -74,9 +83,18 @@ window.allComponents["mainView"] = {
                     const metaData = this.$route.meta || {};
                     const section = this.$route.path.split('/');
                     let h1 = metaData.h1;
+                    let h1Prefix = null;
 
                     if (section.length > 2) {
-                        h1 = `${section[1].charAt(0).toUpperCase()}${section[1].slice(1)} &nbsp;&mdash;&nbsp; ${h1}`;
+                        h1Prefix = capitalize(section[1]);
+                    }
+
+                    if (metaData.parentTitle) {
+                        h1Prefix = metaData.parentTitle;
+                    }
+
+                    if (h1Prefix) {
+                        h1 = `${h1Prefix} &nbsp;&mdash;&nbsp; ${h1}`;
                     }
 
                     document.title = `${metaData.title}`;

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/main/utils.js
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/main/utils.js
@@ -83,3 +83,7 @@ function loadPage(id, targetPath, compDef, customJsPath) {
         });
     });
 }
+
+function capitalize(src) {
+    return `${src.charAt(0).toUpperCase()}${src.slice(1)}`;
+}

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
@@ -56,7 +56,7 @@ function createRoutes(){
             meta: {
                 h1: '${page.metadata.h1?js_string}',
                 title: '${page.metadata.title?js_string}',
-                parentTitle: <#if page.metadata.parentTitle??>'${page.metadata.parentTitle?js_string}'<#else>null</#if>,
+                h1Prefix: <#if page.metadata.h1Prefix??>'${page.metadata.h1Prefix?js_string}'<#else>null</#if>,
                 description: <#if page.metadata.description??>'${page.metadata.description?js_string}'<#else>null</#if>,
                 keywords: <#if page.metadata.keywords??>'${page.metadata.keywords?js_string}'<#else>null</#if>,
                 customLayout: <#if customLayoutEntries[source]??>'${customLayoutEntries[source]}'<#else>null</#if>,

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
@@ -56,6 +56,7 @@ function createRoutes(){
             meta: {
                 h1: '${page.metadata.h1?js_string}',
                 title: '${page.metadata.title?js_string}',
+                parentTitle: <#if page.metadata.parentTitle??>'${page.metadata.parentTitle?js_string}'<#else>null</#if>,
                 description: <#if page.metadata.description??>'${page.metadata.description?js_string}'<#else>null</#if>,
                 keywords: <#if page.metadata.keywords??>'${page.metadata.keywords?js_string}'<#else>null</#if>,
                 customLayout: <#if customLayoutEntries[source]??>'${customLayoutEntries[source]}'<#else>null</#if>,


### PR DESCRIPTION
Overridable parent title with header param `parentTitle`, example:
```adoc
= Overview
:parentTitle: Se & Mp
```
![image](https://user-images.githubusercontent.com/1773630/78132716-886deb00-741d-11ea-9956-8fa6db0aaee3.png)

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>