### PR TITLE
Improve archetype-post-generate.groovy  …

### DIFF
--- a/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/MojoHelper.java
+++ b/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/MojoHelper.java
@@ -29,16 +29,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import com.github.mustachejava.DefaultMustacheVisitor;
-import com.github.mustachejava.MustacheException;
-import com.github.mustachejava.MustacheVisitor;
-import com.github.mustachejava.TemplateContext;
-import com.github.mustachejava.codes.ValueCode;
 import io.helidon.build.archetype.engine.Maps;
 
 import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.DefaultMustacheVisitor;
 import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
+import com.github.mustachejava.MustacheVisitor;
+import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.codes.ValueCode;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 

--- a/helidon-archetype/maven-plugin/src/main/resources/archetype-post-generate.groovy.mustache
+++ b/helidon-archetype/maven-plugin/src/main/resources/archetype-post-generate.groovy.mustache
@@ -14,224 +14,48 @@
 * limitations under the License.
 */
 
-def mavenLibDir = new File(System.getProperty("maven.home"), "lib")
+def aetherScript = '''
+{{aetherScript}}
+'''
 
-// check Maven version
-def mavenCoreName = mavenLibDir.list().find { it.startsWith("maven-core-") }
-if (mavenCoreName == null) {
-    throw new IllegalStateException("Unable to determine Maven version")
-}
-def mavenVersionStr = mavenCoreName.substring("maven-core-".length(), mavenCoreName.length() - ".jar".length());
-def minMavenVersion = new org.apache.maven.artifact.versioning.ComparableVersion("3.2.5")
-def mavenVersion = new org.apache.maven.artifact.versioning.ComparableVersion(mavenVersionStr)
-if (mavenVersion.compareTo(minMavenVersion) < 0) {
-    throw new IllegalStateException("Requires Maven >= 3.2.5")
-}
+def engineScript = '''
+{{engineScript}}
+'''
 
