### PR TITLE
Update helidon-maven-plugin:native-image to support windows properly.

### DIFF
--- a/helidon-maven-plugin/src/main/java/io/helidon/build/maven/graal/GraalNativeMojo.java
+++ b/helidon-maven-plugin/src/main/java/io/helidon/build/maven/graal/GraalNativeMojo.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Resource;


### PR DESCRIPTION
Add logic to find command with known windows executable extensions (.exe, .cmd etc)
Add quote around the -H options. E.g. -H:foo="bar" arguments.

Fixes https://github.com/oracle/helidon/issues/2230