### PR TITLE
Wrap table content by default, optional nowrap attribute

### DIFF
--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/css/helidon-sitegen.css
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/css/helidon-sitegen.css
@@ -472,12 +472,21 @@ table > thead > tr > th {
     text-align: left;
 }
 
-.table__overflow code, table__overflow kbd{
-    white-space: nowrap!important;
+.table__overflow code, table__overflow kbd {
+    white-space: nowrap !important;
 }
 
-.table__overflow tbody td {
+.table__overflow {
+}
+
+.no_wrap_table {
     white-space: nowrap!important;
+    overflow: auto;
+}
+
+.no_wrap_cell {
+    white-space: nowrap!important;
+    max-width: 100px;
 }
 
 .card__example .card__text {

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/block_table.ftl
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/block_table.ftl
@@ -25,8 +25,11 @@ TODO:
 <#list attributes["role"]?replace(","," ")?replace("  ", " ")?split(" ") as class>${class}<#sep> </#sep></#list>
 </#if>
 </#assign>
+<#assign nowrap = attributes["nowrap"]?? && attributes["nowrap"]?boolean>
+<#assign cell_classes = nowrap?then('no_wrap_cell', '')>
+<#assign table_classes = nowrap?then('no_wrap_table', '') + ' ' + css_classes>
 <#if title??><div class="block-title"><span>${title}</span></div></#if>
-<div class="table__overflow elevation-1 ${css_classes}">
+<div class="table__overflow elevation-1 ${table_classes}">
 <table class="datatable table">
 <colgroup>
 <#list columns as column>
@@ -47,8 +50,8 @@ TODO:
 <tr>
 <#list row.cells as cell>
 <#if cell.content?is_enumerable>
-<#list cell.content as cellcontent><td>${cellcontent}</td></#list>
-<#else><td>${cell.content}</td>
+<#list cell.content as cellcontent><td class="${cell_classes}">${cellcontent}</td></#list>
+<#else><td class="${cell_classes}">${cell.content}</td>
 </#if>
 </#list>
 </tr>

--- a/sitegen-maven-plugin/src/test/resources/testvuetify1/about/06_tables.adoc
+++ b/sitegen-maven-plugin/src/test/resources/testvuetify1/about/06_tables.adoc
@@ -102,3 +102,23 @@ The following table lists some animals:
 | `java.util.regex.Pattern`
 |
 |===
+
+== A wrapped table
+
+Table configured as `[cols="2,5"]`
+[cols="2,5"]
+|===
+|short text|Lorem ipsum
+|long text|Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nibh est, tempor id, tempus sit amet, facilisis in, erat. In hac habitasse platea dictumst. Donec fermentum, pede vitae hendrerit sodales, odio lacus mattis ante, non ultrices ligula tellus et massa. Praesent placerat est sed dui.
+|short text|Lorem ipsum
+|===
+
+== A no-wrap table
+
+Table configured as `[cols="2,5", nowrap="true"]`
+[cols="2,5", nowrap="true"]
+|===
+|short text|Lorem ipsum
+|long text|Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nibh est, tempor id, tempus sit amet, facilisis in, erat. In hac habitasse platea dictumst. Donec fermentum, pede vitae hendrerit sodales, odio lacus mattis ante, non ultrices ligula tellus et massa. Praesent placerat est sed dui.
+|short text|Lorem ipsum
+|===


### PR DESCRIPTION
```adoc
== A wrapped table

Table configured as `[cols="2,5"]`
[cols="2,5"]
|===
|short text|Lorem ipsum
|long text|Lorem ipsum dolor sit amet....
|short text|Lorem ipsum
|===

== A no-wrap table

Table configured as `[cols="2,5", nowrap="true"]`
[cols="2,5", nowrap="true"]
|===
|short text|Lorem ipsum
|long text|Lorem ipsum dolor sit amet, ....
|short text|Lorem ipsum
|===
```

![image](https://user-images.githubusercontent.com/1773630/79699794-06d9e200-8292-11ea-8801-63ef885cddf0.png)
