### PR TITLE
Split cli parsing logic in two passes

### DIFF
--- a/helidon-cli/codegen/src/main/java/io/helidon/build/cli/codegen/CommandAnnotationProcessor.java
+++ b/helidon-cli/codegen/src/main/java/io/helidon/build/cli/codegen/CommandAnnotationProcessor.java
@@ -58,6 +58,7 @@ public class CommandAnnotationProcessor extends AbstractProcessor {
     private final Map<String, CommandFragmentMetaModel> fragmentsByQualifiedName = new HashMap<>();
     private boolean done;
 
+    // TODO detect bad duplicates (options with same name but of different type)
     // TODO enforce options only for command fragments (i.e no argument)
     // TODO support inheritance
     // TODO add unit tests
@@ -136,7 +137,7 @@ public class CommandAnnotationProcessor extends AbstractProcessor {
             String registryQualifiedName = pkg + "." + CodeGenerator.REGISTRY_NAME;
             JavaFileObject fileObject = filer.createSourceFile(registryQualifiedName);
             try (BufferedWriter bw = new BufferedWriter(fileObject.openWriter())) {
-                bw.append(CodeGenerator.generateCommandRegistry(pkg, CodeGenerator.REGISTRY_NAME, models));
+                bw.append(CodeGenerator.generateCommandRegistry(pkg, models));
             }
             FileObject serviceFileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", REGISTRY_SERVICE_FILE);
             try (BufferedWriter bw = new BufferedWriter(serviceFileObject.openWriter())) {

--- a/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/CommandContext.java
+++ b/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/CommandContext.java
@@ -47,6 +47,7 @@ public final class CommandContext {
     private final AtomicReference<SystemLogWriter> logWriter = new AtomicReference<>();
     private final CLIDefinition cli;
     private final CommandRegistry registry;
+    private final Properties properties;
     private Verbosity verbosity;
     private ExitAction exitAction;
     private CommandParser parser;
@@ -60,6 +61,7 @@ public final class CommandContext {
         this.cli = Objects.requireNonNull(cli, "cli is null");
         this.registry = Objects.requireNonNull(registry, "registry is null");
         this.exitAction = new ExitAction();
+        this.properties = new Properties();
     }
 
     /**
@@ -286,14 +288,23 @@ public final class CommandContext {
     /**
      * Get the command parser.
      *
-     * @return command parser
-     * @throws IllegalStateException if parser is not set
+     * @return parser
+     * @throws IllegalStateException if the parser is not set
+     */
+    CommandParser parser() {
+        if (parser == null) {
+            throw new IllegalStateException("parser is not set");
+        }
+        return parser;
+    }
+
+    /**
+     * Get the parsed properties.
+     *
+     * @return properties, never {@code null}
      */
     public Properties properties() {
-        if (parser == null) {
-            return new Properties();
-        }
-        return parser.properties();
+        return properties;
     }
 
     /**
@@ -334,6 +345,7 @@ public final class CommandContext {
 
     /**
      * Lazily initialize and return the {@link SystemLogWriter}.
+     *
      * @return The writer.
      */
     private SystemLogWriter logWriter() {

--- a/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/GlobalOptions.java
+++ b/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/GlobalOptions.java
@@ -16,6 +16,7 @@
 package io.helidon.build.cli.harness;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.helidon.build.cli.harness.CommandModel.FlagInfo;
 
@@ -114,11 +115,19 @@ public class GlobalOptions {
         return GLOBAL_FLAG_ARGUMENTS.contains(argument);
     }
 
-    private static final Set<String> GLOBAL_FLAG_ARGUMENTS = Set.of(
-            HELP_FLAG_ARGUMENT,
-            VERBOSE_FLAG_ARGUMENT,
-            DEBUG_FLAG_ARGUMENT,
-            PLAIN_FLAG_ARGUMENT);
+    /**
+     * Global flags.
+     */
+    static final FlagInfo[] GLOBAL_FLAGS = new FlagInfo[]{
+            HELP_FLAG_INFO,
+            VERBOSE_FLAG_INFO,
+            DEBUG_FLAG_INFO,
+            PLAIN_FLAG_INFO
+    };
+
+    private static final Set<String> GLOBAL_FLAG_ARGUMENTS = Set.of(GLOBAL_FLAGS).stream()
+            .map(f -> "--" + f.name())
+            .collect(Collectors.toSet());
 
     private GlobalOptions() {
     }

--- a/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/OutputHelper.java
+++ b/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/OutputHelper.java
@@ -15,8 +15,8 @@
  */
 package io.helidon.build.cli.harness;
 
-import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Utility class to help with output.
@@ -36,28 +36,18 @@ public final class OutputHelper {
      * @return rendered table
      */
     public static String table(Map<String, String> map) {
-        int maxOptNameLength = 0;
-        for (String opt : map.keySet()) {
-            int optNameLength = opt.length();
-            if (optNameLength > maxOptNameLength) {
-                maxOptNameLength = optNameLength;
-            }
+        int maxKeyWidth = map.keySet().stream().mapToInt(String::length).max().orElse(0);
+        return map.entrySet().stream()
+                .map(e -> BEGIN_SPACING + e.getKey() + padding(maxKeyWidth, e.getKey()) + COL_SPACING + e.getValue())
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static String padding(int maxKeyWidth, Object key) {
+        final int keyLen = key.toString().length();
+        if (maxKeyWidth > keyLen) {
+            return " ".repeat(maxKeyWidth - keyLen);
+        } else {
+            return "";
         }
-        String out = "";
-        Iterator<Map.Entry<String, String>> it = map.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<String, String> optEntry = it.next();
-            String optName = optEntry.getKey();
-            int curColPos = maxOptNameLength - optName.length();
-            String colSpacing = "";
-            for (int i = 0; i < curColPos; i++) {
-                colSpacing += " ";
-            }
-            out += BEGIN_SPACING + optName + colSpacing + COL_SPACING + optEntry.getValue();
-            if (it.hasNext()) {
-                out += "\n";
-            }
-        }
-        return out;
     }
 }

--- a/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/UsageCommand.java
+++ b/helidon-cli/harness/src/main/java/io/helidon/build/cli/harness/UsageCommand.java
@@ -40,7 +40,7 @@ final class UsageCommand extends CommandModel {
     }
 
     @Override
-    public CommandExecution createExecution(CommandParser parser) {
+    public CommandExecution createExecution(CommandParser.Resolver resolver) {
         return this::execute;
     }
 

--- a/helidon-cli/harness/src/test/java/io/helidon/build/cli/harness/ExecTest.java
+++ b/helidon-cli/harness/src/test/java/io/helidon/build/cli/harness/ExecTest.java
@@ -117,19 +117,18 @@ public class ExecTest {
 
         private static final FlagInfo FOO = new FlagInfo("foo", "Foo option");
         private static final FlagInfo BAR = new FlagInfo("bar", "Bar option");
+        private static final CommandInfo CMD = new CommandInfo("simple", "A simple test command");
 
         SimpleCommand() {
-            super(new CommandInfo("simple", "A simple test command"));
-            addParameter(FOO);
-            addParameter(BAR);
+            super(CMD, FOO, BAR);
         }
 
         @Override
-        public CommandExecution createExecution(CommandParser parser) {
+        public CommandExecution createExecution(CommandParser.Resolver resolver) {
             return (context) -> {
-                if (parser.resolve(FOO)) {
+                if (resolver.resolve(FOO)) {
                     Log.info("foo");
-                } else if (parser.resolve(BAR)) {
+                } else if (resolver.resolve(BAR)) {
                     Log.info("bar");
                 } else {
                     Log.info("noop");
@@ -142,18 +141,17 @@ public class ExecTest {
 
         private static final CommonOptionsInfo COMMON_OPTIONS = new CommonOptionsInfo();
         private static final FlagInfo FOO = new FlagInfo("foo", "Turn on foo mode");
+        private static final CommandInfo CMD = new CommandInfo("common", "A test command with common options");
 
         CommandWithCommonOptions() {
-            super(new CommandInfo("common", "A test command with common options"));
-            addParameter(COMMON_OPTIONS);
-            addParameter(FOO);
+            super(CMD, COMMON_OPTIONS, FOO);
         }
 
         @Override
-        public CommandExecution createExecution(CommandParser parser) {
+        public CommandExecution createExecution(CommandParser.Resolver resolver) {
             return (context) -> {
-                String key = COMMON_OPTIONS.resolve(parser).key;
-                if (parser.resolve(FOO)) {
+                String key = COMMON_OPTIONS.resolve(resolver).key;
+                if (resolver.resolve(FOO)) {
                     Log.info("foo: " + key);
                 } else {
                     Log.info(key);
@@ -176,13 +174,12 @@ public class ExecTest {
         private static final KeyValueInfo<String> KEY_OPTION = new KeyValueInfo<>(String.class, "key", "key option", null, true);
 
         private CommonOptionsInfo() {
-            super(CommonOptions.class);
-            addParameter(KEY_OPTION);
+            super(CommonOptions.class, KEY_OPTION);
         }
 
         @Override
-        public CommonOptions resolve(CommandParser parser) {
-            return new CommonOptions(parser.resolve(KEY_OPTION));
+        public CommonOptions resolve(CommandParser.Resolver resolver) {
+            return new CommonOptions(resolver.resolve(KEY_OPTION));
         }
     }
 }


### PR DESCRIPTION
Split cli parsing logic in two passes.

The first pass parses the command name, the global flags and the properties specified before the command name
The 2nd pass parses the command specific options and the properties specified after the command name

Fixes #261