### PR TITLE
redirect STDIN for all maven processes.

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/MavenCommand.java
+++ b/utils/src/main/java/io/helidon/build/util/MavenCommand.java
@@ -457,7 +457,10 @@ public class MavenCommand {
 
             // Create the process builder
 
-            processBuilder = new ProcessBuilder().directory(directory.toFile()).command(command);
+            processBuilder = new ProcessBuilder()
+                    .redirectInput(ProcessBuilder.Redirect.INHERIT)
+                    .directory(directory.toFile())
+                    .command(command);
 
             // Ensure we use the current Maven version
 


### PR DESCRIPTION
This is to ensure the forked processes are killed when interrupted on windows

Fixes #253