### PR TITLE
Use manifest file inside the jar to identify maven version.

### DIFF
--- a/helidon-archetype/maven-plugin/src/main/resources/groovy/HelidonEngine.groovy
+++ b/helidon-archetype/maven-plugin/src/main/resources/groovy/HelidonEngine.groovy
@@ -28,7 +28,7 @@ class HelidonEngineImpl {
         if (mavenCoreJar == null) {
             throw new IllegalStateException("Unable to determine Maven version")
         }
-        String mavenVersion = mavenCoreJar.substring("maven-core-".length(), mavenCoreJar.length() - ".jar".length());
+		String mavenVersion = new java.util.jar.JarFile(mavenCoreJar).manifest.mainAttributes.getValue("Implementation-Version");
         ComparableVersion minMavenVersion = new ComparableVersion("3.2.5")
         if (new ComparableVersion(mavenVersion) < minMavenVersion) {
             throw new IllegalStateException("Requires Maven >= 3.2.5")


### PR DESCRIPTION
**Note: This is a bit of a shot in the dark as I don't know how to test this.** 

Even before I made this change, `mvn install` fails on my system. I'm happy to do more with this if needed, but I'll need some guidance from someone with a bit more knowledge of the project.

