### PR TITLE
Fix MavenCommand PATH env setup

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/MavenCommand.java
+++ b/utils/src/main/java/io/helidon/build/util/MavenCommand.java
@@ -463,8 +463,9 @@ public class MavenCommand {
 
             Map<String, String> env = processBuilder.environment();
             String mavenPath = mavenExecutable().getParent().toString();
-            String path = mavenPath + pathSeparatorChar + env.get(PATH_VAR);
-            env.put(PATH_VAR, path);
+            env.entrySet().stream()
+                    .filter(e -> e.getKey().equalsIgnoreCase(PATH_VAR))
+                    .forEach(e -> env.put(e.getKey(), mavenPath + pathSeparatorChar + e.getValue()));
 
             // Setup MAVEN_OPTS with debugger, if needed
 


### PR DESCRIPTION
Prepend mavenHome/bin to any env variable named PATH regardless of the case

Fixes #250