-// check Java version
-def javaVersion = System.getProperty("java.version")
-if (javaVersion == null || !javaVersion.startsWith("11")) {
-    throw new IllegalStateException("Requires Java >= 11")
-}
-
-def ccl =  Thread.currentThread().getContextClassLoader()
-
-// the current class loader is restricted and there is no way to bootstrap aether as-is
-// create a class-loader with the maven core libraries found under ${maven.home}/lib
-def mavenLibs = []
-mavenLibDir.eachFile { mavenLibs.add(it.toURI().toURL()) }
-def mcl = new URLClassLoader(mavenLibs.toArray(new URL[mavenLibs.size()]), ccl)
-
-// set-it as the context thread class loader for plexus to work properly...
-Thread.currentThread().setContextClassLoader(mcl)
-
-// ----------------------------------------
-// load classes from the created class-loader
-// ----------------------------------------
-
-def mavenRepoSystemUtilsClass = mcl.loadClass("org.apache.maven.repository.internal.MavenRepositorySystemUtils")
-def localRepositoryClass = mcl.loadClass("org.eclipse.aether.repository.LocalRepository")
-def repoConnectorFactoryClass = mcl.loadClass("org.eclipse.aether.spi.connector.RepositoryConnectorFactory")
-def basicRepoConnectorFactoryClass = mcl.loadClass("org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory")
-def transporterFactoryClass = mcl.loadClass("org.eclipse.aether.spi.connector.transport.TransporterFactory")
-def wagonTransporterFactoryClass = mcl.loadClass("org.eclipse.aether.transport.wagon.WagonTransporterFactory")
-def wagonProviderClass = mcl.loadClass("org.eclipse.aether.transport.wagon.WagonProvider")
-def wagonClass = mcl.loadClass("org.apache.maven.wagon.Wagon")
-def httpWagonClass = mcl.loadClass("org.apache.maven.wagon.providers.http.HttpWagon")
-def plexusContainerClass = mcl.loadClass("org.codehaus.plexus.PlexusContainer")
-def defaultPlexusContainerClass = mcl.loadClass("org.codehaus.plexus.DefaultPlexusContainer")
-def plexusDescClass = mcl.loadClass("org.codehaus.plexus.component.repository.ComponentDescriptor")
-def plexusWagonProviderClass = mcl.loadClass("org.eclipse.aether.internal.transport.wagon.PlexusWagonProvider")
-def repoSystemClass = mcl.loadClass("org.eclipse.aether.RepositorySystem")
-def remoteRepoBuilderClass = mcl.loadClass("org.eclipse.aether.repository.RemoteRepository\$Builder")
-def repoPolicyClass = mcl.loadClass("org.eclipse.aether.repository.RepositoryPolicy")
-def proxyClass = mcl.loadClass("org.eclipse.aether.repository.Proxy")
-def authenticationClass = mcl.loadClass("org.eclipse.aether.repository.Authentication")
-def authenticationBuilderClass = mcl.loadClass("org.eclipse.aether.util.repository.AuthenticationBuilder")
-def artifactRequestClass = mcl.loadClass("org.eclipse.aether.resolution.ArtifactRequest")
-def defaultArtifactClass = mcl.loadClass("org.eclipse.aether.artifact.DefaultArtifact")
-def dependencyClass = mcl.loadClass("org.eclipse.aether.graph.Dependency")
-def artifactClass = mcl.loadClass("org.eclipse.aether.artifact.Artifact")
-def collectRequestClass = mcl.loadClass("org.eclipse.aether.collection.CollectRequest")
-def dependencyRequestClass = mcl.loadClass("org.eclipse.aether.resolution.DependencyRequest")
-def dependencyFilterUtilsClass = mcl.loadClass("org.eclipse.aether.util.filter.DependencyFilterUtils")
-
-// ----------------------------------------
-// setup wagon
-// ----------------------------------------
-
-def createPlexusDescriptor(plexusDescClass, roleClass, roleHint, implClass, strategy) {
-    def desc = plexusDescClass
-        .getConstructor()
-        .newInstance()
-    desc.setRoleClass(roleClass)
-    desc.setRoleHint(roleHint)
-    desc.setImplementationClass(implClass)
-    desc.setInstantiationStrategy(strategy)
-    return desc
-}
-
-def plexusContainer = defaultPlexusContainerClass
-    .getConstructor()
-    .newInstance()
-plexusContainer.addComponentDescriptor(createPlexusDescriptor(plexusDescClass, httpWagonClass, "http", httpWagonClass,
-    "per-lookup"))
-plexusContainer.addComponentDescriptor(createPlexusDescriptor(plexusDescClass, httpWagonClass, "https", httpWagonClass,
-    "per-lookup"))
-
-def wagonProvider = plexusWagonProviderClass
-    .getConstructor(plexusContainerClass)
-    .newInstance(plexusContainer)
-
-// ----------------------------------------
-// setup aether
-// ----------------------------------------
-
-def repoSystem = mavenRepoSystemUtilsClass
-    .getMethod("newServiceLocator")
-    .invoke(null)
-    .setServices(wagonProviderClass, wagonProvider)
-    .addService(transporterFactoryClass, wagonTransporterFactoryClass)
-    .addService(repoConnectorFactoryClass, basicRepoConnectorFactoryClass)
-    .getService(repoSystemClass);
-
-def localRepo = localRepositoryClass
-    .getConstructor(File.class)
-    .newInstance(request
-    .getProjectBuildingRequest()
-    .getRepositorySession()
-    .getLocalRepository()
-    .getBasedir());
-
-def repoSession = mavenRepoSystemUtilsClass
-    .getMethod("newSession")
-    .invoke(null)
-repoSession.setLocalRepositoryManager(repoSystem.newLocalRepositoryManager(repoSession, localRepo))
-
-// ----------------------------------------
-// remote repositories configuration
-// ----------------------------------------
-
-def repoCtor = remoteRepoBuilderClass.getConstructor(String.class, String.class, String.class)
-def policyCtor = repoPolicyClass.getConstructor(Boolean.TYPE, String.class, String.class)
-def proxyCtor = proxyClass.getConstructor(String.class, String.class, Integer.TYPE, authenticationClass)
-
-def remoteRepositories = request.getProjectBuildingRequest().getRemoteRepositories()
-.collect {
-    def builder = repoCtor.newInstance(it.getId(), it.getLayout().getId(), it.getUrl());
-    def releases = it.getReleases()
-    if (releases != null) {
-        def releasePolicy = policyCtor.newInstance(releases.isEnabled(), releases.getUpdatePolicy(),
-            releases.getChecksumPolicy())
-        builder.setReleasePolicy(releasePolicy)
-    }
-    def snapshots = it.getSnapshots()
-    if (snapshots != null) {
-        def snapshotPolicy = policyCtor.newInstance(snapshots.isEnabled(), snapshots.getUpdatePolicy(),
-            snapshots.getChecksumPolicy())
-        builder.setSnapshotPolicy(snapshotPolicy)
-    }
-    def proxy = it.getProxy()
-    if (proxy != null) {
-        def authentication = authenticationBuilderClass
-            .getConstructor()
-            .newInstance()
-            .addUsername(proxy.getUserName())
-            .addPassword((String) proxy.getPassword())
-            .build()
-        builder.setProxy(proxyCtor.newInstance(proxy.getProtocol(), proxy.getHost(), proxy.getPort(),
-            authentication));
-    }
-    return builder.build();
-}
-
-// resolve the archetype file from the local repository
-def archetypeArtifact = defaultArtifactClass
-    .getConstructor(String.class, String.class, String.class, String.class)
-    .newInstance(request.getArchetypeGroupId(),
-    request.getArchetypeArtifactId(),
-    "jar",
-    request.getArchetypeVersion())
-
-def archetypeArtifactRequest = artifactRequestClass
-    .getConstructor()
-    .newInstance()
-    .setArtifact(archetypeArtifact)
-
-def archetypeFile = repoSystem
-    .resolveArtifact(repoSession, archetypeArtifactRequest)
-    .getArtifact()
-    .getFile()
+def helidonEngine = new GroovyShell().parse(engineScript).create()
+helidonEngine.checkMavenVersion()
+helidonEngine.checkJavaVersion()
 
 def engineGav = "{{engineGroupId}}:{{engineArtifactId}}:{{engineVersion}}"
 
