### PR TITLE
Fix helidon-cli/impl dependencies

### DIFF
--- a/helidon-cli/impl/pom.xml
+++ b/helidon-cli/impl/pom.xml
@@ -48,20 +48,15 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.build-tools.cli</groupId>
             <artifactId>helidon-cli-codegen</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/TestUtils.java
+++ b/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/TestUtils.java
@@ -92,7 +92,7 @@ class TestUtils {
                                                .capture(true)
                                                .build()
                                                .start()
-                                               .waitForCompletion(60, TimeUnit.SECONDS);
+                                               .waitForCompletion(120, TimeUnit.SECONDS);
         String output = String.join(EOL, monitor.output());
         return stripAnsi(output);
     }


### PR DESCRIPTION
Move slf4j-jdk14 to test scope
remove spotbugs annotations.
Increase timeout for command exec.