### PR TITLE
Ignore "jdkInternals" dependency. Fix Helidon version extraction. 

### DIFF
--- a/helidon-linker/src/main/java/io/helidon/linker/Jar.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/Jar.java
@@ -220,6 +220,15 @@ public final class Jar implements ResourceContainer {
     }
 
     /**
+     * Returns the manifest, if present.
+     *
+     * @return The manifest or {@code null} if not present.
+     */
+    public Manifest manifest() {
+        return manifest;
+    }
+
+    /**
      * Returns the entries in this jar.
      *
      * @return The entries.
@@ -328,10 +337,10 @@ public final class Jar implements ResourceContainer {
         if (Constants.OS.isPosix()) {
             try {
                 Files.setPosixFilePermissions(targetFile, Set.of(
-                    PosixFilePermission.OWNER_READ,
-                    PosixFilePermission.OWNER_WRITE,
-                    PosixFilePermission.GROUP_READ,
-                    PosixFilePermission.OTHERS_READ
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.GROUP_READ,
+                        PosixFilePermission.OTHERS_READ
                 ));
             } catch (IOException e) {
                 Log.warn("Unable to set %s read-only: %s", e.getMessage());

--- a/helidon-linker/src/main/java/io/helidon/linker/JavaDependencies.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/JavaDependencies.java
@@ -54,6 +54,7 @@ public final class JavaDependencies {
         "split package", JavaDependencies::split,
         "not found", JavaDependencies::ignore,
         "unnamed module", JavaDependencies::ignore,
+        "jdk8internals", JavaDependencies::debug,
         "JDK removed internal API", JavaDependencies::debug
     );
 

--- a/helidon-linker/src/test/java/io/helidon/linker/ApplicationTest.java
+++ b/helidon-linker/src/test/java/io/helidon/linker/ApplicationTest.java
@@ -16,11 +16,16 @@
 
 package io.helidon.linker;
 
+import java.nio.file.Path;
+
+import io.helidon.build.test.TestFiles;
+
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.linker.Application.versionFromFileName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * Unit test for class {@link Application}.
@@ -28,12 +33,12 @@ import static org.hamcrest.Matchers.is;
 class ApplicationTest {
 
     @Test
-    void testVersionParsing() {
-        assertThat(versionFromFileName("helidon-config-1.4.2.jar"), is("1.4.2"));
-        assertThat(versionFromFileName("helidon-config-1.4.3-SNAPSHOT.jar"), is("1.4.3-SNAPSHOT"));
-        assertThat(versionFromFileName("helidon-config-2.0.jar"), is("2.0"));
-        assertThat(versionFromFileName("helidon-config-2.0-SNAPSHOT.jar"), is("2.0-SNAPSHOT"));
-        assertThat(versionFromFileName("helidon-config.jar"), is("0.0.0"));
+    void testHelidonVersion() {
+        Path mainJar = TestFiles.helidonMpJar();
+        Application app = Application.create(mainJar);
+        String version = app.helidonVersion();
+        assertThat(version, is(notNullValue()));
+        assertThat(version, is(not("0.0.0")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #177 