-// resolve the engine dependencies
-def engineArtifact = defaultArtifactClass
-    .getConstructor(String.class)
-    .newInstance(engineGav)
-
-def engineDependency = dependencyClass
-    .getConstructor(artifactClass, String.class)
-    .newInstance(engineArtifact, "compile")
-
-def collectRequest = collectRequestClass
-    .getConstructor()
-    .newInstance()
-    .setRoot(engineDependency)
-    .setRepositories(remoteRepositories)
-
-def filter = dependencyFilterUtilsClass
-    .getMethod("classpathFilter", Collection.class)
-    .invoke(null, ["runtime"])
-
-def dependencyRequest = dependencyRequestClass
-    .getConstructor()
-    .newInstance()
-    .setCollectRequest(collectRequest)
-    .setFilter(filter)
-
-def engineDependencies = repoSystem
-    .resolveDependencies(repoSession, dependencyRequest)
-    .getArtifactResults()
-    .collect { it.getArtifact().getFile().toURI().toURL() }
-
-// create a class-loader with the engine dependencies
-def ecl = new URLClassLoader(engineDependencies.toArray(new URL[engineDependencies.size()]), ccl)
-
 def archetypeProperties = request.getProperties()
 def props = [
-    "maven": "true",
+"maven": "true",
 {{#propNames}}
     "{{.}}": archetypeProperties.getProperty("{{.}}"),
 {{/propNames}}
 ]
 
-def rootDir = new File(request.getOutputDirectory() + "/" + request.getArtifactId())
-new File(rootDir, "pom.xml").delete() // delete place place-holder pom
+def localRepo = request
+    .getProjectBuildingRequest()
+    .getRepositorySession()
+    .getLocalRepository()
+    .getBasedir()
 
-// generate !
-def engine = ecl.loadClass("io.helidon.build.archetype.engine.ArchetypeEngine")
-    .getConstructor(File.class, Map.class)
-    .newInstance(archetypeFile, props)
+def remoteRepos = request
+    .getProjectBuildingRequest()
+    .getRemoteRepositories()
 
-engine.generate(rootDir)
+def projectDir = new File(request.getOutputDirectory() + "/" + request.getArtifactId())
+
+helidonEngine.generate(
+    aetherScript,
+    localRepo,
+    remoteRepos,
+    request.getArchetypeGroupId(),
+    request.getArchetypeArtifactId(),
+    request.getArchetypeVersion(),
+    engineGav,
+    props,
+    projectDir)
+

--- a/helidon-archetype/maven-plugin/src/main/resources/groovy/Aether.groovy
+++ b/helidon-archetype/maven-plugin/src/main/resources/groovy/Aether.groovy
@@ -1,0 +1,150 @@
+/*
+* Copyright (c) 2020 Oracle and/or its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils
+import org.apache.maven.wagon.Wagon
+import org.apache.maven.wagon.providers.http.HttpWagon
+import org.codehaus.plexus.DefaultPlexusContainer
+import org.codehaus.plexus.component.repository.ComponentDescriptor
+import org.eclipse.aether.RepositorySystem
+import org.eclipse.aether.RepositorySystemSession
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.collection.CollectRequest
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory
+import org.eclipse.aether.graph.Dependency
+import org.eclipse.aether.internal.transport.wagon.PlexusWagonProvider
+import org.eclipse.aether.repository.LocalRepository
+import org.eclipse.aether.repository.Proxy
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.repository.RepositoryPolicy
+import org.eclipse.aether.resolution.ArtifactRequest
+import org.eclipse.aether.resolution.DependencyRequest
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory
+import org.eclipse.aether.spi.connector.transport.TransporterFactory
+import org.eclipse.aether.transport.wagon.WagonProvider
+import org.eclipse.aether.transport.wagon.WagonTransporterFactory
+import org.eclipse.aether.util.filter.DependencyFilterUtils
+import org.eclipse.aether.util.repository.AuthenticationBuilder
+
+/**
+ * Standalone aether utility.
+ */
+class AetherImpl {
+
+    private List<RemoteRepository> remoteRepos
+    private RepositorySystem repoSystem
+    private RepositorySystemSession repoSession
+
+    @SuppressWarnings("GroovyAssignabilityCheck")
+    AetherImpl(File localRepoDir, remoteArtifactRepos) {
+        def plexusContainer = new DefaultPlexusContainer()
+        plexusContainer.addComponentDescriptor(plexusDesc(Wagon.class, "http", HttpWagon.class, "per-lookup"))
+        plexusContainer.addComponentDescriptor(plexusDesc(Wagon.class, "https", HttpWagon.class, "per-lookup"))
+        repoSystem = MavenRepositorySystemUtils.newServiceLocator()
+                .setServices(WagonProvider.class, new PlexusWagonProvider(plexusContainer))
+                .addService(TransporterFactory.class, WagonTransporterFactory.class)
+                .addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class)
+                .getService(RepositorySystem.class)
+        repoSession = MavenRepositorySystemUtils.newSession()
+        repoSession.setLocalRepositoryManager(repoSystem.newLocalRepositoryManager(repoSession,
+                new LocalRepository(localRepoDir)))
+        remoteRepos = remoteArtifactRepos.collect { remoteRepo(it) }
+    }
+
+    private static ComponentDescriptor plexusDesc(Class<?>roleClass,
+                                                  String roleHint,
+                                                  Class<?> implClass,
+                                                  String strategy) {
+        def desc = new ComponentDescriptor()
+        desc.setRoleClass(roleClass)
+        desc.setRoleHint(roleHint)
+        desc.setImplementationClass(implClass)
+        desc.setInstantiationStrategy(strategy)
+        return desc
+    }
+
+    @SuppressWarnings("GroovyAssignabilityCheck")
+    private static RemoteRepository remoteRepo(aRepo) {
+        def builder = new RemoteRepository.Builder(aRepo.getId(), aRepo.getLayout().getId(), aRepo.getUrl());
+        def releases = aRepo.getReleases()
+        if (releases != null) {
+            def releasePolicy = new RepositoryPolicy(releases.isEnabled(), releases.getUpdatePolicy(),
+                    releases.getChecksumPolicy())
+            builder.setReleasePolicy(releasePolicy)
+        }
+        def snapshots = aRepo.getSnapshots()
+        if (snapshots != null) {
+            def snapshotPolicy = new RepositoryPolicy(snapshots.isEnabled(), snapshots.getUpdatePolicy(),
+                    snapshots.getChecksumPolicy())
+            builder.setSnapshotPolicy(snapshotPolicy)
+        }
+        def proxy = aRepo.getProxy()
+        if (proxy != null) {
+            def authentication = new AuthenticationBuilder()
+                    .addUsername(proxy.getUserName())
+                    .addPassword((String) proxy.getPassword())
+                    .build()
+            builder.setProxy(new Proxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), authentication));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Resolve the given artifact.
+     *
+     * @param groupId the groupId
+     * @param artifactId the artifactId
+     * @param type the type e.g. {@code "jar"}
+     * @param version the version
+     * @return artifact file
+     */
+    File resolveArtifact(String groupId, String artifactId, String type, String version) {
+        return repoSystem
+                .resolveArtifact(repoSession, new ArtifactRequest()
+                        .setArtifact(new DefaultArtifact(groupId, artifactId, type, version)))
+                .getArtifact()
+                .getFile()
+    }
+
+    /**
+     * Resolve transitive dependencies of the given GAV.
+     *
+     * @param gav GAV string (groupId:artifactId:version)
+     * @return list of files
+     */
+    List<File> resolveDependencies(String gav) {
+        return repoSystem
+                .resolveDependencies(repoSession, new DependencyRequest()
+                        .setCollectRequest(new CollectRequest()
+                                .setRoot(new Dependency(new DefaultArtifact(gav), "compile"))
+                                .setRepositories(remoteRepos))
+                        .setFilter(DependencyFilterUtils.classpathFilter("runtime")))
+                .getArtifactResults()
+                .collect { it.getArtifact().getFile() }
+    }
+}
+
+/**
+ * Create a new Aether instance.
+ * @param localRepoDir local repository directory
+ * @param remoteArtifactRepos remote artifacts repositories
+ * @return AetherImpl
+ */
+def create(localRepoDir, remoteArtifactRepos) {
+    return new AetherImpl(localRepoDir, remoteArtifactRepos)
+}
+
+return this

--- a/helidon-archetype/maven-plugin/src/main/resources/groovy/HelidonEngine.groovy
+++ b/helidon-archetype/maven-plugin/src/main/resources/groovy/HelidonEngine.groovy
@@ -1,0 +1,118 @@
+/*
+* Copyright (c) 2020 Oracle and/or its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import org.apache.maven.artifact.versioning.ComparableVersion
+
+class HelidonEngineImpl {
+
+    private File mavenLibDir = new File(System.getProperty("maven.home"), "lib")
+
+    /**
+     * Check that the Maven version is greater or equal to 3.2.5.
+     */
+    void checkMavenVersion() {
+        def mavenCoreJar = mavenLibDir.list().find { it.startsWith("maven-core-") }
+        if (mavenCoreJar == null) {
+            throw new IllegalStateException("Unable to determine Maven version")
+        }
+        String mavenVersion = mavenCoreJar.substring("maven-core-".length(), mavenCoreJar.length() - ".jar".length());
+        ComparableVersion minMavenVersion = new ComparableVersion("3.2.5")
+        if (new ComparableVersion(mavenVersion) < minMavenVersion) {
+            throw new IllegalStateException("Requires Maven >= 3.2.5")
+        }
+    }
+
+    /**
+     * Check that the Java version is greater or equal to 11.
+     */
+    void checkJavaVersion() {
+        def javaVersion = System.getProperty("java.version")
+        if (javaVersion == null || !javaVersion.startsWith("11")) {
+            throw new IllegalStateException("Requires Java >= 11")
+        }
+    }
+
+    /**
+     * Generate a project.
+     *
+     * @param aetherScript script for {@code Aether.groovy}
+     * @param localRepo local repository directory
+     * @param remoteRepos remote artifacts repositories
+     * @param archetypeGroupId archetype groupId
+     * @param archetypeArtifactId archetype artifactId
+     * @param archetypeVersion archetype version
+     * @param engineGav helidon engine GAV string
+     * @param props properties
+     * @param projectDir project directory
+     */
+    void generate(String aetherScript,
+                  File localRepo,
+                  remoteRepos,
+                  String archetypeGroupId,
+                  String archetypeArtifactId,
+                  String archetypeVersion,
+                  String engineGav,
+                  Map<String, String> props,
+                  File projectDir) {
+
+        // the current class loader is restricted and there is no way to bootstrap aether as-is
+        // create a class-loader with the maven core libraries found under ${maven.home}/lib
+        List<URL> mavenLibs = mavenLibDir
+                .listFiles()
+                .collect{ it.toURI().toURL() }
+        def cl = new URLClassLoader(mavenLibs.toArray(new URL[mavenLibs.size()]), this.getClass().getClassLoader())
+
+        // set the context class loader for plexus to work properly.
+        Thread.currentThread().setContextClassLoader(cl)
+
+        def aether = new GroovyShell(cl)
+                .parse(aetherScript)
+                .create(localRepo, remoteRepos)
+
+        // resolve the archetype JAR from the local repository
+        def archetypeFile = aether
+                .resolveArtifact(archetypeGroupId, archetypeArtifactId, "jar", archetypeVersion)
+
+        // resolve the helidon engine libs from remote repository
+        List<URL> engineLibs = aether
+                .resolveDependencies(engineGav)
+                .collect { it.toURI().toURL() }
+
+        // create a class-loader with the engine dependencies
+        def ecl = new URLClassLoader(engineLibs.toArray(new URL[engineLibs.size()]), this.getClass().getClassLoader())
+
+        // instantiate the engine
+        def engine = ecl.loadClass("io.helidon.build.archetype.engine.ArchetypeEngine")
+                .getConstructor(File.class, Map.class)
+                .newInstance(archetypeFile, props)
+
+        // delete place place-holder pom
+        new File(projectDir, "pom.xml")
+                .delete()
+
+        engine.generate(projectDir)
+    }
+}
+
+/**
+ * Create a new engine instance.
+ * @return HelidonEngineImpl
+ */
+def create() {
+    return new HelidonEngineImpl()
+}
+
+return this


### PR DESCRIPTION
Decomposing the code of  archetype-post-generate.groovy into 2 separate classes:
 - Aether.groovy
 - HelidonEngine.groovy

archetype-post-generate.groovy now only has bootstrap code, the main logic is in HelidonEngine.groovy.
It creates the class loader with all the maven core libs and uses a separate GroovyShell to create the instance of Aether.groovy
This removes the need to use reflection to bootstrap and use aether.

Because the main script is evaluated from a string there is no way to load the includes with a File, Path or URI.
Thus, the 2 includes are inlined in the main script using multi line strings.