### PR TITLE
implement collapsible top-level menu for the site/doc generator

### DIFF
--- a/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Backend.java
+++ b/sitegen-maven-plugin/src/main/java/io/helidon/build/sitegen/Backend.java
@@ -132,7 +132,7 @@ public abstract class Backend implements Model {
                         break;
                     default:
                         throw new IllegalStateException(
-                                "Unkown attribute: " + attr);
+                                "Unknown attribute: " + attr);
                 }
             }
             return (T) BackendProvider.get(name, node);

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/docNav.js
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/components/docNav.js
@@ -23,7 +23,7 @@ window.allComponents['docNav'] = {
         scriptElt.id = "doc-nav";
         scriptElt.type = "text/x-template";
         scriptElt.text =
-        `<v-navigation-drawer v-model="isActive" fixed dark app>
+        `<v-navigation-drawer v-model="isActive" fixed dark app class="docNav">
             <v-toolbar flat dark class="transparent">
             <v-list class="pa-0 vuetify">
                 <v-list-tile tag="div">
@@ -62,43 +62,129 @@ window.allComponents['docNav'] = {
             </v-toolbar>
             <v-divider></v-divider>
             <v-list dense>
-            <template v-for="item in items">
+            <template v-for="(item,itemIndex) in items">
                 <v-list-group v-if="item.items" v-bind:group="item.group">
-                <v-list-tile slot="item" ripple>
-                    <v-list-tile-action>
-                    <v-icon dark>{{ item.action }}</v-icon>
-                    </v-list-tile-action>
+                    <v-list-tile slot="item" ripple>
+                        <v-list-tile-action>
+                            <v-icon dark>{{ item.action }}</v-icon>
+                        </v-list-tile-action>
+                        <v-list-tile-content>
+                            <v-list-tile-title>{{ item.title }}</v-list-tile-title>
+                        </v-list-tile-content>
+                        <v-list-tile-action>
+                            <v-icon dark>keyboard_arrow_down</v-icon>
+                        </v-list-tile-action>
+                    </v-list-tile>
+                    <v-list-tile
+                        v-for="subItem in item.items" v-bind:key="subItem.title"
+                        v-bind="{ to: !subItem.target ? subItem.href : null,  href: subItem.target && subItem.href }"
+                        @click.native="setIsSearching(false)"
+                        ripple
+                        v-bind:disabled="subItem.disabled"
+                        v-bind:target="subItem.target">
+                        <v-list-tile-content>
+                            <v-list-tile-title>{{ subItem.title }}</v-list-tile-title>
+                        </v-list-tile-content>
+                        <v-list-tile-action v-if="subItem.action">
+                            <v-icon dark :class="[subItem.actionClass || 'success--text']">{{ subItem.action }}</v-icon>
+                        </v-list-tile-action>
+                    </v-list-tile>
+                </v-list-group>
+                <v-list-tile v-else-if="item.header" disabled>
                     <v-list-tile-content>
-                    <v-list-tile-title>{{ item.title }}</v-list-tile-title>
+                        <v-list-tile-title>{{ item.header }}</v-list-tile-title>
                     </v-list-tile-content>
-                    <v-list-tile-action>
-                    <v-icon dark>keyboard_arrow_down</v-icon>
-                    </v-list-tile-action>
                 </v-list-tile>
+                <v-expansion-panel
+                    v-else-if="item.groups"
+                    class="navGroups">
+                    <v-expansion-panel-content
+                        hide-actions
+                        v-bind:ref="'group-'+itemIndex+'-'+groupIndex"
+                        v-for="(group,groupIndex) in item.groups"
+                        :key="groupIndex"
+                        v-model="groups[itemIndex][groupIndex]">
+                        <ul slot="header"
+                            class="list--group__header"
+                            v-bind:class="{ 'list--group__header--active': groups[itemIndex][groupIndex] }"
+                            @click.stop="toggleGroup(itemIndex, groupIndex, $event)">
+                            <li>
+                                <a class="list__tile list__tile--link" data-ripple="true" style="position: relative;">
+                                    <v-list-tile-action v-if="group.action">
+                                        <v-icon dark>{{ group.action }}</v-icon>
+                                    </v-list-tile-action>
+                                    <div class="list__tile__content">
+                                        <div class="list__tile__title">{{ group.title }}</div>
+                                    </div>
+                                    <!-- <v-icon dark>{{groups[itemIndex][groupIndex] ? "keyboard_arrow_up" : "keyboard_arrow_down" }}</v-icon> -->
+                                </a>
+                            </li>
+                        </ul>
+                        <v-card @click.stop="click" class="navGroupItem">
+                            <template v-for="(groupItem,groupItemIndex) in group.items">
+                                <v-list-group
+                                    v-bind:ref="'group-'+itemIndex+'-'+groupIndex+'-'+groupItemIndex"
+                                    v-if="groupItem.items"
+                                    v-bind:group="groupItem.group">
+                                    <v-list-tile
+                                        ripple
+                                        slot="item"
+                                        @click.native="toggleGroupItem(itemIndex, groupIndex, groupItemIndex)">
+                                        <v-list-tile-action>
+                                            <v-icon dark>{{ groupItem.action }}</v-icon>
+                                        </v-list-tile-action>
+                                        <v-list-tile-content>
+                                            <v-list-tile-title>{{ groupItem.title }}</v-list-tile-title>
+                                        </v-list-tile-content>
+                                        <v-list-tile-action>
+                                            <v-icon dark>keyboard_arrow_down</v-icon>
+                                        </v-list-tile-action>
+                                    </v-list-tile>
+                                    <v-list-tile
+                                        v-for="subGroupItem in groupItem.items" v-bind:key="subGroupItem.title"
+                                        v-bind="{ to: !subGroupItem.target ? subGroupItem.href : null,  href: subGroupItem.target && subGroupItem.href }"
+                                        @click.native="setIsSearching(false)"
+                                        ripple
+                                        v-bind:disabled="subGroupItem.disabled"
+                                        v-bind:target="subGroupItem.target">
+                                        <v-list-tile-content>
+                                            <v-list-tile-title>{{ subGroupItem.title }}</v-list-tile-title>
+                                        </v-list-tile-content>
+                                        <v-list-tile-action v-if="subGroupItem.action">
+                                            <v-icon dark :class="[subGroupItem.actionClass || 'success--text']">{{ subGroupItem.action }}</v-icon>
+                                        </v-list-tile-action>
+                                    </v-list-tile>
+                                </v-list-group>
+                                <v-list-tile
+                                    v-else
+                                    v-bind="{ to: !groupItem.target ? groupItem.href : null, href: groupItem.target && groupItem.href }"
+                                    @click.native="setIsSearching(false)"
+                                    ripple
+                                    v-bind:disabled="groupItem.disabled"
+                                    v-bind:target="groupItem.target"
+                                    rel="noopener">
+                                    <v-list-tile-action>
+                                        <v-icon dark>{{ groupItem.action }}</v-icon>
+                                    </v-list-tile-action>
+                                    <v-list-tile-content>
+                                        <v-list-tile-title>{{ groupItem.title }}</v-list-tile-title>
+                                    </v-list-tile-content>
+                                    <v-list-tile-action v-if="groupItem.action">
+                                        <v-icon dark class="success--text">{{ groupItem.action }}</v-icon>
+                                    </v-list-tile-action>
+                                </v-list-tile>
+                            </template>
+                        </v-card>
+                    </v-expansion-panel-content>
+                </v-expansion-panel>
+                <v-divider v-else-if="item.divider"></v-divider>
                 <v-list-tile
-                    v-for="subItem in item.items" v-bind:key="subItem.title"
-                    v-bind="{ to: !subItem.target ? subItem.href : null,  href: subItem.target && subItem.href }"
+                    v-bind="{ to: !item.target ? item.href : null, href: item.target && item.href }"
                     @click.native="setIsSearching(false)"
                     ripple
-                    v-bind:disabled="subItem.disabled"
-                    v-bind:target="subItem.target">
-                    <v-list-tile-content>
-                    <v-list-tile-title>{{ subItem.title }}</v-list-tile-title>
-                    </v-list-tile-content>
-                    <v-list-tile-action v-if="subItem.action">
-                    <v-icon dark :class="[subItem.actionClass || 'success--text']">{{ subItem.action }}</v-icon>
-                    </v-list-tile-action>
-                </v-list-tile>
-                </v-list-group>
-                <v-subheader v-else-if="item.header" dark>{{ item.header }}</v-subheader>
-                <v-divider v-else-if="item.divider"></v-divider>
-                <v-list-tile 
-                v-bind="{ to: !item.target ? item.href : null, href: item.target && item.href }"
-                @click.native="setIsSearching(false)"
-                ripple
-                v-bind:disabled="item.disabled"
-                v-bind:target="item.target"
-                rel="noopener"
+                    v-bind:disabled="item.disabled"
+                    v-bind:target="item.target"
+                    rel="noopener"
                 v-else>
                 <v-list-tile-action>
                     <v-icon dark>{{ item.action }}</v-icon>
@@ -134,8 +220,34 @@ window.allComponents['docNav'] = {
                     navTitle: config.navTitle,
                     release: config.release,
                     releases: config.releases,
-                    items: navItems
+                    items: navItems,
+                    groups: [],
+                    activeIndex: 0,
+                    activeGroupIndex: 0,
                 };
+            },
+            created: function() {
+                var first = false
+                for (var i = 0; i < this.items.length; i++) {
+                    if (this.items[i].groups) {
+                        var group = []
+                        for(var j = 0; j < this.items[i].groups.length ; j++) {
+                            if (!first) {
+                                group[j] = true
+                                first = true
+                            } else {
+                                group[j] = false
+                            }
+                        }
+                        this.groups.push(group)
+                    } else {
+                        this.groups.push(false)
+                    }
+                }
+                this.$router.afterEach((to, from) => this.toggleGroupForRoute(to))
+            },
+            mounted: function() {
+                this.toggleGroupForRoute(this.$route)
             },
             computed: {
                 filter() {
@@ -166,6 +278,39 @@ window.allComponents['docNav'] = {
                 }
             },
             methods: {
+                toggleGroupForRoute(route) {
+                    var group = this.items[this.activeIndex].groups[this.activeGroupIndex].group
+                    if (route.path.startsWith(group)) {
+                        return
+                    }
+                    for (var i = 0; i < this.items.length; i++) {
+                        if (this.items[i].groups) {
+                            for(var j = 0; j < this.items[i].groups.length ; j++) {
+                                group = this.items[i].groups[j].group
+                                if (route.path.startsWith(group)) {
+                                    this.toggleGroup(i, j)
+                                }
+                            }
+                        }
+                    }
+                },
+                toggleGroup(itemIndex, groupIndex, e) {
+                    if (!this.groups[itemIndex][groupIndex]) {
+                        this.$refs['group-'+ this.activeIndex+'-' + this.activeGroupIndex][0].isActive = false
+                        this.$refs['group-' + itemIndex + '-' + groupIndex][0].isActive = true
+                        this.activeIndex = itemIndex
+                        this.activeGroupIndex = groupIndex
+                    }
+                    this.$store.commit('sitegen/ISSEARCHING', false);
+                },
+                toggleGroupItem(itemIndex, groupIndex, groupItemIndex) {
+                    var refName = 'group-'+itemIndex+'-'+groupIndex+'-'+groupItemIndex
+                    var ref = this.$refs[refName]
+                    if (ref.length && ref.length ==1) {
+                        ref[0].isActive = !ref[0].isActive
+                    }
+                    this.$store.commit('sitegen/ISSEARCHING', false);
+                },
                 setIsSearching(val) {
                     this.$store.commit('sitegen/ISSEARCHING', val);
                 }

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/css/helidon-sitegen.css
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-static/vuetify/css/helidon-sitegen.css
@@ -55,6 +55,10 @@ p {
     color: #939699!important;
 }
 
+.navigation-drawer > .list > .list--group__container > .list--group:after {
+ content: none;
+}
+
 pre, code {
     display: inline;
     word-break: break-word;
@@ -171,6 +175,27 @@ ul.ulist {
 .navLogo img{
     width:32px!important;
     height:32px!important;
+}
+
+.docNav {
+    overflow-y: scroll;
+}
+
+.docNav .list__tile:after {
+  content: none!important;
+}
+
+.docNav .list--group:after {
+  content: none!important;
+}
+
+ul.navGroups {
+    display: block!important;
+    box-shadow: none!important;
+}
+
+ul.navGroups > li.expansion-panel__container > div.expansion-panel__header {
+    padding: 0!important;
 }
 
 .vuetify .list__tile__avatar img{

--- a/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
+++ b/sitegen-maven-plugin/src/main/resources/helidon-sitegen-templates/vuetify/config.ftl
@@ -77,9 +77,42 @@ function createRoutes(){
 function createNav(){
     return [
 <#if navigation??>
+        {
+            groups: [
 <#list navigation.items as navitem>
-<#if navitem.isgroup>
-        { header: '${navitem.title?js_string}' },
+<#if navitem.isgroup && navitem.pathprefix??>
+                {
+                    title: '${navitem.title?js_string}',
+                    group: '${navitem.pathprefix}',
+                    items: [
+<#list navitem.items as groupitem>
+                        {
+                            title: '${groupitem.title?js_string}',
+                            action: <#if groupitem.glyph??>'${groupitem.glyph.value}'<#else>null</#if>,
+<#if groupitem.islink>
+                            href: '${groupitem.href}',
+                            target: '_blank'
+<#elseif groupitem.isgroup>
+                            group: <#if groupitem.pathprefix??>'${groupitem.pathprefix}'<#else>null</#if>,
+                            items: [
+<#list groupitem.items as subgroupitem>
+<#if subgroupitem.islink>
+                                { href: '${subgroupitem.href}', title: '${subgroupitem.title?js_string}' }<#sep>,</#sep>
+</#if>
+</#list>
+                            ]
+</#if>
+                        }<#if groupitem?has_next>,</#if>
+</#list>
+                    ]
+                }<#if navitem?has_next>,</#if>
+</#if>
+</#list>
+            ]
+        }
+<#list navigation.items as navitem>
+<#if navitem.isgroup && !navitem.pathprefix??>
+        ,{ header: '${navitem.title?js_string}' },
 <#list navitem.items as groupitem>
         {
             title: '${groupitem.title?js_string}',
@@ -107,9 +140,6 @@ function createNav(){
             target: '_blank'
         }<#if navitem?has_next>,</#if>
 </#if>
-<#sep>
-        { divider: true },
-</#sep>
 </#list>
 </#if>
     ];

--- a/sitegen-maven-plugin/src/test/java/io/helidon/build/sitegen/ConfigTest.java
+++ b/sitegen-maven-plugin/src/test/java/io/helidon/build/sitegen/ConfigTest.java
@@ -161,6 +161,7 @@ public class ConfigTest {
 
         VuetifyNavigation.Group mainDocNavGroup = assertType(topNavItems.get(0), VuetifyNavigation.Group.class, "nav.items[0]");
         assertEquals("Main Documentation", mainDocNavGroup.getTitle(), "nav.items[0].title");
+        assertEquals("/about", mainDocNavGroup.getPathprefix(), "nav.items[0].pathprefix");
 
         List<VuetifyNavigation.Item> mainDocNavItems = mainDocNavGroup.getItems();
         assertList(3, mainDocNavItems, "nav.items[0].items");

--- a/sitegen-maven-plugin/src/test/resources/config/vuetify.yaml
+++ b/sitegen-maven-plugin/src/test/resources/config/vuetify.yaml
@@ -26,6 +26,7 @@ backend:
         value: "import_contacts"
       items:
         - title: "Main Documentation"
+          pathprefix: "/about"
           items:
             - title: "About"
               pathprefix: "/about"


### PR DESCRIPTION
Add support for collapsible top level menu using expansion panels.
Requires top level navigation groups to declare a path prefix in order to automatically open the panels for the corresponding routes.