### PR TITLE
Basic implementation for the archetype harness.

### DIFF
--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -25,5 +25,9 @@
     <suppress checks="FileLength"
             files="config/config/src/main/java/io/helidon/config/Config.java"
             lines="1"/>
+    <suppress checks="LineLength"
+            files="helidon-archetype/engine/src/test/resources/META-INF/test.properties" />
+    <suppress checks="LineLength"
+            files="helidon-archetype/maven-plugin/src/test/resources/io/helidon/build/archetype/maven/test.properties" />
 </suppressions>
 

--- a/etc/copyright-exclude.txt
+++ b/etc/copyright-exclude.txt
@@ -13,5 +13,6 @@ vuex-router-sync.js
 .jpg
 .ftl
 .txt
+.mustache
 .json
 javax.annotation.processing.Processor

--- a/helidon-archetype/engine/pom.xml
+++ b/helidon-archetype/engine/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools.archetype</groupId>
+        <artifactId>helidon-archetype-project</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-archetype-engine</artifactId>
+    <name>Helidon Archetype Engine</name>
+
+    <properties>
+        <mainClass>io.helidon.build.archetype.engine.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/ArchetypeDescriptor.java
+++ b/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/ArchetypeDescriptor.java
@@ -1,0 +1,831 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.engine;
+
+import java.io.InputStream;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Helidon archetype XML descriptor.
+ */
+public final class ArchetypeDescriptor {
+
+    private final LinkedList<Property> properties = new LinkedList<>();
+    private final LinkedList<Transformation> transformations = new LinkedList<>();
+    private TemplateSets templateSets;
+    private FileSets fileSets;
+    private final InputFlow inputFlow = new InputFlow();
+
+    ArchetypeDescriptor() {
+    }
+
+    /**
+     * Create a archetype descriptor instance from an input stream.
+     *
+     * @param is input stream
+     * @return ArchetypeDescriptor
+     */
+    public static ArchetypeDescriptor read(InputStream is) {
+        return ArchetypeDescriptorReader.read(is);
+    }
+
+    /**
+     * Get the archetype properties.
+     *
+     * @return list of {@link Property}, never {@code null}
+     */
+    public LinkedList<Property> properties() {
+        return properties;
+    }
+
+    /**
+     * Get the transformations.
+     *
+     * @return list of {@link Transformation}, never {@code null}
+     */
+    public LinkedList<Transformation> transformations() {
+        return transformations;
+    }
+
+    /**
+     * Get the template sets.
+     *
+     * @return optional of template sets, never {@code null}
+     */
+    public Optional<TemplateSets> templateSets() {
+        return Optional.ofNullable(templateSets);
+    }
+
+    /**
+     * Set the template sets.
+     * @param templateSets template sets
+     */
+    void templateSets(TemplateSets templateSets) {
+        this.templateSets = Objects.requireNonNull(templateSets, "templateSets is null");
+    }
+
+    /**
+     * Get the file sets.
+     *
+     * @return optional of file sets, never {@code null}
+     */
+    public Optional<FileSets> fileSets() {
+        return Optional.ofNullable(fileSets);
+    }
+
+    /**
+     * Set the file sets.
+     * @param fileSets file sets
+     */
+    void fileSets(FileSets fileSets) {
+        this.fileSets = Objects.requireNonNull(fileSets, "fileSets is null");
+    }
+
+    /**
+     * Get the input flow.
+     *
+     * @return input flow, never {@code null}
+     */
+    public InputFlow inputFlow() {
+        return inputFlow;
+    }
+
+    public static final class Property {
+
+        private final String id;
+        private final String description;
+        private final Optional<String> defaultValue;
+
+        Property(String id, String description, String defaultValue) {
+            this.id = Objects.requireNonNull(id, "id is null");
+            this.description = Objects.requireNonNull(description, "description is null");
+            this.defaultValue = Optional.ofNullable(defaultValue);
+        }
+
+        /**
+         * Get the property id.
+         *
+         * @return property id, never {@code null}
+         */
+        public String id() {
+            return id;
+        }
+
+        /**
+         * get the property description.
+         *
+         * @return description, never {@code null}
+         */
+        public String description() {
+            return description;
+        }
+
+        /**
+         * Get the default value.
+         *
+         * @return default value
+         */
+        public Optional<String> defaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 5;
+            hash = 29 * hash + Objects.hashCode(this.id);
+            hash = 29 * hash + Objects.hashCode(this.description);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final Property other = (Property) obj;
+            if (!Objects.equals(this.id, other.id)) {
+                return false;
+            }
+            return Objects.equals(this.description, other.description);
+        }
+    }
+
+    /**
+     *  transformation, a pipeline of string replacement operations.
+     */
+    public static final class Transformation {
+
+        private final String id;
+        private final LinkedList<Replacement> replacements;
+
+        Transformation(String id) {
+            this.id = Objects.requireNonNull(id, "id is null");
+            this.replacements = new LinkedList<>();
+        }
+
+        /**
+         * Get the transformation id.
+         *
+         * @return transformation id, never {@code null}
+         */
+        public String id() {
+            return id;
+        }
+
+        /**
+         * Get the replacements.
+         *
+         * @return linked list of replacement, never {@code null}
+         */
+        public LinkedList<Replacement> replacements() {
+            return replacements;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 3;
+            hash = 41 * hash + Objects.hashCode(this.id);
+            hash = 41 * hash + Objects.hashCode(this.replacements);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final Transformation other = (Transformation) obj;
+            if (!Objects.equals(this.id, other.id)) {
+                return false;
+            }
+            return Objects.equals(this.replacements, other.replacements);
+        }
+    }
+
+    /**
+     * Replace operation for a transformation.
+     */
+    public static final class Replacement {
+
+        private final String regex;
+        private final String replacement;
+
+        Replacement(String regex, String replacement) {
+            this.regex = Objects.requireNonNull(regex, "regex is null");
+            this.replacement = Objects.requireNonNull(replacement, "replacement is null");
+        }
+
+        /**
+         * Get the source regular expression to match the section to be replaced.
+         *
+         * @return regular expression, never {@code null}
+         */
+        public String regex() {
+            return regex;
+        }
+
+        /**
+         * Get the replacement for the matches of the source regular expression.
+         *
+         * @return replacement, never {@code null}
+         */
+        public String replacement() {
+            return replacement;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 23 * hash + Objects.hashCode(this.regex);
+            hash = 23 * hash + Objects.hashCode(this.replacement);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final Replacement other = (Replacement) obj;
+            if (!Objects.equals(this.regex, other.regex)) {
+                return false;
+            }
+            return Objects.equals(this.replacement, other.replacement);
+        }
+    }
+
+    /**
+     * Base class for conditional nodes.
+     */
+    public abstract static class Conditional {
+
+        private final List<Property> ifProperties;
+        private final List<Property> unlessProperties;
+
+        Conditional(List<Property> ifProperties, List<Property> unlessProperties) {
+            this.ifProperties = Objects.requireNonNull(ifProperties, "ifProperties is null");
+            this.unlessProperties = Objects.requireNonNull(unlessProperties, "unlessProperties is null");
+        }
+
+        /**
+         * Get the if properties.
+         *
+         * @return list of properties, never {@code null}
+         */
+        public List<Property> ifProperties() {
+            return ifProperties;
+        }
+
+        /**
+         * Get the {@code unless} properties.
+         *
+         * @return list of properties, never {@code null}
+         */
+        public List<Property> unlessProperties() {
+            return unlessProperties;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 5;
+            hash = 17 * hash + Objects.hashCode(this.ifProperties);
+            hash = 17 * hash + Objects.hashCode(this.unlessProperties);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final Conditional other = (Conditional) obj;
+            if (!Objects.equals(this.ifProperties, other.ifProperties)) {
+                return false;
+            }
+            return Objects.equals(this.unlessProperties, other.unlessProperties);
+        }
+    }
+
+    /**
+     * Set of included template files.
+     */
+    public static final class TemplateSets extends PathSets {
+
+        private final LinkedList<FileSet> templateSets = new LinkedList<>();
+
+        TemplateSets(List<Transformation> transformations) {
+            super(transformations);
+        }
+
+        /**
+         * Get the template sets.
+         *
+         * @return list of file set, never {@code null}
+         */
+        public LinkedList<FileSet> templateSets() {
+            return templateSets;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 5;
+            hash = 31 * hash + Objects.hashCode(this.templateSets);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            if (!super.equals((PathSets) obj)) {
+                return false;
+            }
+            final TemplateSets other = (TemplateSets) obj;
+            return Objects.equals(this.templateSets, other.templateSets);
+        }
+    }
+
+    /**
+     * Set of included template files.
+     */
+    public static final class FileSets extends PathSets {
+
+        private final LinkedList<FileSet> fileSets = new LinkedList<>();
+
+        FileSets(List<Transformation> transformations) {
+            super(transformations);
+        }
+
+        /**
+         * Get the file sets.
+         *
+         * @return list of file set, never {@code null}
+         */
+        public LinkedList<FileSet> fileSets() {
+            return fileSets;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 5;
+            hash = 31 * hash + Objects.hashCode(this.fileSets);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            if (!super.equals((PathSets) obj)) {
+                return false;
+            }
+            final FileSets other = (FileSets) obj;
+            return Objects.equals(this.fileSets, other.fileSets);
+        }
+    }
+
+    /**
+     * Base class for {@link TemplateSets} and {@link FileSets}.
+     */
+    public abstract static class PathSets {
+
+        private final List<Transformation> transformations;
+
+        protected PathSets(List<Transformation> transformations) {
+            this.transformations = Objects.requireNonNull(transformations, "transformations is null");
+        }
+
+        /**
+         * Get the transformations.
+         *
+         * @return list of transformation, never {@code null}
+         */
+        public List<Transformation> transformations() {
+            return transformations;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 3;
+            hash = 11 * hash + Objects.hashCode(this.transformations);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final PathSets other = (PathSets) obj;
+            return Objects.equals(this.transformations, other.transformations);
+        }
+    }
+
+    /**
+     * A list of included files.
+     */
+    public static final class FileSet extends Conditional {
+
+        private final List<Transformation> transformations;
+        private final LinkedList<String> includes;
+        private final LinkedList<String> excludes;
+        private String directory;
+
+        FileSet(List<Transformation> transformations, List<Property> ifProperties, List<Property> unlessProperties) {
+            super(ifProperties, unlessProperties);
+            this.transformations = Objects.requireNonNull(transformations, "transformations is null");
+            this.includes = new LinkedList<>();
+            this.excludes = new LinkedList<>();
+        }
+
+        /**
+         * Get the directory of this file set.
+         *
+         * @return directory optional, never {@code null}
+         */
+        public Optional<String> directory() {
+            return Optional.ofNullable(directory);
+        }
+
+        /**
+         * Set the directory.
+         * @param directory directory
+         */
+        void directory(String directory) {
+            this.directory = Objects.requireNonNull(directory, "directory is null");
+        }
+
+        /**
+         * Get the exclude filters.
+         *
+         * @return list of exclude filter, never {@code null}
+         */
+        public LinkedList<String> excludes() {
+            return excludes;
+        }
+
+        /**
+         * Get the include filters.
+         *
+         * @return list of include filter, never {@code null}
+         */
+        public LinkedList<String> includes() {
+            return includes;
+        }
+
+        /**
+         * Get the applied transformations.
+         *
+         * @return list of transformation, never {@code null}
+         */
+        public List<Transformation> transformations() {
+            return transformations;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash += super.hashCode();
+            hash = 67 * hash + Objects.hashCode(this.transformations);
+            hash = 67 * hash + Objects.hashCode(this.directory);
+            hash = 67 * hash + Objects.hashCode(this.includes);
+            hash = 67 * hash + Objects.hashCode(this.excludes);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            if (!super.equals((Conditional) obj)) {
+                return false;
+            }
+            final FileSet other = (FileSet) obj;
+            if (!Objects.equals(this.directory, other.directory)) {
+                return false;
+            }
+            if (!Objects.equals(this.transformations, other.transformations)) {
+                return false;
+            }
+            if (!Objects.equals(this.includes, other.includes)) {
+                return false;
+            }
+            return Objects.equals(this.excludes, other.excludes);
+        }
+    }
+
+    /**
+     * User input flow.
+     */
+    public static final class InputFlow {
+
+        private final LinkedList<FlowNode> nodes = new LinkedList<>();
+
+        /**
+         * Get the flow nodes.
+         *
+         * @return list of flow node, never {@code null}
+         */
+        public LinkedList<FlowNode> nodes() {
+            return nodes;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 29 * hash + Objects.hashCode(this.nodes);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final InputFlow other = (InputFlow) obj;
+            return Objects.equals(this.nodes, other.nodes);
+        }
+    }
+
+    /**
+     * Base class for flow nodes.
+     */
+    public abstract static class FlowNode extends Conditional {
+
+        private final String text;
+
+        protected FlowNode(String text, List<Property> ifProperties, List<Property> unlessProperties) {
+            super(ifProperties, unlessProperties);
+            this.text = Objects.requireNonNull(text, "text is null");
+        }
+
+        /**
+         * Get the input text for this select.
+         *
+         * @return input text, never {@code null}
+         */
+        public String text() {
+            return text;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash += super.hashCode();
+            hash = 11 * hash + Objects.hashCode(this.text);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            if (!super.equals((Conditional) obj)) {
+                return false;
+            }
+            final FlowNode other = (FlowNode) obj;
+            return Objects.equals(this.text, other.text);
+        }
+    }
+
+    /**
+     * Select input, one of N choices.
+     */
+    public static final class Select extends FlowNode {
+
+        private final LinkedList<Choice> choices;
+
+        Select(String text, List<Property> ifProperties, List<Property> unlessProperties) {
+            super(text, ifProperties, unlessProperties);
+            this.choices = new LinkedList<>();
+        }
+
+        /**
+         * Get the choices.
+         *
+         * @return list of {@code Choice}, never {@code null}
+         */
+        public LinkedList<Choice> choices() {
+            return choices;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash += super.hashCode();
+            hash = 89 * hash + Objects.hashCode(this.choices);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            if (!super.equals((FlowNode) obj)) {
+                return false;
+            }
+            final Select other = (Select) obj;
+            return Objects.equals(this.choices, other.choices);
+        }
+    }
+
+    /**
+     * A selectable choice.
+     */
+    public static final class Choice extends FlowNode {
+
+        private final Property property;
+
+        Choice(Property property, String text, List<Property> ifProperties, List<Property> unlessProperties) {
+            super(text, ifProperties, unlessProperties);
+            this.property = Objects.requireNonNull(property, "property is null");
+        }
+
+        /**
+         * Get the property mapping for this choice.
+         *
+         * @return property, never {@code null}
+         */
+        public Property property() {
+            return property;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash += super.hashCode();
+            hash = 79 * hash + Objects.hashCode(this.property);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            if (!super.equals((FlowNode) obj)) {
+                return false;
+            }
+            final Choice other = (Choice) obj;
+            return Objects.equals(this.property, other.property);
+        }
+    }
+
+    /**
+     * A user input.
+     */
+    public static final class Input extends FlowNode {
+
+        private final Property property;
+        private final Optional<String> defaultValue;
+
+        Input(Property property, String defaultValue, String text, List<Property> ifProperties,
+                List<Property> unlessProperties) {
+
+            super(text, ifProperties, unlessProperties);
+            this.property = Objects.requireNonNull(property, "property is null");
+            this.defaultValue = Optional.ofNullable(defaultValue);
+        }
+
+        /**
+         * Get the mapped property.
+         *
+         * @return Property, never {@code null}
+         */
+        public Property property() {
+            return property;
+        }
+
+        /**
+         * Get the default value.
+         *
+         * @return default value
+         */
+        public Optional<String> defaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 5;
+            hash += super.hashCode();
+            hash = 17 * hash + Objects.hashCode(this.property);
+            hash = 17 * hash + Objects.hashCode(this.defaultValue);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            if (!super.equals((FlowNode) obj)) {
+                return false;
+            }
+            final Input other = (Input) obj;
+            if (!Objects.equals(this.defaultValue, other.defaultValue)) {
+                return false;
+            }
+            return Objects.equals(this.property, other.property);
+        }
+    }
+}

