### PR TITLE
Add "-jri" suffix to directory name in JLinkImageMojo

### DIFF
--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BuildCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BuildCommand.java
@@ -18,6 +18,7 @@ package io.helidon.build.cli.impl;
 
 import io.helidon.build.cli.harness.Command;
 import io.helidon.build.cli.harness.CommandContext;
+import io.helidon.build.cli.harness.Config;
 import io.helidon.build.cli.harness.Creator;
 import io.helidon.build.cli.harness.Option.Flag;
 import io.helidon.build.cli.harness.Option.KeyValue;
@@ -36,10 +37,12 @@ public final class BuildCommand extends BaseCommand {
 
     private static final String JLINK_OPTION = "-Pjlink-image";
     private static final String NATIVE_OPTION = "-Pnative-image";
+    private static final String PLUGIN_VERSION_PROPERTY_PREFIX = "-Dversion.plugin.helidon=";
 
     private final CommonOptions commonOptions;
     private final boolean clean;
     private final BuildMode buildMode;
+    private final String pluginVersionProperty;
 
     enum BuildMode {
         PLAIN,
@@ -50,11 +53,15 @@ public final class BuildCommand extends BaseCommand {
     @Creator
     BuildCommand(CommonOptions commonOptions,
                  @Flag(name = "clean", description = "Perform a clean before the build") boolean clean,
-                 @KeyValue(name = "mode", description = "Build mode", defaultValue = "PLAIN") BuildMode buildMode) {
+                 @KeyValue(name = "mode", description = "Build mode", defaultValue = "PLAIN") BuildMode buildMode,
+                 @Flag(name = "current", description = "Use the build version as the helidon-maven-plugin version",
+                         visible = false)
+                         boolean currentPluginVersion) {
         super(commonOptions, true);
         this.commonOptions = commonOptions;
         this.clean = clean;
         this.buildMode = buildMode;
+        this.pluginVersionProperty = currentPluginVersion ? PLUGIN_VERSION_PROPERTY_PREFIX + Config.buildVersion() : null;
     }
 
     @Override
@@ -68,6 +75,7 @@ public final class BuildCommand extends BaseCommand {
 
         MavenCommand.Builder builder = MavenCommand.builder()
                                                    .addArgument(ENABLE_HELIDON_CLI)
+                                                   .addOptionalArgument(pluginVersionProperty)
                                                    .addArguments(context.propertyArgs(true))
                                                    .verbose(context.verbosity() != NORMAL)
                                                    .directory(commonOptions.project());

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
@@ -83,9 +83,9 @@ public final class DevCommand extends BaseCommand {
     DevCommand(CommonOptions commonOptions,
                @Flag(name = "clean", description = "Perform a clean before the first build") boolean clean,
                @Flag(name = "fork", description = "Fork mvn execution") boolean fork,
-               @KeyValue(name = "version", description = "helidon-maven-plugin version", visible = false)
+               @KeyValue(name = "version", description = "helidon-cli-maven-plugin version", visible = false)
                        String pluginVersion,
-               @Flag(name = "current", description = "Use the build version as the helidon-maven-cli-plugin version",
+               @Flag(name = "current", description = "Use the build version as the helidon-cli-maven-plugin version",
                        visible = false)
                        boolean currentPluginVersion,
                @KeyValue(name = "app-jvm-args", description = "JVM args used when starting the application")

--- a/helidon-linker/src/main/java/io/helidon/linker/util/Constants.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/Constants.java
@@ -83,6 +83,11 @@ public final class Constants {
     public static final String DIR_SEP = File.separator;
 
     /**
+     * The suffix to append to JRI directories when name must be created.
+     */
+    public static final String JRI_DIR_SUFFIX = "-jri";
+
+    /**
      * Indent function.
      */
     public static final Function<String, String> INDENT = line -> "    " + line;
@@ -113,16 +118,16 @@ public final class Constants {
      * The help message to log if the script execution policy error occurs.
      */
     public static final String WINDOWS_SCRIPT_EXECUTION_POLICY_ERROR_HELP =
-        EOL
-        + EOL
-        + Bold.apply("To enable script execution, run the following command: ")
-        + EOL
-        + EOL
-        + "    "
-        + BoldBrightYellow.apply("powershell Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned")
-        + EOL
-        + EOL
-        + Bold.apply("and answer 'Y' if prompted.");
+            EOL
+            + EOL
+            + Bold.apply("To enable script execution, run the following command: ")
+            + EOL
+            + EOL
+            + "    "
+            + BoldBrightYellow.apply("powershell Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned")
+            + EOL
+            + EOL
+            + Bold.apply("and answer 'Y' if prompted.");
 
     private Constants() {
     }

--- a/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
@@ -41,6 +41,7 @@ import static io.helidon.build.util.FileUtils.assertDir;
 import static io.helidon.build.util.FileUtils.assertFile;
 import static io.helidon.build.util.FileUtils.fileName;
 import static io.helidon.build.util.FileUtils.listFiles;
+import static io.helidon.linker.util.Constants.JRI_DIR_SUFFIX;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -53,7 +54,6 @@ public final class JavaRuntime implements ResourceContainer {
     private static final String JAVA_BASE_JMOD = "java.base.jmod";
     private static final String JMOD_CLASSES_PREFIX = "classes/";
     private static final String JMOD_MODULE_INFO_PATH = JMOD_CLASSES_PREFIX + "module-info.class";
-    private static final String JRI_SUFFIX = "-jri";
     private static final String FILE_SEP = File.separator;
     private static final String JAVA_EXEC = OS.javaExecutable();
     private static final String JAVA_CMD_PATH = "bin" + FILE_SEP + JAVA_EXEC;
@@ -85,7 +85,7 @@ public final class JavaRuntime implements ResourceContainer {
     public static Path prepareJriDirectory(Path jriDirectory, Path mainJar, boolean replaceExisting) throws IOException {
         if (jriDirectory == null) {
             final String jarName = fileName(requireNonNull(mainJar));
-            final String dirName = jarName.substring(0, jarName.lastIndexOf('.')) + JRI_SUFFIX;
+            final String dirName = jarName.substring(0, jarName.lastIndexOf('.')) + JRI_DIR_SUFFIX;
             jriDirectory = FileUtils.WORKING_DIR.resolve(dirName);
         }
         if (Files.exists(jriDirectory)) {

--- a/helidon-maven-plugin/src/main/java/io/helidon/build/maven/link/JLinkImageMojo.java
+++ b/helidon-maven-plugin/src/main/java/io/helidon/build/maven/link/JLinkImageMojo.java
@@ -35,6 +35,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
+import static io.helidon.linker.util.Constants.JRI_DIR_SUFFIX;
+
 /**
  * Maven goal to create a custom Java Runtime Image.
  */
@@ -117,7 +119,7 @@ public class JLinkImageMojo extends AbstractMojo {
         }
         final Path buildDir = buildDirectory.toPath();
         final Path mainJar = mainJar(buildDir);
-        final Path outputDir = buildDir.resolve(finalName);
+        final Path outputDir = buildDir.resolve(finalName + JRI_DIR_SUFFIX);
         final Log.Writer writer = new MavenLogWriter(getLog());
         try {
             Configuration config = Configuration.builder()


### PR DESCRIPTION
Fixes #295.
 
This naming convention is not identical to that suggested in #295, but is instead the default behavior of the underlying linker. 