### PR TITLE
Fix MonitorReader.close()

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/ProcessMonitor.java
+++ b/utils/src/main/java/io/helidon/build/util/ProcessMonitor.java
@@ -596,8 +596,12 @@ public final class ProcessMonitor {
 
         @Override
         public void close() throws IOException {
-            consumeLines();
-            super.close();
+            try {
+                consumeLines();
+            } catch (Exception ignore) {
+            } finally {
+                super.close();
+            }
         }
     }
 


### PR DESCRIPTION
Wrap consumeLines with try/catch/finally in MonitorReader.close()