### PR TITLE
Convert uses of ByteArrayOutputStream.toByteArray() to toString() where a String is created.

### DIFF
--- a/helidon-cli/harness/src/test/java/io/helidon/build/cli/harness/ExecTest.java
+++ b/helidon-cli/harness/src/test/java/io/helidon/build/cli/harness/ExecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class ExecTest {
         } finally {
             System.setOut(stdout);
         }
-        String out = Strings.normalizeNewLines(new String(baos.toByteArray(), StandardCharsets.UTF_8));
+        String out = Strings.normalizeNewLines(baos.toString(StandardCharsets.UTF_8));
         return strip(out);
     }
 

--- a/utils/src/main/java/io/helidon/build/util/StreamUtils.java
+++ b/utils/src/main/java/io/helidon/build/util/StreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public final class StreamUtils {
      * @return The string.
      */
     public static String toString(ByteArrayOutputStream out) {
-        return new String(out.toByteArray(), UTF_8);
+        return out.toString(UTF_8);
     }
 
     /**

--- a/utils/src/main/java/io/helidon/build/util/Style.java
+++ b/utils/src/main/java/io/helidon/build/util/Style.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -308,7 +308,10 @@ public class Style {
         try {
             STRIP_BYTES.reset();
             STRIP.write(input.getBytes(UTF_8));
-            return new String(STRIP_BYTES.toByteArray(), UTF_8);
+            // Using new String(toByteArray(), UTF_8) here would result in 2 copies of the bytes, since
+            // the String ctors always create their own copy; by using toString(UTF_8) we avoid a copy
+            // and it is still safe to reuse our stream.
+            return STRIP_BYTES.toString(UTF_8); // always copies
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } finally {


### PR DESCRIPTION
This avoids an extra array copy.