### PR TITLE
Follow symlinks fix

### DIFF
--- a/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/CommandContext.java
+++ b/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/CommandContext.java
@@ -180,6 +180,16 @@ public final class CommandContext {
                 if (Style.isStyled(message)) {
                     Log.info(message);
                 } else {
+                    if (message == null) {
+                        if (error.getMessage() != null) {
+                            message = error.getMessage();
+                        } else if (error.getCause() != null) {
+                            message = error.getCause().getMessage();
+                        } else {
+                            message = "Unknown error";
+                            error.printStackTrace();
+                        }
+                    }
                     Log.log(level, error, message);
                 }
                 if (Log.isVerbose()) {

--- a/helidon-linker/src/test/java/io/helidon/linker/LinkerTest.java
+++ b/helidon-linker/src/test/java/io/helidon/linker/LinkerTest.java
@@ -120,7 +120,7 @@ class LinkerTest {
         Path mainAppJar = FileUtils.assertFile(appDir.resolve(mainJarName));
         assertReadOnly(mainAppJar);
         Path appLibDir = FileUtils.assertDir(appDir.resolve("libs"));
-        for (Path file : FileUtils.listFiles(appLibDir, name -> true)) {
+        for (Path file : FileUtils.listFiles(appLibDir, (path, attrs) -> attrs.isRegularFile())) {
             assertReadOnly(file);
         }
     }

--- a/utils/src/main/java/io/helidon/build/util/FileUtils.java
+++ b/utils/src/main/java/io/helidon/build/util/FileUtils.java
@@ -180,7 +180,7 @@ public final class FileUtils {
     public static List<Path> listFiles(Path directory, Predicate<String> fileNameFilter, int maxDepth) {
         try {
             return Files.find(assertDir(directory), maxDepth, (path, attrs) ->
-                    attrs.isRegularFile() && fileNameFilter.test(path.getFileName().toString())
+                    fileNameFilter.test(path.getFileName().toString())
             ).collect(Collectors.toList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/utils/src/main/java/io/helidon/build/util/FileUtils.java
+++ b/utils/src/main/java/io/helidon/build/util/FileUtils.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -170,6 +171,17 @@ public final class FileUtils {
     }
 
     /**
+     * List all files in the given directory that match the given filter. Does not recurse.
+     *
+     * @param directory The directory.
+     * @param pathFilter The filter.
+     * @return The normalized, absolute file paths.
+     */
+    public static List<Path> listFiles(Path directory, BiPredicate<Path, BasicFileAttributes> pathFilter) {
+        return listFiles(directory, pathFilter, 1);
+    }
+
+    /**
      * List all files in the given directory that match the given filter, recursively if maxDepth > 1.
      *
      * @param directory The directory.
@@ -178,10 +190,20 @@ public final class FileUtils {
      * @return The normalized, absolute file paths.
      */
     public static List<Path> listFiles(Path directory, Predicate<String> fileNameFilter, int maxDepth) {
+        return listFiles(directory, (path, attrs) -> fileNameFilter.test(path.getFileName().toString()), maxDepth);
+    }
+
+    /**
+     * List all files in the given directory that match the given filter, recursively if maxDepth > 1.
+     *
+     * @param directory The directory.
+     * @param pathFilter The filter.
+     * @param maxDepth The maximum recursion depth.
+     * @return The normalized, absolute file paths.
+     */
+    public static List<Path> listFiles(Path directory, BiPredicate<Path, BasicFileAttributes> pathFilter, int maxDepth) {
         try {
-            return Files.find(assertDir(directory), maxDepth, (path, attrs) ->
-                    fileNameFilter.test(path.getFileName().toString())
-            ).collect(Collectors.toList());
+            return Files.find(assertDir(directory), maxDepth, pathFilter).collect(Collectors.toList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Fixes #176

  * Follow symlinks when resolving JAVA_HOME and MAVEN_HOME
  * Resolve Maven version from manifest
  * Don't hide exceptions with `getMessage() == null`

```
kec@ubukec:~/idp/helidon-build-tools/helidon-cli/impl/target$ ./helidon init
error: Unable to find Java installation, please set JAVA_HOME
kec@ubukec:~/idp/helidon-build-tools/helidon-cli/impl/target$ export JAVA_HOME="/usr/lib/jvm/graalvm-ce-java11-20.1.0/"
kec@ubukec:~/idp/helidon-build-tools/helidon-cli/impl/target$ ./helidon init
Looking up latest Helidon version
Using Helidon version 2.0.0-RC1
Helidon flavor
  (1) SE 
  (2) MP 
Enter selection (Default: 1): ^C
kec@ubukec:~/idp/helidon-build-tools/helidon-cli/impl/target$ ll /usr/share/maven/lib | grep maven-core
lrwxrwxrwx 1 root root   26 led 27 22:19 maven-core-3.x.jar -> ../../java/maven3-core.jar

```