### PR TITLE
Close the readers for the process stream readers.

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/ProcessMonitor.java
+++ b/utils/src/main/java/io/helidon/build/util/ProcessMonitor.java
@@ -535,8 +535,8 @@ public final class ProcessMonitor {
 
     private static final class MonitorTask {
 
-        final BufferedReader reader;
-        final Future<?> task;
+        private final BufferedReader reader;
+        private final Future<?> task;
 
         MonitorTask(BufferedReader reader, Future<?> task) {
             this.reader = reader;


### PR DESCRIPTION
On windows currently only the first iteration of the devloop shows the output of the application.
It turns out that this is because the readers of the streams for the current application process are not closed when canceling.