### PR TITLE
Add details if possible on missing jmods error

### DIFF
--- a/helidon-linker/src/main/java/io/helidon/linker/Application.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/Application.java
@@ -39,13 +39,15 @@ import static java.util.jar.Attributes.Name.IMPLEMENTATION_VERSION;
  * in its manifest.
  */
 public final class Application implements ResourceContainer {
-    static final Path APP_DIR = Paths.get("app");
+    /**
+     * The relative path of the application directory.
+     */
+    public static final Path APP_DIR = Paths.get("app");
     private static final Path ARCHIVE_PATH = Paths.get("lib" + DIR_SEP + "start.jsa");
     private static final String HELIDON_JAR_NAME_PREFIX = "helidon-";
     private static final String MP_FILE_PREFIX = HELIDON_JAR_NAME_PREFIX + "microprofile";
     private static final String VERSION_1_4_1 = "1.4.1";
     private static final String UNKNOWN_VERSION = "0.0.0";
-    private static final String SNAPSHOT = "-SNAPSHOT";
     private final Jar mainJar;
     private final List<Jar> classPath;
     private final boolean isMicroprofile;

--- a/helidon-linker/src/main/java/io/helidon/linker/StartScript.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/StartScript.java
@@ -58,7 +58,10 @@ import static java.util.Objects.requireNonNull;
  * Installs a start script for a main jar.
  */
 public class StartScript {
-    private static final String INSTALL_PATH = OS.withScriptExtension("start");
+    /**
+     * The script file name.
+     */
+    public static final String SCRIPT_FILE_NAME = OS.withScriptExtension("start");
     private final Path installDirectory;
     private final Path scriptFile;
     private final String script;
@@ -645,7 +648,7 @@ public class StartScript {
             if (mainJar == null) {
                 throw new IllegalStateException("mainJar is required");
             }
-            this.scriptFile = scriptInstallDirectory.resolve(INSTALL_PATH);
+            this.scriptFile = scriptInstallDirectory.resolve(SCRIPT_FILE_NAME);
             this.config = toConfig();
             this.script = template().render(config);
             return new StartScript(this);

--- a/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
@@ -37,7 +37,6 @@ import java.util.zip.ZipFile;
 import io.helidon.build.util.FileUtils;
 import io.helidon.linker.Jar;
 import io.helidon.linker.ResourceContainer;
-import io.helidon.linker.StartScript;
 
 import static io.helidon.build.util.Constants.OS;
 import static io.helidon.build.util.Constants.javaHome;
@@ -63,8 +62,11 @@ public final class JavaRuntime implements ResourceContainer {
     private static final String FILE_SEP = File.separator;
     private static final String JAVA_EXEC = OS.javaExecutable();
     private static final String JAVA_CMD_PATH = "bin" + FILE_SEP + JAVA_EXEC;
-    private static final String INVALID_JRI = "Not a valid JRI (" + JAVA_CMD_PATH + " not found): %s";
-    private static final String INCOMPLETE_JDK = "Not a complete JDK, the required *.jmod files are missing (e.g. jmods/%s): %s";
+    private static final String JAVA_MODULE_NAME_PREFIX = "java.";
+    private static final String JDK_MODULE_NAME_PREFIX = "java.";
+    private static final String HELIDON_JAR_NAME_PREFIX = "helidon-";
+    private static final String INVALID_JRI = "This is not a valid JRI (" + JAVA_CMD_PATH + " not found): %s";
+    private static final String INCOMPLETE_JDK = "The required *.jmod files (e.g. jmods/%s) are missing in this JDK: %s";
     private static final String HELIDON_JRI = "This is a custom Helidon JRI.";
     private static final String CUSTOM_JRI = "This appears to be a custom JRI.";
     private static final boolean OPEN_JDK = System.getProperty("java.vm.name").toLowerCase(Locale.ENGLISH).contains("openjdk");
@@ -390,7 +392,8 @@ public final class JavaRuntime implements ResourceContainer {
                                .findAll()
                                .stream()
                                .map(ref -> ref.descriptor().name())
-                               .anyMatch(moduleName -> !(moduleName.startsWith("java.") || moduleName.startsWith("jdk.")));
+                               .anyMatch(moduleName -> !(moduleName.startsWith(JAVA_MODULE_NAME_PREFIX)
+                                                         || moduleName.startsWith(JDK_MODULE_NAME_PREFIX)));
         } else {
             return false;
         }
@@ -398,11 +401,10 @@ public final class JavaRuntime implements ResourceContainer {
 
     private static boolean isHelidonJri(Path jdkDirectory) {
         final Path appDir = jdkDirectory.resolve(APP_DIR);
-        final Path startScript = jdkDirectory.resolve("bin").resolve(StartScript.SCRIPT_FILE_NAME);
-        if (Files.isDirectory(appDir) && Files.exists(startScript)) {
+        if (Files.isDirectory(appDir)) {
             return FileUtils.list(appDir, 2)
                             .stream()
-                            .anyMatch(path -> path.getFileName().toString().startsWith("helidon-"));
+                            .anyMatch(path -> path.getFileName().toString().startsWith(HELIDON_JAR_NAME_PREFIX));
         }
         return false;
     }

--- a/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
@@ -50,7 +50,7 @@ import static io.helidon.linker.util.Constants.JRI_DIR_SUFFIX;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A Java Runtime directory.
+ * Java Runtime metadata.
  */
 public final class JavaRuntime implements ResourceContainer {
     private static final AtomicReference<Path> CURRENT_JAVA_HOME_DIR = new AtomicReference<>();
@@ -76,6 +76,7 @@ public final class JavaRuntime implements ResourceContainer {
     private static final String OPEN_JDK_DEB = "OpenJDK builds on Debian derivatives provide *.jmod files only in the"
                                                + " *-jdk-headless-* packages.";
     private static final Map<String, String> OPEN_JDK_LINUX_PACKAGING = Map.of("yum", OPEN_JDK_RPM,
+                                                                               "apt", OPEN_JDK_DEB,
                                                                                "apt-get", OPEN_JDK_DEB,
                                                                                "dpkg", OPEN_JDK_DEB,
                                                                                "aptitude", OPEN_JDK_DEB);

--- a/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
@@ -63,7 +63,7 @@ public final class JavaRuntime implements ResourceContainer {
     private static final String JAVA_EXEC = OS.javaExecutable();
     private static final String JAVA_CMD_PATH = "bin" + FILE_SEP + JAVA_EXEC;
     private static final String JAVA_MODULE_NAME_PREFIX = "java.";
-    private static final String JDK_MODULE_NAME_PREFIX = "java.";
+    private static final String JDK_MODULE_NAME_PREFIX = "jdk.";
     private static final String HELIDON_JAR_NAME_PREFIX = "helidon-";
     private static final String INVALID_JRI = "This is not a valid JRI (" + JAVA_CMD_PATH + " not found): %s";
     private static final String INCOMPLETE_JDK = "The required *.jmod files (e.g. jmods/%s) are missing in this JDK: %s";

--- a/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
@@ -71,7 +71,8 @@ public final class JavaRuntime implements ResourceContainer {
     private static final String CUSTOM_JRI = "This appears to be a custom JRI.";
     private static final boolean OPEN_JDK = System.getProperty("java.vm.name").toLowerCase(Locale.ENGLISH).contains("openjdk");
     private static final String OPEN_JDK_RPM = "OpenJDK builds on Red Hat derivatives provide *.jmod files in a separate RPM "
-                                               + "package (e.g. java-11-openjdk-jmods.x86_64): try 'yum list | grep jmods'.";
+                                               + "package (e.g. java-11-openjdk-jmods.x86_64): try 'yum list | grep jmods' to "
+                                               + "find the package corresponding to your version.";
     private static final String OPEN_JDK_DEB = "OpenJDK builds on Debian derivatives provide *.jmod files only in the"
                                                + " *-jdk-headless-* packages.";
     private static final Map<String, String> OPEN_JDK_LINUX_PACKAGING = Map.of("yum", OPEN_JDK_RPM,

--- a/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
@@ -47,7 +47,6 @@ import static io.helidon.build.util.FileUtils.fileName;
 import static io.helidon.build.util.FileUtils.findExecutableInPath;
 import static io.helidon.build.util.FileUtils.listFiles;
 import static io.helidon.linker.Application.APP_DIR;
-import static io.helidon.linker.util.Constants.EOL;
 import static io.helidon.linker.util.Constants.JRI_DIR_SUFFIX;
 import static java.util.Objects.requireNonNull;
 
@@ -148,7 +147,7 @@ public final class JavaRuntime implements ResourceContainer {
         final Path result = assertDir(jdkDirectory);
         if (!isValidJdk(result)) {
             final StringBuilder sb = new StringBuilder().append(String.format(INCOMPLETE_JDK, JAVA_BASE_JMOD, jdkDirectory));
-            incompleteJdkDetailMessage(jdkDirectory).ifPresent(detail -> sb.append(EOL).append(detail));
+            incompleteJdkDetailMessage(jdkDirectory).ifPresent(detail -> sb.append(". ").append(detail));
             throw new IllegalArgumentException(sb.toString());
         }
         return result;

--- a/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
+++ b/helidon-linker/src/main/java/io/helidon/linker/util/JavaRuntime.java
@@ -45,6 +45,7 @@ import static io.helidon.build.util.FileUtils.assertFile;
 import static io.helidon.build.util.FileUtils.fileName;
 import static io.helidon.build.util.FileUtils.findExecutableInPath;
 import static io.helidon.build.util.FileUtils.listFiles;
+import static io.helidon.build.util.OSType.Linux;
 import static io.helidon.linker.Application.APP_DIR;
 import static io.helidon.linker.util.Constants.JRI_DIR_SUFFIX;
 import static java.util.Objects.requireNonNull;
@@ -70,11 +71,11 @@ public final class JavaRuntime implements ResourceContainer {
     private static final String HELIDON_JRI = "This is a custom Helidon JRI.";
     private static final String CUSTOM_JRI = "This appears to be a custom JRI.";
     private static final boolean OPEN_JDK = System.getProperty("java.vm.name").toLowerCase(Locale.ENGLISH).contains("openjdk");
-    private static final String OPEN_JDK_RPM = "OpenJDK builds on Red Hat derivatives provide *.jmod files in a separate RPM "
-                                               + "package (e.g. java-11-openjdk-jmods.x86_64): try 'yum list | grep jmods' to "
+    private static final String OPEN_JDK_RPM = "RPM based OpenJDK distributions provide *.jmod files in separate "
+                                               + "\"java-*-openjdk-jmods\" packages: try 'yum list | grep jmods' to "
                                                + "find the package corresponding to your version.";
-    private static final String OPEN_JDK_DEB = "OpenJDK builds on Debian derivatives provide *.jmod files only in the"
-                                               + " *-jdk-headless-* packages.";
+    private static final String OPEN_JDK_DEB = "Debian based OpenJDK distributions provide *.jmod files only in the "
+                                               + "\"openjdk-*-jdk-headless\" packages.";
     private static final Map<String, String> OPEN_JDK_LINUX_PACKAGING = Map.of("yum", OPEN_JDK_RPM,
                                                                                "apt", OPEN_JDK_DEB,
                                                                                "apt-get", OPEN_JDK_DEB,
@@ -378,7 +379,7 @@ public final class JavaRuntime implements ResourceContainer {
             return Optional.of(HELIDON_JRI);
         } else if (isCustomJri(jdkDirectory)) {
             return Optional.of(CUSTOM_JRI);
-        } else if (OPEN_JDK) {
+        } else if (OPEN_JDK && OS == Linux) {
             return OPEN_JDK_LINUX_PACKAGING.entrySet()
                                            .stream()
                                            .filter(e -> findExecutableInPath(e.getKey()).isPresent())

--- a/helidon-linker/src/test/java/io/helidon/linker/LinkerTest.java
+++ b/helidon-linker/src/test/java/io/helidon/linker/LinkerTest.java
@@ -143,7 +143,7 @@ class LinkerTest {
             fail("should have failed");
         } catch (Exception e) {
             String message = e.getMessage();
-            assertThat(message, containsString("jmod files are missing"));
+            assertThat(message, containsString("required *.jmod files (e.g. jmods/java.base.jmod) are missing"));
             assertThat(message, containsString("custom Helidon JRI"));
         }
     }

--- a/helidon-linker/src/test/java/io/helidon/linker/LinkerTest.java
+++ b/helidon-linker/src/test/java/io/helidon/linker/LinkerTest.java
@@ -25,12 +25,15 @@ import java.util.Set;
 import io.helidon.build.test.TestFiles;
 import io.helidon.build.util.FileUtils;
 import io.helidon.linker.util.Constants;
+import io.helidon.linker.util.JavaRuntime;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for class {@link Linker}.
@@ -53,6 +56,7 @@ class LinkerTest {
         assertApplication(jri, mainJar.getFileName().toString());
         assertCdsArchive(jri, false);
         assertScript(jri);
+        assertHelidonJri(jri);
     }
 
     @Test
@@ -94,6 +98,7 @@ class LinkerTest {
         assertApplication(jri, mainJar.getFileName().toString());
         assertCdsArchive(jri, true);
         assertScript(jri);
+        assertHelidonJri(jri);
     }
 
     @Test
@@ -112,6 +117,7 @@ class LinkerTest {
         assertApplication(jri, mainJar.getFileName().toString());
         assertCdsArchive(jri, true);
         assertScript(jri);
+        assertHelidonJri(jri);
     }
 
     private static void assertApplication(Path jri, String mainJarName) throws IOException {
@@ -129,6 +135,17 @@ class LinkerTest {
         Path binDir = FileUtils.assertDir(jri.resolve("bin"));
         Path scriptFile = FileUtils.assertFile(binDir.resolve(Constants.OS.withScriptExtension("start")));
         assertExecutable(scriptFile);
+    }
+
+    private static void assertHelidonJri(Path jri) {
+        try {
+            JavaRuntime.assertJdk(jri);
+            fail("should have failed");
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertThat(message, containsString("jmod files are missing"));
+            assertThat(message, containsString("custom Helidon JRI"));
+        }
     }
 
     private static void assertCdsArchive(Path jri, boolean archiveExists) {

--- a/utils/src/main/java/io/helidon/build/util/FileUtils.java
+++ b/utils/src/main/java/io/helidon/build/util/FileUtils.java
@@ -516,7 +516,7 @@ public final class FileUtils {
      */
     public static Optional<Path> findExecutableInPath(String executableName) {
         return Arrays.stream(requireNonNull(System.getenv(PATH_VAR)).split(File.pathSeparator))
-                     .map(dir -> Paths.get(dir))
+                     .map(Paths::get)
                      .map(path -> path.resolve(executableName))
                      .filter(path -> !Constants.OS.isPosix() || Files.isExecutable(path))
                      .findFirst();


### PR DESCRIPTION
Fixes #324, adding details when OpenJDK is in use on Debian or Red Hat derivatives. Also adds detail when a custom JRI is in use.     