### PR TITLE
Use forkCount=0 to fix cli-impl tests behind proxy

### DIFF
--- a/helidon-cli/impl/pom.xml
+++ b/helidon-cli/impl/pom.xml
@@ -142,6 +142,13 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>0</forkCount>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/CommandTest.java
+++ b/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/CommandTest.java
@@ -64,7 +64,6 @@ public class CommandTest extends BaseCommandTest {
                 "--groupid", DEFAULT_GROUP_ID,
                 "--name", DEFAULT_NAME,
                 "--batch");
-        System.out.println(res.output);
         assertThat(res.code, is(equalTo(0)));
         Path projectDir = targetDir.resolve(Path.of(DEFAULT_NAME));
         assertTrue(Files.exists(projectDir));
@@ -76,7 +75,6 @@ public class CommandTest extends BaseCommandTest {
         Path projectDir = targetDir.resolve(Path.of(DEFAULT_NAME));
         TestUtils.ExecResult res = exec("build",
                 "--project ", projectDir.toString());
-        System.out.println(res.output);
         assertThat(res.code, is(equalTo(0)));
         assertTrue(Files.exists(projectDir.resolve("target/" + DEFAULT_ARTIFACT_ID + ".jar")));
     }
@@ -87,7 +85,6 @@ public class CommandTest extends BaseCommandTest {
         Path projectDir = targetDir.resolve(Path.of(DEFAULT_NAME));
         TestUtils.ExecResult res = exec("info",
                 "--project ", projectDir.toString());
-        System.out.println(res.output);
         assertThat(res.code, is(equalTo(0)));
     }
 
@@ -97,7 +94,6 @@ public class CommandTest extends BaseCommandTest {
         Path projectDir = targetDir.resolve(Path.of(DEFAULT_NAME));
         TestUtils.ExecResult res = exec("version",
                 "--project ", projectDir.toString());
-        System.out.println(res.output);
         assertThat(res.code, is(equalTo(0)));
     }
 

--- a/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/TestUtils.java
+++ b/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/TestUtils.java
@@ -77,13 +77,12 @@ class TestUtils {
     }
 
     static ExecResult exec(String... args) throws IOException, InterruptedException {
-        List<String> cmdArgs = new ArrayList<>(List.of(javaPath(), "-cp", "\"" + System.getProperty("java.class.path") + "\""));
-        String version = System.getProperty(HELIDON_VERSION_PROPERTY);
         return execWithDirAndInput(null, null, args);
     }
 
     static ExecResult execWithDirAndInput(File wd, File input, String... args) throws IOException, InterruptedException {
-        List<String> cmdArgs = new ArrayList<>(List.of(javaPath(), "-cp", "\"" + System.getProperty("java.class.path") + "\""));
+        String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+        List<String> cmdArgs = new ArrayList<>(List.of(javaPath(), "-cp", "\"" + classPath + "\""));
         String version = System.getProperty(HELIDON_VERSION_PROPERTY);
         if (version != null) {
             cmdArgs.add("-D" + HELIDON_VERSION_PROPERTY + "=" + version);
@@ -102,6 +101,7 @@ class TestUtils {
         if (!p.waitFor(10, TimeUnit.SECONDS)) {
             throw new IllegalStateException("timeout waiting for process");
         }
+        System.out.println(output);
         return new ExecResult(p.exitValue(), stripAnsi(output));
     }
 


### PR DESCRIPTION
Use surefire.test.class.path to compute the classpath of the forked commands, fallback to java.class.path to keep the IDEs happy
Always print the exec output