--- a/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/ArchetypeDescriptorReader.java
+++ b/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/ArchetypeDescriptorReader.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.engine;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Choice;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FileSet;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FileSets;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FlowNode;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Input;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Property;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Replacement;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Select;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.TemplateSets;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Transformation;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * {@link ArchetypeDescriptor} reader.
+ */
+final class ArchetypeDescriptorReader extends DefaultHandler {
+
+    private final ArchetypeDescriptor descriptor;
+    private final LinkedList<String> stack;
+    private final Map<String, Property> propertiesMap;
+    private final Map<String, Transformation> transformationsMap;
+
+    private ArchetypeDescriptorReader() {
+        descriptor =  new ArchetypeDescriptor();
+        stack = new LinkedList<>();
+        propertiesMap = new HashMap<>();
+        transformationsMap = new HashMap<>();
+    }
+
+    /**
+     * Read the descriptor from the given input stream.
+     * @param is input stream
+     * @return descriptor, never {@code null}
+     */
+    static ArchetypeDescriptor read(InputStream is) {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        try {
+            ArchetypeDescriptorReader reader = new ArchetypeDescriptorReader();
+            factory.newSAXParser().parse(is, reader);
+            return reader.descriptor;
+        } catch (IOException | ParserConfigurationException | SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:MethodLength")
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        String parent = stack.peek();
+        if (parent == null) {
+            if (!"archetype-descriptor".equals(qName)) {
+                throw new IllegalStateException("Invalid root element '" + qName + "'");
+            }
+            stack.push("archetype-descriptor");
+        } else {
+            switch (parent) {
+                case "archetype-descriptor":
+                    switch (qName) {
+                        case "properties":
+                            stack.push(qName);
+                            break;
+                        case "transformations":
+                            stack.push(qName);
+                            break;
+                        case "template-sets":
+                            descriptor.templateSets(new TemplateSets(transformationRefs(attributes, qName)));
+                            stack.push(qName);
+                            break;
+                        case "file-sets":
+                            descriptor.fileSets(new FileSets(transformationRefs(attributes, qName)));
+                            stack.push(qName);
+                            break;
+                        case "input-flow":
+                            stack.push(qName);
+                            break;
+                        default:
+                            throw new IllegalStateException("Invalid top-level element: " + qName);
+                    }
+                    break;
+                case "properties":
+                    validateChild("property", parent, qName);
+                    Property prop = new Property(
+                            // TODO validate property id (dot separated alphanumerical)
+                            requiredAttr("id", qName, attributes),
+                            requiredAttr("description", "property", attributes),
+                            attributes.getValue("default"));
+                    descriptor.properties().add(prop);
+                    propertiesMap.put(prop.id(), prop);
+                    stack.push("properties/property");
+                    break;
+                case "transformations":
+                    validateChild("transformation", parent, qName);
+                    Transformation transformation = new Transformation(requiredAttr("id", qName, attributes));
+                    descriptor.transformations().add(transformation);
+                    transformationsMap.put(transformation.id(), transformation);
+                    stack.push("transformations/transformation");
+                    break;
+                case "transformations/transformation":
+                    validateChild("replace", parent, qName);
+                    descriptor.transformations().getLast().replacements().add(new Replacement(
+                            requiredAttr("regex", qName, attributes),
+                            requiredAttr("replacement", qName, attributes)));
+                    stack.push("transformations/transformation/replace");
+                    break;
+                case "template-sets":
+                    validateChild("template-set", parent, qName);
+                    descriptor.templateSets().get().templateSets().add(new FileSet(
+                            transformationRefs(attributes, qName),
+                                    propertyRefs(attributes, "if", qName),
+                                    propertyRefs(attributes, "unless", qName)));
+                    stack.push("template-sets/template-set");
+                    break;
+                case "template-sets/template-set":
+                    switch (qName) {
+                        case "directory":
+                            stack.push("template-sets/template-set/directory");
+                            break;
+                        case "includes":
+                            stack.push("template-sets/template-set/includes");
+                            break;
+                        case "excludes":
+                            stack.push("template-sets/template-set/excludes");
+                            break;
+                        default:
+                            throw new IllegalStateException("Invalid template-set child node: '" + qName + "'");
+                    }
+                    break;
+                case "template-sets/template-set/includes":
+                    stack.push("template-sets/template-set/includes/include");
+                    break;
+                case "template-sets/template-set/excludes":
+                    stack.push("template-sets/template-set/excludes/exclude");
+                    break;
+                case "file-sets":
+                    validateChild("file-set", parent, qName);
+                    descriptor.fileSets().get().fileSets().add(new FileSet(
+                            transformationRefs(attributes, qName),
+                                    propertyRefs(attributes, "if", qName),
+                                    propertyRefs(attributes, "unless", qName)));
+                    stack.push("file-sets/file-set");
+                    break;
+                case "file-sets/file-set":
+                    switch (qName) {
+                        case "directory":
+                            stack.push("file-sets/file-set/directory");
+                            break;
+                        case "includes":
+                            stack.push("file-sets/file-set/includes");
+                            break;
+                        case "excludes":
+                            stack.push("file-sets/file-set/excludes");
+                            break;
+                        default:
+                            throw new IllegalStateException("Invalid file-set child node: '" + qName + "'");
+                    }
+                    break;
+                case "file-sets/file-set/includes":
+                    stack.push("file-sets/file-set/includes/include");
+                    break;
+                case "file-sets/file-set/excludes":
+                    stack.push("file-sets/file-set/excludes/exclude");
+                    break;
+                case "input-flow":
+                    switch (qName) {
+                        case "select":
+                            descriptor.inputFlow().nodes().add(new Select(
+                                    requiredAttr("text", qName, attributes),
+                                    propertyRefs(attributes, "if", qName),
+                                    propertyRefs(attributes, "unless", qName)));
+                            stack.push("input-flow/select");
+                            break;
+                        case "input":
+                            descriptor.inputFlow().nodes().add(new Input(
+                                    propertyRef(requiredAttr("property", qName, attributes), qName),
+                                    attributes.getValue("default"),
+                                    requiredAttr("text", qName, attributes),
+                                    propertyRefs(attributes, "if", qName),
+                                    propertyRefs(attributes, "unless", qName)));
+                            stack.push("input-flow/input");
+                            break;
+                        default:
+                            throw new IllegalStateException("Invalid input flow child node: '" + qName + "'");
+                    }
+                    break;
+                case "input-flow/select":
+                    validateChild("choice", parent, qName);
+                    FlowNode lastFlowNode = descriptor.inputFlow().nodes().getLast();
+                    if (!(lastFlowNode instanceof Select)) {
+                        throw new IllegalStateException("Unable to add 'choice' to flow node");
+                    }
+                    ((Select) lastFlowNode).choices().add(new Choice(
+                            propertyRef(requiredAttr("property", qName, attributes), qName),
+                            requiredAttr("text", qName, attributes),
+                            propertyRefs(attributes, "if", qName),
+                            propertyRefs(attributes, "unless", qName)));
+                    stack.push("input-flow/select/choice");
+                    break;
+                default:
+                    throw new IllegalStateException("Invalid element: " + qName);
+            }
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        stack.pop();
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        String value = new String(ch, start, length);
+        switch (stack.peek()) {
+            case "template-sets/template-set/directory":
+                descriptor.templateSets().get().templateSets().getLast().directory(value);
+                break;
+            case "template-sets/template-set/includes/include":
+                descriptor.templateSets().get().templateSets().getLast().includes().add(value);
+                break;
+            case "template-sets/template-set/excludes/exclude":
+                descriptor.templateSets().get().templateSets().getLast().excludes().add(value);
+                break;
+            case "file-sets/file-set/directory":
+                descriptor.fileSets().get().fileSets().getLast().directory(value);
+                break;
+            case "file-sets/file-set/includes/include":
+                descriptor.fileSets().get().fileSets().getLast().includes().add(value);
+                break;
+            case "file-sets/file-set/excludes/exclude":
+                descriptor.fileSets().get().fileSets().getLast().excludes().add(value);
+                break;
+            default:
+        }
+    }
+
+    private void validateChild(String child, String parent, String qName) {
+        if (!child.equals(qName)) {
+            throw new IllegalStateException("Invalid child for '" + parent + "' node: '" + qName + "'");
+        }
+    }
+
+    private Property propertyRef(String name, String qName) {
+        Property ref = propertiesMap.get(name);
+        if (ref == null) {
+            throw new IllegalStateException("Unknown property reference: '" + name + "' in element: '" + qName + "'");
+        }
+        return ref;
+    }
+
+    private List<Property> propertyRefs(Attributes attr, String attrName, String qName) {
+        String refNames = attr.getValue(attrName);
+        if (refNames == null) {
+            return Collections.emptyList();
+        }
+        List<Property> refs = new LinkedList<>();
+        for (String refName : refNames.split(",")) {
+            refs.add(propertyRef(refName, qName));
+        }
+        return refs;
+    }
+
+    private List<Transformation> transformationRefs(Attributes attr, String qName) {
+        String refNames = attr.getValue("transformations");
+        if (refNames == null) {
+            return Collections.emptyList();
+        }
+        List<Transformation> refs = new LinkedList<>();
+        for (String refName : refNames.split(",")) {
+            Transformation ref = transformationsMap.get(refName);
+            if (ref == null) {
+                throw new IllegalStateException("Unknown transformation reference: '" + refName + "' in element: '"
+                        + qName + "'");
+            }
+            refs.add(ref);
+        }
+        return refs;
+    }
+
+    private static String requiredAttr(String name, String qName, Attributes attr) {
+        String value = attr.getValue(name);
+        if (value == null) {
+            throw new IllegalStateException("Missing required attribute '" + name + "' for element: '" + qName + "'");
+        }
+        return value;
+    }
+}

--- a/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/ArchetypeEngine.java
+++ b/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/ArchetypeEngine.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.engine;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Conditional;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FileSet;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FileSets;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Property;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Replacement;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.TemplateSets;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Transformation;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+
+/**
+ * Archetype engine.
+ */
+public final class ArchetypeEngine {
+
+    /**
+     * Constant for the archetype descriptor path.
+     */
+    public static final String DESCRIPTOR_RESOURCE_NAME = "META-INF/helidon-archetype.xml";
+
+    /**
+     * Constant for the archetype resources manifest path.
+     */
+    public static final String RESOURCES_LIST = "META-INF/helidon-archetype-resources.txt";
+
+    private final MustacheFactory mf;
+    private final ClassLoader cl;
+    private final ArchetypeDescriptor descriptor;
+    private final Map<String, String> properties;
+    private final Map<String, List<Transformation>> templates;
+    private final Map<String, List<Transformation>> files;
+
+    /**
+     * Create a new archetype engine instance.
+     * @param archetype archetype file
+     * @param userProperties user properties
+     * @throws MalformedURLException if an error occurred converting the file to a URL
+     */
+    public ArchetypeEngine(File archetype, Properties userProperties) throws MalformedURLException {
+        this(new URLClassLoader(new URL[] {archetype.toURI().toURL()}), userProperties);
+    }
+
+    /**
+     * Create a new archetype engine instance.
+     * @param cl class loader used to load the archetype
+     * @param userProperties user properties
+     */
+    public ArchetypeEngine(ClassLoader cl, Properties userProperties) {
+        this.cl = Objects.requireNonNull(cl, "class-loader is null");
+        this.mf = new DefaultMustacheFactory();
+        this.descriptor = loadDescriptor(cl);
+        Objects.requireNonNull(userProperties, "userProperties is null");
+        this.properties = descriptor.properties().stream()
+                .filter((p) -> p.defaultValue().isPresent() || userProperties.containsKey(p.id()))
+                .collect(Collectors.toMap(Property::id, (p) -> userProperties.getProperty(p.id(), p.defaultValue().orElse(""))));
+        List<SourcePath> paths = loadResourcesList(cl);
+        this.templates = resolveFileSets(descriptor.templateSets().map(TemplateSets::templateSets).orElseGet(LinkedList::new),
+                descriptor.templateSets().map(TemplateSets::transformations).orElseGet(Collections::emptyList), paths,
+                properties);
+        this.files = resolveFileSets(descriptor.fileSets().map(FileSets::fileSets).orElseGet(LinkedList::new),
+                descriptor.fileSets().map(FileSets::transformations).orElseGet(Collections::emptyList), paths, properties);
+    }
+
+    private static ArchetypeDescriptor loadDescriptor(ClassLoader cl) {
+        InputStream descIs = cl.getResourceAsStream(DESCRIPTOR_RESOURCE_NAME);
+        if (descIs == null) {
+            throw new IllegalStateException(DESCRIPTOR_RESOURCE_NAME + " not found in class-path");
+        }
+        return ArchetypeDescriptor.read(descIs);
+    }
+
+    private static List<SourcePath> loadResourcesList(ClassLoader cl) {
+        InputStream rListIs = cl.getResourceAsStream(RESOURCES_LIST);
+        if (rListIs == null) {
+            throw new IllegalStateException(RESOURCES_LIST + " not found in class-path");
+        }
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(rListIs))) {
+            return br.lines().map(SourcePath::new).collect(Collectors.toList());
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static Map<String, List<Transformation>> resolveFileSets(List<FileSet> fileSets, List<Transformation> transformations,
+            List<SourcePath> paths, Map<String, String> properties) {
+
+        Map<String, List<Transformation>> resolved = new HashMap<>();
+        for (FileSet fileSet : fileSets) {
+            if (evaluateConditional(fileSet, properties)) {
+                List<Transformation> allTransformations = new LinkedList<>(transformations);
+                allTransformations.addAll(fileSet.transformations());
+                for (SourcePath path : SourcePath.filter(paths, fileSet.includes(), fileSet.excludes())) {
+                    String filteredPath = path.asString();
+                    String dir = fileSet.directory().orElse(null);
+                    if (dir == null || dir.isEmpty()) {
+                        continue;
+                    }
+                    String dirPath = new SourcePath(dir).asString();
+                    if (filteredPath.startsWith(dirPath)) {
+                        resolved.put(path.asString(), allTransformations);
+                    }
+                }
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * Transform a string with transformations.
+     * @param input input to be transformed
+     * @param transformations transformed to apply
+     * @param properties properties values
+     * @return transformation result
+     */
+    static String transform(String input, List<Transformation> transformations, Map<String, String> properties) {
+        String output = input;
+        List<Replacement> replacements = transformations.stream()
+                .flatMap((t) -> t.replacements().stream())
+                .collect(Collectors.toList());
+        for (Replacement rep : replacements) {
+            String replacement = resolveProperties(rep.replacement(), properties);
+            output = output.replaceAll(rep.regex(), replacement);
+        }
+        return output;
+    }
+
+    /**
+     * Resolve a property of the form <code>${prop}</code>.
+     * @param input input to be resolved
+     * @param properties properties values
+     * @return resolved property
+     */
+    static String resolveProperties(String input, Map<String, String> properties) {
+        int start = input.indexOf("${");
+        int end = input.indexOf("}");
+        int index = 0;
+        String resolved = null;
+        while (start >= 0 && end > 0) {
+            if (resolved == null) {
+                resolved = input.substring(index, start);
+            } else {
+                resolved += input.substring(index, start);
+            }
+            String propName = input.substring(start + 2, end);
+
+            // search for transformation (name/regexp/replace)
+            int matchStart = 0;
+            do {
+                matchStart = propName.indexOf("/", matchStart + 1);
+            } while (matchStart > 0 && propName.charAt(matchStart - 1) == '\\');
+            int matchEnd = matchStart;
+            do {
+                matchEnd = propName.indexOf("/", matchEnd + 1);
+            } while (matchStart > 0 && propName.charAt(matchStart - 1) == '\\');
+
+            String regexp = null;
+            String replace = null;
+            if (matchStart > 0 && matchEnd > matchStart) {
+                regexp = propName.substring(matchStart + 1, matchEnd);
+                replace = propName.substring(matchEnd + 1);
+                propName = propName.substring(0, matchStart);
+            }
+
+            String propValue = properties.get(propName);
+            if (propValue == null) {
+                propValue = "";
+            } else if (regexp != null && replace != null) {
+                propValue = propValue.replaceAll(regexp, replace);
+            }
+
+            resolved += propValue;
+            index = end + 1;
+            start = input.indexOf("${", index);
+            end = input.indexOf("}", index);
+        }
+        if (resolved != null) {
+            return resolved + input.substring(index);
+        }
+        return input;
+    }
+
+    /**
+     * Resolve a {@link Conditional} object.
+     * @param conditional object to resolve
+     * @param props properties used to resolve the value of the declared properties
+     * @return evaluation results
+     */
+    static boolean evaluateConditional(Conditional conditional, Map<String, String> props) {
+        List<Property> ifProps = conditional.ifProperties();
+        if (ifProps == null) {
+            ifProps = Collections.emptyList();
+        }
+        for (Property prop : ifProps) {
+            if (!Boolean.valueOf(props.get(prop.id()))) {
+                return false;
+            }
+        }
+        List<Property> unlessProps = conditional.unlessProperties();
+        if (unlessProps == null) {
+            unlessProps = Collections.emptyList();
+        }
+        for (Property prop : unlessProps) {
+            if (Boolean.valueOf(props.get(prop.id()))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Run the archetype.
+     * @param outputDirectory output directory
+     */
+    public void generate(File outputDirectory) {
+        for (Entry<String, List<Transformation>> entry : templates.entrySet()) {
+            String resourcePath = entry.getKey().substring(1);
+            InputStream is = cl.getResourceAsStream(resourcePath);
+            if (is == null) {
+                throw new IllegalStateException(resourcePath + " not found in class-path");
+            }
+            Mustache m = mf.compile(new InputStreamReader(is), resourcePath);
+            File outputFile = new File(outputDirectory, transform(resourcePath, entry.getValue(), properties));
+            outputFile.getParentFile().mkdirs();
+            try (FileWriter writer = new FileWriter(outputFile)) {
+                m.execute(writer, properties).flush();
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        for (Entry<String, List<Transformation>> entry : files.entrySet()) {
+            String resourcePath = entry.getKey().substring(1);
+            InputStream is = cl.getResourceAsStream(resourcePath);
+            if (is == null) {
+                throw new IllegalStateException(resourcePath + " not found in class-path");
+            }
+            File outputFile = new File(outputDirectory, transform(resourcePath, entry.getValue(), properties));
+            outputFile.getParentFile().mkdirs();
+            try {
+                Files.copy(is, outputFile.toPath());
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}

--- a/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/Main.java
+++ b/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/Main.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.engine;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Helidon archetype engine main class.
+ */
+public final class Main {
+
+    private Main() {
+    }
+
+    /**
+     * Helidon archetype engine main method.
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+        if (args.length != 2) {
+            System.err.println("Usage: template-jar directory");
+            System.exit(1);
+        }
+        File templateJar = new File(args[0]);
+        if (!templateJar.exists()) {
+            System.err.println(templateJar + " does not exist");
+            System.exit(1);
+        }
+
+        URLClassLoader cl;
+        try {
+            cl = new URLClassLoader(new URL[] {templateJar.toURI().toURL()}, null);
+        } catch (MalformedURLException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        File outputDir = new File(args[1]);
+        if (outputDir.exists()) {
+            System.err.println(templateJar + " exists");
+            System.exit(1);
+        }
+        new ArchetypeEngine(cl, System.getProperties()).generate(outputDir);
+    }
+}

--- a/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/SourcePath.java
+++ b/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/SourcePath.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.archetype.engine;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Utility class to parse and match path segments.
+ */
+public class SourcePath {
+
+    private static final char WILDCARD = '*';
+    private static final String DOUBLE_WILDCARD = "**";
+    private final String[] segments;
+
+    /**
+     * Create a new {@link SourcePath} instance for a file in a given directory.
+     * The path represented will be the relative path of the file in the directory
+     * @param dir the directory containing the file
+     * @param file the filed contained in the directory
+     */
+    public SourcePath(File dir, File file){
+        segments = parseSegments(getRelativePath(dir, file));
+    }
+
+    /**
+     * Create a new {@link SourcePath} instance for the given path.
+     * @param path the path to use as {@code String}
+     */
+    public SourcePath(String path) {
+        segments = parseSegments(path);
+    }
+
+    private static String getRelativePath(File sourcedir, File source) {
+        return sourcedir.toPath().relativize(source.toPath()).toString()
+                // force UNIX style path on windows
+                .replace("\\", "/");
+    }
+
+    private static String[] parseSegments(String path) throws IllegalArgumentException {
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("path is null or empty");
+        }
+        String[] tokens = path.split("/");
+        if (tokens.length == 0) {
+            throw new IllegalArgumentException("invalid path: " + path);
+        }
+        List<String> segments = new LinkedList<>();
+        for (int i = 0; i < tokens.length; i++) {
+            String token = tokens[i];
+            if ((i < tokens.length - 1 && token.isEmpty())
+                    || token.equals(".")) {
+                continue;
+            }
+            segments.add(token);
+        }
+        return segments.toArray(new String[segments.size()]);
+    }
+
+
+    /**
+     * Filter the given {@code Collection} of {@link SourcePath} with the given filter.
+     * @param paths the paths to filter
+     * @param includesPatterns a {@code Collection} of {@code String} as include patterns
+     * @param excludesPatterns a {@code Collection} of {@code String} as exclude patterns
+     * @return the filtered {@code Collection} of pages
+     */
+    public static List<SourcePath> filter(Collection<SourcePath> paths,
+                                          Collection<String> includesPatterns,
+                                          Collection<String> excludesPatterns){
+
+        if (paths == null || paths.isEmpty()
+                || includesPatterns == null || includesPatterns.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        if (excludesPatterns == null) {
+            excludesPatterns = Collections.emptyList();
+        }
+
+        List<SourcePath> included = new LinkedList<>();
+        for (String includesPattern : includesPatterns) {
+            for (SourcePath path : paths) {
+                if (path.matches(includesPattern)) {
+                    included.add(path);
+                }
+            }
+        }
+
+        List<SourcePath> matchedRoutes = new LinkedList<>();
+        for (SourcePath path : included) {
+            boolean matched = false;
+            for (String excludesPattern : excludesPatterns) {
+                if (path.matches(excludesPattern)) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                matchedRoutes.add(path);
+            }
+        }
+        return matchedRoutes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final SourcePath other = (SourcePath) obj;
+        for (int i = 0; i < this.segments.length; i++) {
+            if (!this.segments[i].equals(other.segments[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 59 * hash + Objects.hashCode(this.segments);
+        return hash;
+    }
+
+    private static boolean doRecursiveMatch(String[] segments,
+                                            int offset,
+                                            String[] patterns,
+                                            int pOffset){
+
+        boolean expand = false;
+        // for each segment pattern
+        for (; pOffset < patterns.length; pOffset++) {
+            // no segment to match
+            if (offset == segments.length) {
+                break;
+            }
+            String pattern = patterns[pOffset];
+            if (pattern.equals(DOUBLE_WILDCARD)) {
+                expand = true;
+            } else {
+                if (expand) {
+                    for (int j = 0; j < segments.length; j++) {
+                        if (wildcardMatch(segments[j], pattern)) {
+                            if (doRecursiveMatch(segments, j + 1, patterns, pOffset + 1)) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                } else if (!wildcardMatch(segments[offset], pattern)) {
+                    return false;
+                }
+                offset++;
+            }
+        }
+
+        // unprocessed patterns can only be double wildcard
+        for (; pOffset < patterns.length; pOffset++) {
+            String pattern = patterns[pOffset];
+            if (!pattern.equals(DOUBLE_WILDCARD)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Tests if the given pattern matches this {@link SourcePath}.
+     * @param pattern the pattern to match
+     * @return {@code true} if this {@link SourcePath} matches the pattern, {@code false} otherwise
+     */
+    public boolean matches(String pattern) {
+        if (pattern == null) {
+            return false;
+        }
+        if (pattern.isEmpty()) {
+            return segments.length == 0;
+        }
+        return doRecursiveMatch(segments, 0, parseSegments(pattern), 0);
+    }
+
+    /**
+     * Matches the given value with a pattern that may contain wildcard(s)
+     * character that can filter any sub-sequence in the value.
+     *
+     * @param val the string to filter
+     * @param pattern the pattern to use for matching
+     * @return returns {@code true} if pattern matches, {@code false} otherwise
+     */
+    public static boolean wildcardMatch(String val, String pattern) {
+
+        Objects.requireNonNull(val);
+        Objects.requireNonNull(pattern);
+
+        if (pattern.isEmpty()) {
+            // special case for empty pattern
+            // matches if val is also empty
+            return val.isEmpty();
+        }
+
+        int valIdx = 0;
+        int patternIdx = 0;
+        boolean matched = true;
+        while (matched) {
+            int wildcardIdx = pattern.indexOf(WILDCARD, patternIdx);
+            if (wildcardIdx >= 0) {
+                // pattern has unprocessed wildcard(s)
+                int patternOffset = wildcardIdx - patternIdx;
+                if (patternOffset > 0) {
+                    // filter the sub pattern before the wildcard
+                    String subPattern = pattern.substring(patternIdx, wildcardIdx);
+                    int idx = val.indexOf(subPattern, valIdx);
+                    if (patternIdx > 0 && pattern.charAt(patternIdx - 1) == WILDCARD) {
+                        // if expanding a wildcard
+                        // the sub-segment needs to contain the sub-pattern
+                        if (idx < valIdx) {
+                            matched = false;
+                            break;
+                        }
+                    } else if (idx != valIdx) {
+                        // not expanding a wildcard
+                        // the sub-segment needs to start with the sub-pattern
+                        matched = false;
+                        break;
+                    }
+                    valIdx = idx + subPattern.length();
+                }
+                patternIdx = wildcardIdx + 1;
+            } else {
+                String subPattern = pattern.substring(patternIdx);
+                String subSegment = val.substring(valIdx);
+                if (patternIdx > 0 && pattern.charAt(patternIdx - 1) == WILDCARD) {
+                    // if expanding a wildcard
+                    // sub-segment needs to end with sub-pattern
+                    if (!subSegment.endsWith(subPattern)) {
+                        matched = false;
+                    }
+                } else if (!subSegment.equals(subPattern)) {
+                    // not expanding a wildcard
+                    // the sub-segment needs to stricly filter the sub-pattern
+                    matched = false;
+                }
+                break;
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * Convert this {@link SourcePath} into a {@code String}.
+     * @return the {@code String} representation of this {@link SourcePath}
+     */
+    public String asString() {
+        StringBuilder sb = new StringBuilder("/");
+        for (int i = 0; i < segments.length; i++) {
+            sb.append(segments[i]);
+            if (i < segments.length - 1) {
+                sb.append("/");
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return SourcePath.class.getSimpleName() + "{ " + asString() + " }";
+    }
+
+    private static class SourceFileComparator implements Comparator<SourcePath> {
+
+        @Override
+        public int compare(SourcePath o1, SourcePath o2) {
+            for (int i = 0; i < o1.segments.length; i++) {
+                int cmp = o1.segments[i].compareTo(o2.segments[i]);
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+            return 0;
+        }
+    }
+
+    private static final Comparator<SourcePath> COMPARATOR = new SourceFileComparator();
+
+    /**
+     * Sort the given {@code List} of {@link SourcePath} with natural ordering.
+     * @param sourcePaths the {@code List} of {@link SourcePath} to sort
+     * @return the sorted {@code List}
+     */
+    public static List<SourcePath> sort(List<SourcePath> sourcePaths){
+        Objects.requireNonNull(sourcePaths, "sourcePaths");
+        sourcePaths.sort(COMPARATOR);
+        return sourcePaths;
+    }
+
+    /**
+     * Scan all files recursively as {@link SourcePath} instance in the given directory.
+     * @param dir the directory to scan
+     * @return the {@code List} of scanned {@link SourcePath}
+     */
+    public static List<SourcePath> scan(File dir) {
+        return doScan(dir, dir);
+    }
+
+    private static List<SourcePath> doScan(File root, File dir) {
+        List<SourcePath> sourcePaths = new ArrayList<>();
+        DirectoryStream<Path> dirStream = null;
+        try {
+            dirStream = Files.newDirectoryStream(dir.toPath());
+            Iterator<Path> it = dirStream.iterator();
+            while (it.hasNext()) {
+                Path next = it.next();
+                if (Files.isDirectory(next)) {
+                    sourcePaths.addAll(doScan(root, next.toFile()));
+                } else {
+                    sourcePaths.add(new SourcePath(root, next.toFile()));
+                }
+            }
+        } catch (IOException ex) {
+            if (dirStream != null) {
+                try {
+                    dirStream.close();
+                } catch (IOException e) { }
+            }
+        }
+        return sort(sourcePaths);
+    }
+}

--- a/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/package-info.java
+++ b/helidon-archetype/engine/src/main/java/io/helidon/build/archetype/engine/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon archetype engine.
+ */
+package io.helidon.build.archetype.engine;

--- a/helidon-archetype/engine/src/test/java/io/helidon/build/archetype/engine/ArchetypeDescriptorTest.java
+++ b/helidon-archetype/engine/src/test/java/io/helidon/build/archetype/engine/ArchetypeDescriptorTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.engine;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Choice;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FileSet;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FileSets;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FlowNode;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Input;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.InputFlow;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Replacement;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Transformation;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Property;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Select;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.TemplateSets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.empty;
+
+/**
+ * Tests {@link ArchetypeDescriptor}.
+ */
+public class ArchetypeDescriptorTest {
+
+    @Test
+    public void testUnmarshall() {
+        InputStream is = ArchetypeDescriptorTest.class.getClassLoader()
+                .getResourceAsStream(ArchetypeEngine.DESCRIPTOR_RESOURCE_NAME);
+        assertThat(is, is(notNullValue()));
+
+        ArchetypeDescriptor desc = ArchetypeDescriptor.read(is);
+        Map<String, Property> properties = desc.properties().stream().collect(Collectors.toMap(Property::id, (p) -> p));
+        assertThat(properties.entrySet(), is(not(empty())));
+        assertThat(properties.size(), is(7));
+        assertThat(properties.keySet(), hasItems("gradle", "maven", "groupId", "artifactId", "version", "name", "package"));
+        assertThat(properties.values().stream().map(Property::description).collect(Collectors.toList()),
+                hasItems("Gradle based project", "Maven based project", "Project groupId", "Project artifactId", "Project version"
+                , "Project name", "Java package name"));
+        assertThat(properties.get("version").defaultValue().get(), is("1.0-SNAPSHOT"));
+
+        Map<String, Transformation> transformations = desc.transformations().stream()
+                .collect(Collectors.toMap(Transformation::id, (o) -> o));
+        assertThat(transformations.size(), is(2));
+        assertThat(transformations.keySet(), hasItems("packaged", "mustache"));
+        List<Replacement> packaged = transformations.get("packaged").replacements();
+        assertThat(packaged, is(not(empty())));
+        assertThat(packaged.stream().map(Replacement::regex).collect(Collectors.toList()), hasItems("__pkg__"));
+        assertThat(packaged.stream().map(Replacement::replacement).collect(Collectors.toList()),
+                hasItems("${package/\\./\\/}"));
+        List<Replacement> mustache = transformations.get("mustache").replacements();
+        assertThat(mustache, is(not(empty())));
+        assertThat(mustache.stream().map(Replacement::regex).collect(Collectors.toList()), hasItems("\\.mustache$"));
+        assertThat(mustache.stream().map(Replacement::replacement).collect(Collectors.toList()), hasItems(""));
+
+        assertThat(desc.templateSets().isPresent(), is(true));
+        TemplateSets templateSets = desc.templateSets().get();
+        assertThat(templateSets.transformations().stream().map(Transformation::id).collect(Collectors.toList()),
+                hasItems("mustache"));
+        assertThat(templateSets.templateSets().size(), is(4));
+
+        FileSet ts1 = templateSets.templateSets().get(0);
+        assertThat(ts1.transformations().stream().map(Transformation::id).collect(Collectors.toList()),
+                hasItems("packaged"));
+        assertThat(ts1.directory().get(), is("src/main/java"));
+        assertThat(ts1.includes(), hasItems("**/*.mustache"));
+        assertThat(ts1.excludes(), is(empty()));
+        assertThat(ts1.ifProperties(), is(empty()));
+        assertThat(ts1.unlessProperties(), is(empty()));
+
+        FileSet ts2 = templateSets.templateSets().get(1);
+        assertThat(ts2.transformations().stream().map(Transformation::id).collect(Collectors.toList()),
+                hasItems("packaged"));
+        assertThat(ts2.directory().get(), is("src/test/java"));
+        assertThat(ts2.includes(), hasItems("**/*.mustache"));
+        assertThat(ts2.excludes(), is(empty()));
+        assertThat(ts2.ifProperties(), is(empty()));
+        assertThat(ts2.unlessProperties(), is(empty()));
+
+        FileSet ts3 = templateSets.templateSets().get(2);
+        assertThat(ts3.ifProperties().stream().map(Property::id).collect(Collectors.toList()), hasItems("gradle"));
+        assertThat(ts3.unlessProperties(), is(empty()));
+        assertThat(ts3.transformations(), is(empty()));
+        assertThat(ts3.directory().get(), is("."));
+        assertThat(ts3.includes(), hasItems("build.gradle.mustache"));
+        assertThat(ts3.excludes(), is(empty()));
+
+        FileSet ts4 = templateSets.templateSets().get(3);
+        assertThat(ts4.ifProperties().stream().map(Property::id).collect(Collectors.toList()), hasItems("maven"));
+        assertThat(ts4.unlessProperties(), is(empty()));
+        assertThat(ts4.transformations(), is(empty()));
+        assertThat(ts4.directory().get(), is("."));
+        assertThat(ts4.includes(), hasItems("pom.xml.mustache"));
+        assertThat(ts4.excludes(), is(empty()));
+
+        assertThat(desc.fileSets().isPresent(), is(true));
+        FileSets fileSets = desc.fileSets().get();
+        assertThat(fileSets.transformations(), is(empty()));
+        assertThat(fileSets.fileSets().size(), is(4));
+        FileSet fs1 = fileSets.fileSets().get(0);
+        assertThat(fs1.transformations().stream().map(Transformation::id).collect(Collectors.toList()),
+                hasItems("packaged"));
+        assertThat(fs1.directory().get(), is("src/main/java"));
+        assertThat(fs1.includes(), is(empty()));
+        assertThat(fs1.excludes(), hasItems("**/*.mustache"));
+        assertThat(fs1.ifProperties(), is(empty()));
+        assertThat(fs1.unlessProperties(), is(empty()));
+
+        FileSet fs2 = fileSets.fileSets().get(1);
+        assertThat(fs2.transformations(), is(empty()));
+        assertThat(fs2.directory().get(), is("src/main/resources"));
+        assertThat(fs2.excludes(), is(empty()));
+        assertThat(fs2.includes(), hasItems("**/*"));
+        assertThat(fs2.ifProperties(), is(empty()));
+        assertThat(fs2.unlessProperties(), is(empty()));
+
+        FileSet fs3 = fileSets.fileSets().get(2);
+        assertThat(fs3.transformations().stream().map(Transformation::id).collect(Collectors.toList()),
+                hasItems("packaged"));
+        assertThat(fs3.directory().get(), is("src/test/java"));
+        assertThat(fs3.includes(), is(empty()));
+        assertThat(fs3.excludes(), hasItems("**/*.mustache"));
+        assertThat(fs3.ifProperties(), is(empty()));
+        assertThat(fs3.unlessProperties(), is(empty()));
+
+        FileSet fs4 = fileSets.fileSets().get(3);
+        assertThat(fs4.transformations(), is(empty()));
+        assertThat(fs4.directory().get(), is("src/test/resources"));
+        assertThat(fs4.includes(), is(empty()));
+        assertThat(fs4.excludes(), hasItems("**/*"));
+        assertThat(fs4.ifProperties(), is(empty()));
+        assertThat(fs4.unlessProperties(), is(empty()));
+
+        InputFlow inputFlow = desc.inputFlow();
+        assertThat(inputFlow.nodes().size(), is(6));
+        FlowNode fn1 = inputFlow.nodes().get(0);
+        assertThat(fn1, is(instanceOf(Select.class)));
+        assertThat(((Select) fn1).text(), is("Select a build system"));
+        assertThat(((Select) fn1).choices().size(), is(2));
+        assertThat(fn1.ifProperties(), is(empty()));
+        assertThat(fn1.unlessProperties(), is(empty()));
+
+        Choice c1 = ((Select) fn1).choices().get(0);
+        assertThat(c1.property().id(), is("maven"));
+        assertThat(c1.text(), is("Maven"));
+        assertThat(c1.ifProperties(), is(empty()));
+        assertThat(c1.unlessProperties(), is(empty()));
+
+        Choice c2 = ((Select) fn1).choices().get(1);
+        assertThat(c2.property().id(), is("gradle"));
+        assertThat(c2.text(), is("Gradle"));
+        assertThat(c2.ifProperties(), is(empty()));
+        assertThat(c2.unlessProperties(), is(empty()));
+
+        FlowNode fn2 = inputFlow.nodes().get(1);
+        assertThat(fn2, is(instanceOf(Input.class)));
+        assertThat(((Input) fn2).property().id(), is("groupId"));
+        assertThat(((Input) fn2).text(), is("Enter a project groupId"));
+        assertThat(((Input) fn2).defaultValue().isPresent(), is(false));
+        assertThat(fn2.ifProperties().stream().map(Property::id).collect(Collectors.toList()), hasItems("maven"));
+        assertThat(fn2.unlessProperties(), is(empty()));
+
+        FlowNode fn3 = inputFlow.nodes().get(2);
+        assertThat(fn3, is(instanceOf(Input.class)));
+        assertThat(((Input) fn3).property().id(), is("artifactId"));
+        assertThat(((Input) fn3).text(), is("Enter a project artifactId"));
+        assertThat(((Input) fn3).defaultValue().isPresent(), is(false));
+        assertThat(fn3.ifProperties(), is(empty()));
+        assertThat(fn3.unlessProperties(), is(empty()));
+
+        FlowNode fn4 = inputFlow.nodes().get(3);
+        assertThat(fn4, is(instanceOf(Input.class)));
+        assertThat(((Input) fn4).property().id(), is("version"));
+        assertThat(((Input) fn4).text(), is("Enter a project version"));
+        assertThat(((Input) fn4).defaultValue().isPresent(), is(false));
+        assertThat(fn4.ifProperties(), is(empty()));
+        assertThat(fn4.unlessProperties(), is(empty()));
+
+        FlowNode fn5 = inputFlow.nodes().get(4);
+        assertThat(fn5, is(instanceOf(Input.class)));
+        assertThat(((Input) fn5).property().id(), is("name"));
+        assertThat(((Input) fn5).text(), is("Enter a project name"));
+        assertThat(((Input) fn5).defaultValue().get(), is("${artifactId}"));
+        assertThat(fn5.ifProperties(), is(empty()));
+        assertThat(fn5.unlessProperties(), is(empty()));
+
+        FlowNode fn6 = inputFlow.nodes().get(5);
+        assertThat(fn6, is(instanceOf(Input.class)));
+        assertThat(((Input) fn6).property().id(), is("package"));
+        assertThat(((Input) fn6).text(), is("Enter a Java package name"));
+        assertThat(((Input) fn6).defaultValue().get(), is("${groupId}"));
+        assertThat(fn5.ifProperties(), is(empty()));
+        assertThat(fn5.unlessProperties(), is(empty()));
+    }
+}

--- a/helidon-archetype/engine/src/test/java/io/helidon/build/archetype/engine/ArchetypeEngineTest.java
+++ b/helidon-archetype/engine/src/test/java/io/helidon/build/archetype/engine/ArchetypeEngineTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.engine;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.FileSet;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Property;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Replacement;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Transformation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test {@link ArchetypeEngine}.
+ */
+public class ArchetypeEngineTest {
+
+    @Test
+    public void testResolveProperties() {
+        Map<String, String> props = Map.of("foo", "bar", "bar", "foo");
+        assertThat(ArchetypeEngine.resolveProperties("${foo}", props), is("bar"));
+        assertThat(ArchetypeEngine.resolveProperties("${xxx}", props), is(""));
+        assertThat(ArchetypeEngine.resolveProperties("-${foo}-", props), is("-bar-"));
+        assertThat(ArchetypeEngine.resolveProperties("$${foo}}", props), is("$bar}"));
+        assertThat(ArchetypeEngine.resolveProperties("${foo}-${bar}", props), is("bar-foo"));
+        assertThat(ArchetypeEngine.resolveProperties("foo", props), is("foo"));
+        assertThat(ArchetypeEngine.resolveProperties("$foo", props), is("$foo"));
+        assertThat(ArchetypeEngine.resolveProperties("${foo", props), is("${foo"));
+        assertThat(ArchetypeEngine.resolveProperties("${ foo}", props), is(""));
+        assertThat(ArchetypeEngine.resolveProperties("${foo }", props), is(""));
+    }
+
+    @Test
+    public void testTransformedProperties() {
+        Map<String, String> props = Map.of("package", "com.example.myapp");
+        assertThat(ArchetypeEngine.resolveProperties("${package/\\./\\/}", props), is("com/example/myapp"));
+    }
+
+    @Test
+    public void testTransform() {
+        LinkedList<Transformation> transformations = new LinkedList<>();
+        Transformation t1 = new Transformation("mustache");
+        t1.replacements().add(new Replacement("\\.mustache$", ""));
+        transformations.add(t1);
+        Transformation t2 = new Transformation("packaged");
+        t2.replacements().add(new Replacement("__pkg__", "${package/\\./\\/}"));
+        transformations.add(t2);
+        assertThat(ArchetypeEngine.transform("src/main/java/__pkg__/Main.java.mustache", transformations,
+                Map.of("package", "com.example.myapp")),
+                is("src/main/java/com/example/myapp/Main.java"));
+    }
+
+    @Test
+    public void testEvaluateConditional() {
+        Map<String, String> props1 = Map.of("prop1", "true");
+        Map<String, String> props2 = Map.of("prop1", "true", "prop2", "true");
+
+        Property prop1 = new Property("prop1", "Prop 1", null);
+        FileSet fset1 = new FileSet(List.of(), List.of(prop1), List.of());
+        assertThat(ArchetypeEngine.evaluateConditional(fset1, props1), is(true));
+        assertThat(ArchetypeEngine.evaluateConditional(fset1, Collections.emptyMap()), is(false));
+
+        FileSet fset2 = new FileSet(List.of(), List.of(), List.of(prop1));
+        assertThat(ArchetypeEngine.evaluateConditional(fset2, props1), is(false));
+        assertThat(ArchetypeEngine.evaluateConditional(fset2, Collections.emptyMap()), is(true));
+
+        Property prop2 = new Property("prop2", "Prop 2", null);
+        FileSet fset3 = new FileSet(List.of(), List.of(prop1, prop2), List.of());
+        assertThat(ArchetypeEngine.evaluateConditional(fset3, props2), is(true));
+        assertThat(ArchetypeEngine.evaluateConditional(fset3, props1), is(false));
+        assertThat(ArchetypeEngine.evaluateConditional(fset3, Collections.emptyMap()), is(false));
+
+        FileSet fset4 = new FileSet(List.of(), List.of(prop1), List.of(prop2));
+        assertThat(ArchetypeEngine.evaluateConditional(fset4, props2), is(false));
+        assertThat(ArchetypeEngine.evaluateConditional(fset4, Collections.emptyMap()), is(false));
+    }
+
+    @Test
+    public void testGenerate() throws IOException {
+        Properties props = new Properties();
+        props.put("groupId", "com.example");
+        props.put("artifactId", "my-project");
+        props.put("version", "1.0-SNAPSHOT");
+        props.put("name", "my super project");
+        props.put("package", "com.example.myproject");
+        props.put("maven", "true");
+        File targetDir = new File(new File("").getAbsolutePath(), "target");
+        File outputDir = new File(targetDir, "test-project");
+        Path outputDirPath = outputDir.toPath();
+        if (Files.exists(outputDirPath)) {
+            Files.walk(outputDirPath)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+        assertThat(Files.exists(outputDirPath), is(false));
+        new ArchetypeEngine(ArchetypeEngineTest.class.getClassLoader(), props).generate(outputDir);
+        assertThat(Files.exists(outputDirPath), is(true));
+        assertThat(Files.walk(outputDirPath)
+                .filter(p -> !Files.isDirectory(p))
+                .map((p) -> outputDirPath.relativize(p).toString())
+                .collect(Collectors.toList()),
+                is(List.of("pom.xml", "src/main/java/com/example/myproject/Main.java")));
+
+        InputStream is = ArchetypeEngineTest.class.getClassLoader().getResourceAsStream("META-INF/test.properties");
+        assertThat(is, is(not(nullValue())));
+        Properties testProps = new Properties();
+        testProps.load(is);
+
+        String pomBase64 = testProps.getProperty("pom.xml");
+        assertThat(pomBase64, is(not(nullValue())));
+        assertThat(new String(Files.readAllBytes(outputDirPath.resolve("pom.xml")), StandardCharsets.UTF_8),
+                is (new String(Base64.getDecoder().decode(pomBase64), StandardCharsets.UTF_8)));
+
+        String mainBase64 = testProps.getProperty("main.java");
+        assertThat(mainBase64, is(not(nullValue())));
+        assertThat(new String(Files.readAllBytes(outputDirPath.resolve("src/main/java/com/example/myproject/Main.java")),
+                StandardCharsets.UTF_8),
+                is (new String(Base64.getDecoder().decode(mainBase64), StandardCharsets.UTF_8)));
+    }
+}

--- a/helidon-archetype/engine/src/test/resources/META-INF/helidon-archetype-resources.txt
+++ b/helidon-archetype/engine/src/test/resources/META-INF/helidon-archetype-resources.txt
@@ -1,0 +1,2 @@
+pom.xml.mustache
+src/main/java/__pkg__/Main.java.mustache

--- a/helidon-archetype/engine/src/test/resources/META-INF/helidon-archetype.xml
+++ b/helidon-archetype/engine/src/test/resources/META-INF/helidon-archetype.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-descriptor>
+    <properties>
+        <!-- TODO validation -->
+        <property id="gradle" description="Gradle based project" />
+        <property id="maven" description="Maven based project" />
+        <property id="groupId" description="Project groupId" />
+        <property id="artifactId" description="Project artifactId" />
+        <property id="version" description="Project version" default="1.0-SNAPSHOT" />
+        <property id="name" description="Project name" />
+        <property id="package" description="Java package name" />
+    </properties>
+    <transformations>
+        <transformation id="packaged">
+            <replace regex="__pkg__" replacement="${package/\./\/}" />
+        </transformation>
+        <transformation id="mustache">
+            <replace regex="\.mustache$" replacement="" />
+        </transformation>
+    </transformations>
+    <template-sets transformations="mustache">
+        <template-set transformations="packaged">
+            <directory>src/main/java</directory>
+            <includes>
+                <include>**/*.mustache</include>
+            </includes>
+        </template-set>
+        <template-set transformations="packaged">
+            <directory>src/test/java</directory>
+            <includes>
+                <include>**/*.mustache</include>
+            </includes>
+        </template-set>
+        <template-set if="gradle">
+            <directory>.</directory>
+            <includes>
+                <include>build.gradle.mustache</include>
+            </includes>
+        </template-set>
+        <template-set if="maven">
+            <directory>.</directory>
+            <includes>
+                <include>pom.xml.mustache</include>
+            </includes>
+        </template-set>
+    </template-sets>
+    <file-sets>
+        <file-set transformations="packaged">
+            <directory>src/main/java</directory>
+            <excludes>
+                <exclude>**/*.mustache</exclude>
+            </excludes>
+        </file-set>
+        <file-set>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </file-set>
+        <file-set transformations="packaged">
+            <directory>src/test/java</directory>
+            <excludes>
+                <exclude>**/*.mustache</exclude>
+            </excludes>
+        </file-set>
+        <file-set>
+            <directory>src/test/resources</directory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </file-set>
+    </file-sets>
+    <input-flow>
+        <select text="Select a build system">
+            <choice property="maven" text="Maven" />
+            <choice property="gradle" text="Gradle" />
+        </select>
+        <!-- TODO input value transformation -->
+        <!-- TODO choice node at the top for yes/no properties -->
+        <input property="groupId" text="Enter a project groupId" if="maven"/>
+        <input property="artifactId" text="Enter a project artifactId" />
+        <input property="version" text="Enter a project version" />
+        <input property="name" text="Enter a project name" default="${artifactId}" />
+        <input property="package" text="Enter a Java package name" default="${groupId}" />
+    </input-flow>
+</archetype-descriptor>

--- a/helidon-archetype/engine/src/test/resources/META-INF/test.properties
+++ b/helidon-archetype/engine/src/test/resources/META-INF/test.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+pom.xml=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2plY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIKICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21hdmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9kZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CiAgICA8Z3JvdXBJZD5jb20uZXhhbXBsZTwvZ3JvdXBJZD4KICAgIDxhcnRpZmFjdElkPm15LXByb2plY3Q8L2FydGlmYWN0SWQ+CiAgICA8dmVyc2lvbj4xLjAtU05BUFNIT1Q8L3ZlcnNpb24+CiAgICA8bmFtZT5teSBzdXBlciBwcm9qZWN0PC9uYW1lPgo8L3Byb2plY3Q+Cg==
+main.java=cGFja2FnZSBjb20uZXhhbXBsZS5teXByb2plY3Q7CgpwdWJsaWMgZmluYWwgY2xhc3MgTWFpbiB7CiAgICBwdWJsaWMgc3RhdGljIHZvaWQgbWFpbihTdHJpbmdbXSBhcmdzKSB7CiAgICAgICAgU3lzdGVtLm91dC5wcmludGxuKCJIZWxsbyBXb3JsZCIpOwogICAgfQp9

--- a/helidon-archetype/engine/src/test/resources/io/helidon/build/archetype/engine/helidon-archetype.xml
+++ b/helidon-archetype/engine/src/test/resources/io/helidon/build/archetype/engine/helidon-archetype.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-descriptor name="test">
+    <properties>
+        <property id="gradle" description="Gradle based project" />
+        <property id="maven" description="Maven based project" />
+        <property id="groupId" description="Project groupId" />
+        <property id="artifactId" description="Project artifactId" />
+        <property id="version" description="Project version" />
+        <property id="name" description="Project name" />
+        <property id="package" description="Java package name" />
+    </properties>
+    <path-transformations>
+        <path-transformation id="packaged">
+            <replace regex="__pkg__" replacement="${package}" />
+            <replace regex="\\." replacement="\\/" />
+        </path-transformation>
+        <path-transformation id="mustache">
+            <replace regex="\.mustache$" replacement="" />
+        </path-transformation>
+    </path-transformations>
+    <template-sets transformations="mustache">
+        <template-set transformations="packaged">
+            <directory>src/main/java</directory>
+            <includes>
+                <include>**/*.mustache</include>
+            </includes>
+        </template-set>
+        <template-set transformations="packaged">
+            <directory>src/test/java</directory>
+            <includes>
+                <include>**/*.mustache</include>
+            </includes>
+        </template-set>
+        <template-set if="gradle">
+            <directory>.</directory>
+            <includes>
+                <include>build.gradle.mustache</include>
+            </includes>
+        </template-set>
+    </template-sets>
+    <file-sets>
+        <file-set transformations="packaged">
+            <directory>src/main/java</directory>
+            <excludes>
+                <exclude>**/*.mustache</exclude>
+            </excludes>
+        </file-set>
+        <file-set>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </file-set>
+        <file-set transformations="packaged">
+            <directory>src/test/java</directory>
+            <excludes>
+                <exclude>**/*.mustache</exclude>
+            </excludes>
+        </file-set>
+        <file-set>
+            <directory>src/test/resources</directory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </file-set>
+    </file-sets>
+    <input-flow>
+        <select id="build" text="Select a build system">
+            <choice property="maven" text="Maven" />
+            <choice property="gradle" text="Gradle" />
+        </select>
+        <input id="groupId" property="groupId" text="Enter a project groupId" if="maven"/>
+        <input id="artifactId" property="artifactId" text="Enter a project artifactId" />
+        <input id="version" property="version" text="Enter a project version" default="1.0-SNAPSHOT" />
+        <input id="name" property="name" text="Enter a project name" default="${artifactId}" />
+        <input id="package" property="package" text="Enter a Java package name" default="${groupId}" />
+    </input-flow>
+</archetype-descriptor>

--- a/helidon-archetype/engine/src/test/resources/pom.xml.mustache
+++ b/helidon-archetype/engine/src/test/resources/pom.xml.mustache
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>{{groupId}}</groupId>
+    <artifactId>{{artifactId}}</artifactId>
+    <version>{{version}}</version>
+    <name>{{name}}</name>
+</project>

--- a/helidon-archetype/engine/src/test/resources/src/main/java/__pkg__/Main.java.mustache
+++ b/helidon-archetype/engine/src/test/resources/src/main/java/__pkg__/Main.java.mustache
@@ -1,0 +1,7 @@
+package {{package}};
+
+public final class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}

--- a/helidon-archetype/maven-plugin/pom.xml
+++ b/helidon-archetype/maven-plugin/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools.archetype</groupId>
+        <artifactId>helidon-archetype-project</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-archetype-maven-plugin</artifactId>
+    <name>Helidon Archetype Maven Plugin</name>
+    <packaging>maven-plugin</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.build-tools.archetype</groupId>
+            <artifactId>helidon-archetype-engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>invoker-install</id>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>invoker-it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <pomIncludes>
+                                <pomInclude>projects/*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>verify</goal>
+                            </goals>
+                            <streamLogs>true</streamLogs>
+                            <showErrors>true</showErrors>
+                            <skipInvocation>${maven.test.skip}</skipInvocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/helidon-archetype/maven-plugin/src/it/projects/archetype1/pom.xml
+++ b/helidon-archetype/maven-plugin/src/it/projects/archetype1/pom.xml
@@ -1,0 +1,41 @@
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.helidon.build-tools.archetype.tests</groupId>
+    <artifactId>test-archetype1</artifactId>
+    <version>@project.version@</version>
+    <name>Test Archetype 1</name>
+    <packaging>helidon-archetype</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>io.helidon.build-tools.archetype</groupId>
+                <artifactId>helidon-archetype-maven-plugin</artifactId>
+                <version>${project.version}</version>
+            </extension>
+        </extensions>
+    </build>
+</project>

--- a/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/main/resources/META-INF/helidon-archetype.xml
+++ b/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/main/resources/META-INF/helidon-archetype.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-descriptor>
+    <properties>
+        <!-- TODO validation -->
+        <property id="gradle" description="Gradle based project" />
+        <property id="maven" description="Maven based project" />
+        <property id="groupId" description="Project groupId" />
+        <property id="artifactId" description="Project artifactId" />
+        <property id="version" description="Project version" default="1.0-SNAPSHOT" />
+        <property id="name" description="Project name" />
+        <property id="package" description="Java package name" />
+    </properties>
+    <transformations>
+        <transformation id="packaged">
+            <replace regex="__pkg__" replacement="${package/\./\/}" />
+        </transformation>
+        <transformation id="mustache">
+            <replace regex="\.mustache$" replacement="" />
+        </transformation>
+    </transformations>
+    <template-sets transformations="mustache">
+        <template-set transformations="packaged">
+            <directory>src/main/java</directory>
+            <includes>
+                <include>**/*.mustache</include>
+            </includes>
+        </template-set>
+        <template-set transformations="packaged">
+            <directory>src/test/java</directory>
+            <includes>
+                <include>**/*.mustache</include>
+            </includes>
+        </template-set>
+        <template-set if="gradle">
+            <directory>.</directory>
+            <includes>
+                <include>build.gradle.mustache</include>
+            </includes>
+        </template-set>
+        <template-set if="maven">
+            <directory>.</directory>
+            <includes>
+                <include>pom.xml.mustache</include>
+            </includes>
+        </template-set>
+    </template-sets>
+    <file-sets>
+        <file-set transformations="packaged">
+            <directory>src/main/java</directory>
+            <excludes>
+                <exclude>**/*.mustache</exclude>
+            </excludes>
+        </file-set>
+        <file-set>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </file-set>
+        <file-set transformations="packaged">
+            <directory>src/test/java</directory>
+            <excludes>
+                <exclude>**/*.mustache</exclude>
+            </excludes>
+        </file-set>
+        <file-set>
+            <directory>src/test/resources</directory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </file-set>
+    </file-sets>
+    <input-flow>
+        <select text="Select a build system">
+            <choice property="maven" text="Maven" />
+            <choice property="gradle" text="Gradle" />
+        </select>
+        <!-- TODO input value transformation -->
+        <!-- TODO choice node at the top for yes/no properties -->
+        <input property="groupId" text="Enter a project groupId" if="maven"/>
+        <input property="artifactId" text="Enter a project artifactId" />
+        <input property="version" text="Enter a project version" />
+        <input property="name" text="Enter a project name" default="${artifactId}" />
+        <input property="package" text="Enter a Java package name" default="${groupId}" />
+    </input-flow>
+</archetype-descriptor>

--- a/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/main/resources/pom.xml.mustache
+++ b/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/main/resources/pom.xml.mustache
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>{{groupId}}</groupId>
+    <artifactId>{{artifactId}}</artifactId>
+    <version>{{version}}</version>
+    <name>{{name}}</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <maven.compiler.release>${maven.compiler.source}</maven.compiler.release>
+    </properties>
+</project>

--- a/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/main/resources/src/main/java/__pkg__/Main.java.mustache
+++ b/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/main/resources/src/main/java/__pkg__/Main.java.mustache
@@ -1,0 +1,7 @@
+package {{package}};
+
+public final class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}

--- a/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/test/resources/projects/it1/archetype.properties
+++ b/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/test/resources/projects/it1/archetype.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+package=com.acme.it2
+version=0.1-SNAPSHOT
+groupId=com.acme
+artifactId=it1

--- a/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/test/resources/projects/it1/goal.txt
+++ b/helidon-archetype/maven-plugin/src/it/projects/archetype1/src/test/resources/projects/it1/goal.txt
@@ -1,0 +1,1 @@
+package

--- a/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/DescriptorConverter.java
+++ b/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/DescriptorConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.maven;
+
+import java.io.Writer;
+
+import io.helidon.build.archetype.engine.ArchetypeDescriptor;
+import io.helidon.build.archetype.engine.ArchetypeDescriptor.Property;
+
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.Xpp3DomWriter;
+
+/**
+ * Converts an {@link ArchetypeDescriptor} to a minimal {@code archetype-metadata.xml}.
+ */
+final class DescriptorConverter {
+
+    /**
+     * Cannot be instantiated.
+     */
+    private DescriptorConverter() {
+    }
+
+    static void convert(ArchetypeDescriptor descriptor, Writer writer) {
+        Xpp3Dom properties = new Xpp3Dom("requiredProperties");
+        for (Property p : descriptor.properties()) {
+            Xpp3Dom prop = new Xpp3Dom("requiredProperty");
+            prop.setAttribute("key", p.id());
+            if (p.defaultValue().isPresent()) {
+                Xpp3Dom defaultValue = new Xpp3Dom("defaultValue");
+                defaultValue.setValue(p.defaultValue().get());
+                prop.addChild(defaultValue);
+            }
+            properties.addChild(prop);
+        }
+        Xpp3Dom root = new Xpp3Dom("archetype-descriptor");
+        root.addChild(properties);
+        Xpp3DomWriter.write(writer, root);
+    }
+}

--- a/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/IntegrationTestMojo.java
+++ b/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/IntegrationTestMojo.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.maven;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.helidon.build.archetype.engine.ArchetypeEngine;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.InvocationOutputHandler;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+
+/**
+ * {@code archetype:integration-test} mojo.
+ */
+@Mojo(name = "integration-test", requiresProject = true)
+public class IntegrationTestMojo extends AbstractMojo {
+
+    /**
+     * Maven invoker.
+     */
+    @Component
+    private Invoker invoker;
+
+    /**
+     * The archetype project to execute the integration tests on.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    /**
+     * Skip the integration test.
+     */
+    @Parameter(property = "archetype.test.skip")
+    private boolean skip = false;
+
+    /**
+     * Directory of test projects.
+     */
+    @Parameter(property = "archetype.test.projectsDirectory", defaultValue = "${project.build.testOutputDirectory}/projects",
+            required = true)
+    private File testProjectsDirectory;
+
+    /**
+     * Suppress logging to the {@code build.log} file.
+     */
+    @Parameter(property = "archetype.test.noLog", defaultValue = "false")
+    private boolean noLog;
+
+    /**
+     * Flag used to determine whether the build logs should be output to the normal mojo log.
+     */
+    @Parameter(property = "archetype.test.streamLogs", defaultValue = "true")
+    private boolean streamLogs;
+
+    /**
+     * flag to show the maven version used.
+     */
+    @Parameter(property = "archetype.test.showVersion", defaultValue = "false")
+    private boolean showVersion;
+
+    /**
+     * Whether to show debug statements in the build output.
+     */
+    @Parameter(property = "archetype.test.debug", defaultValue = "false")
+    private boolean debug;
+
+    /**
+     * Common set of properties to pass in on each project's command line, via -D parameters.
+     */
+    @Parameter
+    private Map<String, String> properties = new HashMap<>();
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            return;
+        }
+
+        if (!testProjectsDirectory.exists()) {
+            getLog().warn("No Archetype IT projects: root 'projects' directory not found.");
+            return;
+        }
+
+        File archetypeFile = project.getArtifact().getFile();
+        if (archetypeFile == null) {
+            throw new MojoFailureException("Archetype not found");
+        }
+
+        try {
+            List<Path> projectGoals = Files.walk(testProjectsDirectory.toPath())
+                    .filter((p) -> p.endsWith("goal.txt"))
+                    .collect(Collectors.toList());
+            if (projectGoals.isEmpty()) {
+                getLog().warn("No projects directory with goal.txt found");
+                return;
+            }
+
+            for (Path goal : projectGoals) {
+                processIntegrationTest(goal, archetypeFile);
+            }
+        } catch (IOException ex) {
+            throw new MojoFailureException(ex.getMessage(), ex);
+        }
+    }
+
+    private void processIntegrationTest(Path projectGoal, File archetypeFile) throws IOException, MojoExecutionException {
+        getLog().info("Processing Archetype IT project: " + projectGoal.getParent().toString());
+        Properties props = new Properties();
+        try (InputStream in = Files.newInputStream(projectGoal.getParent().resolve("archetype.properties"))) {
+            props.load(in);
+        }
+        // FIXME
+        props.put("maven", "true");
+        props.put("name", "test project");
+        Path outputDir = projectGoal.getParent().resolve("project");
+        if (Files.exists(outputDir)) {
+            Files.walk(outputDir)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+        Files.createDirectories(outputDir);
+        new ArchetypeEngine(archetypeFile, props).generate(outputDir.toFile());
+        List<String> goals = Files.readAllLines(projectGoal).stream()
+                .flatMap(g -> Stream.of(g.split(" ")))
+                .collect(Collectors.toList());
+        if (!goals.isEmpty()) {
+            invokePostArchetypeGenerationGoals(goals, outputDir.toFile());
+        }
+    }
+
+    private void invokePostArchetypeGenerationGoals(List<String> goals, File basedir)
+            throws IOException, MojoExecutionException {
+
+        FileLogger logger = setupLogger(basedir);
+
+        if (!goals.isEmpty()) {
+            getLog().info("Invoking post-archetype-generation goals: " + goals);
+            InvocationRequest request = new DefaultInvocationRequest()
+                    .setBaseDirectory(basedir)
+                    .setGoals(goals)
+                    .setBatchMode(true)
+                    .setShowErrors(true)
+                    .setDebug(debug)
+                    .setShowVersion(showVersion);
+
+            if (logger != null) {
+                request.setErrorHandler(logger);
+                request.setOutputHandler(logger);
+            }
+
+            if (!properties.isEmpty()) {
+                Properties props = new Properties();
+                for (Map.Entry<String, String> entry : properties.entrySet()) {
+                    if (entry.getValue() != null) {
+                        props.setProperty(entry.getKey(), entry.getValue());
+                    }
+                }
+                request.setProperties(props);
+            }
+
+            try {
+                InvocationResult result = invoker.execute(request);
+                getLog().info("Post-archetype-generation invoker exit code: " + result.getExitCode());
+                if (result.getExitCode() != 0) {
+                    throw new MojoExecutionException("Execution failure: exit code = " + result.getExitCode(),
+                            result.getExecutionException());
+                }
+            } catch (MavenInvocationException ex) {
+                throw new MojoExecutionException(ex.getMessage(), ex);
+            }
+        } else {
+            getLog().info("No post-archetype-generation goals to invoke.");
+        }
+    }
+
+    private FileLogger setupLogger(File basedir) throws IOException {
+        FileLogger logger = null;
+        if (!noLog) {
+            File outputLog = new File(basedir, "build.log");
+            if (streamLogs) {
+                logger = new FileLogger(outputLog, getLog());
+            } else {
+                logger = new FileLogger(outputLog, null);
+            }
+            getLog().debug("build log initialized in: " + outputLog);
+        }
+        return logger;
+    }
+
+    private static final class FileLogger implements InvocationOutputHandler, Closeable {
+
+        private final PrintStream stream;
+        private final Log log;
+
+        FileLogger(File outputFile, Log log) throws IOException {
+            this.log = log;
+            outputFile.getParentFile().mkdirs();
+            stream = new PrintStream(new FileOutputStream(outputFile));
+        }
+
+        @Override
+        public void consumeLine(String line) {
+            stream.println(line);
+            stream.flush();
+            if (log != null) {
+                log.info(line);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            stream.close();
+        }
+    }
+}

--- a/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/JarMojo.java
+++ b/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/JarMojo.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.maven;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import io.helidon.build.archetype.engine.ArchetypeDescriptor;
+import io.helidon.build.archetype.engine.ArchetypeEngine;
+
+import org.apache.maven.archiver.MavenArchiveConfiguration;
+import org.apache.maven.archiver.MavenArchiver;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.archiver.Archiver;
+import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.codehaus.plexus.archiver.jar.ManifestException;
+import org.codehaus.plexus.util.Scanner;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+/**
+ * {@code archetype:jar} mojo.
+ */
+@Mojo(name = "jar", defaultPhase = LifecyclePhase.PACKAGE, requiresProject = true)
+public class JarMojo extends AbstractMojo {
+
+    /**
+     * Plexus build context used to get the scanner for scanning resources.
+     */
+    @Component
+    private BuildContext buildContext;
+
+    /**
+     * The Maven project this mojo executes on.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    /**
+     * The project build output directory. (e.g. {@code target/})
+     */
+    @Parameter(defaultValue = "${project.build.directory}",
+            readonly = true, required = true)
+    private File outputDirectory;
+
+    /**
+     * Name of the generated JAR.
+     */
+    @Parameter(defaultValue = "${project.build.finalName}", alias = "jarName", required = true)
+    private String finalName;
+
+    /**
+     * The {@link MavenSession}.
+     */
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
+    /**
+     * The Jar archiver.
+     */
+    @Component
+    private Map<String, Archiver> archivers;
+
+    /**
+     * The archive configuration to use.
+     */
+    @Parameter
+    private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
+
+    /**
+     * Timestamp for reproducible output archive entries.
+     */
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Path archetypeDir = outputDirectory.toPath().resolve("archetype");
+        Path baseDir = project.getBasedir().toPath();
+        Path archetypeDescriptor = archetypeDir.resolve(ArchetypeEngine.DESCRIPTOR_RESOURCE_NAME);
+        Path archetypeResourcesList = archetypeDir.resolve(ArchetypeEngine.RESOURCES_LIST);
+        Path mavenArchetypeDescriptor = archetypeDir.resolve("META-INF/maven/archetype-metadata.xml");
+
+        Map<String, List<String>> resources = getResources();
+        Path archetypeDescriptorSource = resources.entrySet().stream()
+                .filter(e -> e.getValue().contains(ArchetypeEngine.DESCRIPTOR_RESOURCE_NAME))
+                .map(e -> baseDir.resolve(e.getKey()).resolve(ArchetypeEngine.DESCRIPTOR_RESOURCE_NAME))
+                .findAny()
+                .orElseThrow(() -> new MojoFailureException(ArchetypeEngine.DESCRIPTOR_RESOURCE_NAME + " not found"));
+
+        // create target/archetype/META-INF
+        // create target/archetype/META-INF/maven
+        // copy src/main/resources/META-INF/helidon-archetype.xml to target/archetype/META-INF/helidon-archetype.xml
+        try {
+            Files.createDirectories(archetypeDescriptor.getParent());
+            Files.createDirectories(mavenArchetypeDescriptor.getParent());
+            Files.copy(archetypeDescriptorSource, archetypeDescriptor, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ex) {
+            throw new MojoExecutionException(ex.getMessage(), ex);
+        }
+
+        // create target/archetype/META-INF/maven/archetype-metadata.xml
+        try (BufferedWriter writer = Files.newBufferedWriter(mavenArchetypeDescriptor)) {
+            ArchetypeDescriptor desc = ArchetypeDescriptor.read(Files.newInputStream(archetypeDescriptorSource));
+            StringWriter sw = new StringWriter();
+            DescriptorConverter.convert(desc, sw);
+            writer.append(sw.toString());
+        } catch (IOException ex) {
+            throw new MojoExecutionException(ex.getMessage(), ex);
+        }
+
+        // create target/archetype/META-INF/helidon-archetype-resources.txt
+        // copy archetype resources to target/archetype/
+        try (BufferedWriter writer = Files.newBufferedWriter(archetypeResourcesList)) {
+            PrintWriter printer = new PrintWriter(writer);
+            for (Entry<String, List<String>> resourcesEntry : resources.entrySet()) {
+                getLog().debug("processing resources scanned from: " + resourcesEntry.getKey());
+                for (String resource : resourcesEntry.getValue()) {
+                    if (resource.startsWith("META-INF/")) {
+                        continue;
+                    }
+                    getLog().debug("adding resource to archetype manifest: " + resource);
+                    printer.println(resource);
+                    Path resourceTarget = archetypeDir.resolve(resource);
+                    getLog().debug("adding resource to archetype directory: " + resource);
+                    Files.createDirectories(resourceTarget);
+                    Files.copy(baseDir.resolve(resourcesEntry.getKey()).resolve(resource), resourceTarget,
+                            StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        } catch (IOException ex) {
+            throw new MojoExecutionException(ex.getMessage(), ex);
+        }
+
+        File jarFile = new File(outputDirectory, finalName + ".jar");
+        getLog().info("Building archetype jar: " + jarFile);
+
+        MavenArchiver archiver = new MavenArchiver();
+        archiver.setCreatedBy("Helidon Archetype Plugin", "io.helidon.build-tools.archetype", "helidon-archetype-maven-plugin");
+        archiver.setOutputFile(jarFile);
+        archiver.setArchiver((JarArchiver) archivers.get("jar"));
+        archiver.configureReproducible(outputTimestamp);
+
+        try {
+            archiver.getArchiver().addDirectory(archetypeDir.toFile());
+            archiver.createArchive(session, project, archive);
+        } catch (IOException | DependencyResolutionRequiredException | ArchiverException | ManifestException e) {
+            throw new MojoExecutionException("Error assembling archetype jar " + jarFile, e);
+        }
+        project.getArtifact().setFile(jarFile);
+    }
+
+    /**
+     * Scan for project resources and produce a comma separated list of include resources.
+     *
+     * @return list of resources
+     */
+    private Map<String, List<String>> getResources() {
+        getLog().debug("Scanning project resources");
+        Map<String, List<String>> allResources = new HashMap<>();
+        for (Resource resource : project.getResources()) {
+            List<String> resources = new ArrayList<>();
+            allResources.put(resource.getDirectory(), resources);
+            File resourcesDir = new File(resource.getDirectory());
+            Scanner scanner = buildContext.newScanner(resourcesDir);
+            String[] includes = null;
+            if (resource.getIncludes() != null
+                    && !resource.getIncludes().isEmpty()) {
+                includes = (String[]) resource.getIncludes()
+                        .toArray(new String[resource.getIncludes().size()]);
+            }
+            scanner.setIncludes(includes);
+            String[] excludes = null;
+            if (resource.getExcludes() != null
+                    && !resource.getExcludes().isEmpty()) {
+                excludes = (String[]) resource.getExcludes()
+                        .toArray(new String[resource.getExcludes().size()]);
+            }
+            scanner.setExcludes(excludes);
+            scanner.scan();
+            for (String included : scanner.getIncludedFiles()) {
+                getLog().debug("Found resource: " + included);
+                resources.add(included);
+            }
+        }
+        return allResources;
+    }
+}

--- a/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/package-info.java
+++ b/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon archetype Maven plugin.
+ */
+package io.helidon.build.archetype.maven;

--- a/helidon-archetype/maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/helidon-archetype/maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,51 @@
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>helidon-archetype</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <extension>jar</extension>
+                <type>helidon-archetype</type>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>helidon-archetype</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
+                            <package>io.helidon.build-tools.archetype:helidon-archetype-maven-plugin:jar</package>
+                            <integration-test>io.helidon.build-tools.archetype:helidon-archetype-maven-plugin:integration-test</integration-test>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/helidon-archetype/maven-plugin/src/test/java/io/helidon/build/archetype/maven/DescriptorConverterTest.java
+++ b/helidon-archetype/maven-plugin/src/test/java/io/helidon/build/archetype/maven/DescriptorConverterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.maven;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.Base64;
+
+import io.helidon.build.archetype.engine.ArchetypeDescriptor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests {@link DescriptorConverter}.
+ */
+public class DescriptorConverterTest {
+
+    @Test
+    public void testConvert() throws IOException {
+        InputStream is = DescriptorConverterTest.class.getResourceAsStream("test.properties");
+        assertThat(is, is(not(nullValue())));
+        Properties testProps = new Properties();
+        testProps.load(is);
+        String mavenArchetypeMetadata = testProps.getProperty("archetype-metadata.xml");
+        assertThat(mavenArchetypeMetadata, is(not(nullValue())));
+        ArchetypeDescriptor desc = ArchetypeDescriptor.read(DescriptorConverterTest.class.getResourceAsStream("helidon-archetype.xml"));
+        StringWriter sw = new StringWriter();
+        DescriptorConverter.convert(desc, sw);
+        String convertedDescriptor = sw.toString();
+        assertThat(convertedDescriptor, is (new String(Base64.getDecoder().decode(mavenArchetypeMetadata), StandardCharsets.UTF_8)));
+    }
+}

--- a/helidon-archetype/maven-plugin/src/test/resources/io/helidon/build/archetype/maven/helidon-archetype.xml
+++ b/helidon-archetype/maven-plugin/src/test/resources/io/helidon/build/archetype/maven/helidon-archetype.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-descriptor>
+    <properties>
+        <property id="gradle" description="Gradle based project" />
+        <property id="maven" description="Maven based project" />
+        <property id="groupId" description="Project groupId" />
+        <property id="artifactId" description="Project artifactId" />
+        <property id="version" description="Project version" default="1.0-SNAPSHOT" />
+        <property id="name" description="Project name" />
+        <property id="package" description="Java package name" />
+    </properties>
+</archetype-descriptor>

--- a/helidon-archetype/maven-plugin/src/test/resources/io/helidon/build/archetype/maven/test.properties
+++ b/helidon-archetype/maven-plugin/src/test/resources/io/helidon/build/archetype/maven/test.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+archetype-metadata.xml=PGFyY2hldHlwZS1kZXNjcmlwdG9yPgogIDxyZXF1aXJlZFByb3BlcnRpZXM+CiAgICA8cmVxdWlyZWRQcm9wZXJ0eSBrZXk9ImdyYWRsZSIvPgogICAgPHJlcXVpcmVkUHJvcGVydHkga2V5PSJtYXZlbiIvPgogICAgPHJlcXVpcmVkUHJvcGVydHkga2V5PSJncm91cElkIi8+CiAgICA8cmVxdWlyZWRQcm9wZXJ0eSBrZXk9ImFydGlmYWN0SWQiLz4KICAgIDxyZXF1aXJlZFByb3BlcnR5IGtleT0idmVyc2lvbiI+CiAgICAgIDxkZWZhdWx0VmFsdWU+MS4wLVNOQVBTSE9UPC9kZWZhdWx0VmFsdWU+CiAgICA8L3JlcXVpcmVkUHJvcGVydHk+CiAgICA8cmVxdWlyZWRQcm9wZXJ0eSBrZXk9Im5hbWUiLz4KICAgIDxyZXF1aXJlZFByb3BlcnR5IGtleT0icGFja2FnZSIvPgogIDwvcmVxdWlyZWRQcm9wZXJ0aWVzPgo8L2FyY2hldHlwZS1kZXNjcmlwdG9yPg==

--- a/helidon-archetype/pom.xml
+++ b/helidon-archetype/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools</groupId>
+        <artifactId>helidon-build-tools-project</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.build-tools.archetype</groupId>
+    <artifactId>helidon-archetype-project</artifactId>
+    <packaging>pom</packaging>
+    <name>Helidon Archetype Project</name>
+
+    <modules>
+        <module>engine</module>
+        <module>maven-plugin</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -118,13 +118,14 @@
         <version.lib.helidon>0.9.0</version.lib.helidon>
         <version.lib.junit>5.6.0</version.lib.junit>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
+        <version.lib.invoker>3.0.1</version.lib.invoker>
         <version.lib.maven>3.6.2</version.lib.maven>
         <version.lib.maven-annotations>3.5</version.lib.maven-annotations>
-        <version.lib.maven-archiver>3.2.0</version.lib.maven-archiver>
+        <version.lib.maven-archiver>3.5.0</version.lib.maven-archiver>
         <version.lib.maven.filtering>3.1.1</version.lib.maven.filtering>
         <version.lib.maven-plugin-testing-harness>3.3.0</version.lib.maven-plugin-testing-harness>
         <version.lib.mustache>0.9.6</version.lib.mustache>
-        <version.lib.plexus-utils>3.0.24</version.lib.plexus-utils>
+        <version.lib.plexus-utils>3.3.0</version.lib.plexus-utils>
         <version.lib.plexus-build-api>0.0.7</version.lib.plexus-build-api>
         <version.lib.slf4j>1.7.25</version.lib.slf4j>
         <version.lib.spotbugs-annotations>3.1.12</version.lib.spotbugs-annotations>
@@ -132,6 +133,7 @@
         <version.lib.jansi>1.18</version.lib.jansi>
         <version.lib.asm>7.2</version.lib.asm>
         <version.lib.maven-resolver>1.4.1</version.lib.maven-resolver>
+        <version.lib.plexus.archiver>4.1.0</version.lib.plexus.archiver>
         <version.lib.plexus.component>2.0.0</version.lib.plexus.component>
         <version.lib.maven-settings>3.6.2</version.lib.maven-settings>
         <version.lib.site-plugin>3.8.2</version.lib.site-plugin>
@@ -153,6 +155,7 @@
         <version.plugin.gpg>1.6</version.plugin.gpg>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.javadoc>3.1.1</version.plugin.javadoc>
+        <version.plugin.invoker>3.2.0</version.plugin.invoker>
         <version.plugin.license>1.16</version.plugin.license>
         <version.plugin.plexus>2.1.0</version.plugin.plexus>
         <version.plugin.plugin-plugin>3.6.0</version.plugin.plugin-plugin>
@@ -171,6 +174,7 @@
         <module>sitegen-maven-plugin</module>
         <module>helidon-maven-plugin</module>
         <module>helidon-cli</module>
+        <module>helidon-archetype</module>
         <module>helidon-linker</module>
         <module>snakeyaml-codegen-maven-plugin</module>
         <module>utils</module>
@@ -409,6 +413,11 @@
                     <artifactId>plexus-component-metadata</artifactId>
                     <version>${version.lib.plexus.component}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>${version.plugin.invoker}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -543,6 +552,11 @@
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>${version.lib.plexus-utils}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-archiver</artifactId>
+                <version>${version.lib.plexus.archiver}</version>
             </dependency>
             <dependency>
                 <groupId>org.asciidoctor</groupId>
@@ -694,7 +708,11 @@
                 <artifactId>mojo-executor</artifactId>
                 <version>${version.lib.mojo-executor}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-invoker</artifactId>
+                <version>${version.lib.invoker}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
 - Engine/harness with a XML descriptor loaded with SAX
 - Maven plugin with basic integration test

Engine/harness features include:
- Re-usable path transformations
- In-place properties transformations (bash style, e.g. ${foo/match/replace})
- Properties reference (use ${foo} as a value when the foo property is resolved by user input)
- Mustach templates
- Input flow / User flow model for batch and interactive modes (only the model is implemented)