### PR TITLE
Copyright maven plugin.

### DIFF
--- a/copyright-maven-plugin/pom.xml
+++ b/copyright-maven-plugin/pom.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools</groupId>
+        <artifactId>helidon-build-tools-project</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-copyright-plugin</artifactId>
+    <name>Helidon Copyright Plugin</name>
+    <packaging>maven-plugin</packaging>
+
+    <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+        <mainClass>io.helidon.build.copyright.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.build-tools</groupId>
+            <artifactId>helidon-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <configuration>
+                    <goalPrefix>helidon-copyright</goalPrefix>
+                    <skipErrorNoDescriptorsFound>false</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>invoker-install</id>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>invoker-it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <ignoreFailures>false</ignoreFailures>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <pomIncludes>
+                                <pomInclude>projects/*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>verify</goal>
+                            </goals>
+                            <streamLogs>true</streamLogs>
+                            <showErrors>true</showErrors>
+                            <!--suppress UnresolvedMavenProperty, MavenModelInspection -->
+                            <skipInvocation>${skipTests}</skipInvocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>libs</classpathPrefix>
+                            <mainClass>${mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${version.plugin.dependency}</version>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                            <excludeScope>test</excludeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Copyright.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Copyright.java
@@ -75,7 +75,7 @@ public class Copyright {
         // add all validators
         ServiceLoader<ValidatorProvider> loader = ServiceLoader.load(ValidatorProvider.class);
         for (ValidatorProvider validatorProvider : loader) {
-            Validator validator = validatorProvider.validator(builder.validatorConfig);
+            Validator validator = validatorProvider.validator(builder.validatorConfig, builder.templateLines);
             allValidators.add(validator);
             for (String suffix : validator.supportedSuffixes()) {
                 suffixToValidator.putIfAbsent(suffix, validator);
@@ -88,6 +88,7 @@ public class Copyright {
         builtIns.add(new ValidatorProperties(builder.validatorConfig, builder.templateLines));
         builtIns.add(new ValidatorXml(builder.validatorConfig, builder.templateLines));
         builtIns.add(new ValidatorAsciidoc(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorBat(builder.validatorConfig, builder.templateLines));
         this.textValidator = new ValidatorText(builder.validatorConfig, builder.templateLines);
         builtIns.add(this.textValidator);
 

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Copyright.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Copyright.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.helidon.build.util.Log;
+
+/**
+ * Copyright checking.
+ *
+ * @see io.helidon.build.copyright.Copyright.Builder
+ * @see #builder()
+ * @see #check()
+ */
+public class Copyright {
+    // quick lookup of validators that handle a file suffix
+    private final Map<String, Validator> suffixToValidator = new HashMap<>();
+    // list of all validators for files not handled by a specific one
+    private final List<Validator> allValidators = new LinkedList<>();
+
+    private final boolean checkFormatOnly;
+    private final Path rootPath;
+    private final Path checkPath;
+    private final List<Exclude> excludes;
+    private final String masterBranch;
+    private final boolean checkAll;
+    private final boolean scmOnly;
+    private final String currentYear;
+    private final Validator textValidator;
+
+    private Copyright(Builder builder) {
+        this.checkFormatOnly = builder.checkFormatOnly;
+        this.rootPath = builder.root;
+        this.checkPath = builder.checkPath;
+        this.excludes = builder.excludes;
+        this.masterBranch = builder.masterBranch;
+        this.scmOnly = builder.scmOnly;
+        this.checkAll = builder.checkAll;
+        this.currentYear = builder.currentYear;
+
+        // add all validators
+        ServiceLoader<ValidatorProvider> loader = ServiceLoader.load(ValidatorProvider.class);
+        for (ValidatorProvider validatorProvider : loader) {
+            Validator validator = validatorProvider.validator(builder.validatorConfig);
+            allValidators.add(validator);
+            for (String suffix : validator.supportedSuffixes()) {
+                suffixToValidator.putIfAbsent(suffix, validator);
+            }
+        }
+        // now add built-in validators
+        List<Validator> builtIns = new LinkedList<>();
+
+        builtIns.add(new ValidatorJava(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorProperties(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorXml(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorAsciidoc(builder.validatorConfig, builder.templateLines));
+        this.textValidator = new ValidatorText(builder.validatorConfig, builder.templateLines);
+        builtIns.add(this.textValidator);
+
+        for (Validator validator : builtIns) {
+            allValidators.add(validator);
+            for (String suffix : validator.supportedSuffixes()) {
+                suffixToValidator.putIfAbsent(suffix, validator);
+            }
+        }
+
+    }
+
+    static String logGood(String good) {
+        return "\"$(GREEN " + good.replace(")", "\\)") + ")\"";
+    }
+
+    static String logBad(String bad) {
+        return "\"$(YELLOW " + bad.replace(")", "\\)") + ")\"";
+    }
+
+    /**
+     * Check copyrights of files and return a list of found problems.
+     *
+     * @return list of problems
+     */
+    public List<String> check() {
+        List<String> messages = new LinkedList<>();
+
+        // find files to check and their last modified year (if checking year as well)
+        List<ValidPath> validPaths = findFilesToCheck(messages);
+
+        if (!messages.isEmpty()) {
+            return messages;
+        }
+
+        // perform copyright check on all files
+        for (ValidPath validPath : validPaths) {
+            checkCopyright(validPath, messages);
+        }
+
+        return messages;
+    }
+
+    private void checkCopyright(ValidPath validPath, List<String> messages) {
+        Path path = validPath.file.path();
+        String relativePath = validPath.file.relativePath();
+
+        if (!Files.isReadable(path)) {
+            messages.add(relativePath + ": not readable");
+            return;
+        }
+        if (FileSystem.size(path) == 0L) {
+            Log.debug(relativePath + ": ignoring empty file");
+            return;
+        }
+
+        Validator validator = suffixToValidator.get(validPath.file.suffix());
+        if (validator == null) {
+            for (Validator candidate : allValidators) {
+                if (candidate.supports(path)) {
+                    validator = candidate;
+                    break;
+                }
+            }
+        }
+        if (validator == null) {
+            Log.debug(relativePath + ": using fallback text validator.");
+            validator = textValidator;
+        }
+
+        Log.verbose(relativePath + " checking copyright with " + validator.getClass().getName());
+        Optional<String> validate = validator.validate(path, validPath.modifiedYear);
+        validate.ifPresent(s -> messages.add("$(CYAN " + relativePath + "): " + s));
+    }
+
+    private List<ValidPath> findFilesToCheck(List<String> messages) {
+
+        // we need to find the complete list of files to check
+        Set<String> filesToCheck;
+        Set<String> locallyModified;
+        if (checkAll) {
+            if (checkFormatOnly) {
+                locallyModified = Set.of();
+            } else {
+                locallyModified = Git.locallyModified(rootPath, checkPath);
+            }
+            if (scmOnly) {
+                filesToCheck = new HashSet<>();
+                filesToCheck.addAll(Git.gitTracked(rootPath, checkPath));
+                filesToCheck.addAll(locallyModified);
+            } else {
+                filesToCheck = findAllFiles(rootPath, checkPath);
+            }
+        } else {
+            locallyModified = Git.locallyModified(rootPath, checkPath);
+            Set<String> gitModified = Git.gitModified(rootPath, checkPath, masterBranch);
+            filesToCheck = new HashSet<>(locallyModified);
+            filesToCheck.addAll(gitModified);
+        }
+
+        List<ValidPath> validPaths = new LinkedList<>();
+
+        for (String relativePath : filesToCheck) {
+            addValidFile(relativePath, locallyModified, validPaths, messages);
+        }
+
+        return validPaths;
+    }
+
+    private static Set<String> findAllFiles(Path rootPath,
+                                            Path checkPath) {
+        Set<String> result = new HashSet<>();
+
+        try {
+            Files.walkFileTree(checkPath, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    result.add(rootPath.relativize(file).toString());
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to list files", e);
+        }
+
+        return result;
+    }
+
+    private void addValidFile(String relativePath,
+                              Set<String> modified,
+                              List<ValidPath> validPaths,
+                              List<String> messages) {
+
+        FileRequest file = FileRequest.create(rootPath, relativePath);
+
+        for (Exclude exclude : excludes) {
+            if (exclude.exclude(file)) {
+                Log.debug("Excluding " + relativePath);
+                return;
+            }
+        }
+
+        if (checkFormatOnly) {
+            // we do not care about year
+            validPaths.add(new ValidPath(file, currentYear));
+            return;
+        }
+
+        if (modified.contains(relativePath)) {
+            Log.debug("Including " + relativePath + " with current year (" + currentYear
+                              + "), as file is locally modified");
+            validPaths.add(new ValidPath(file, currentYear));
+        } else {
+            // now I need to get last modified date from git
+            Git.yearModified(rootPath, relativePath, messages)
+                    .ifPresent(year -> {
+                        Log.debug("Including " + relativePath + " with git modified year (" + year + ")");
+                        validPaths.add(new ValidPath(file, year));
+                    });
+        }
+    }
+
+    /**
+     * Fluent API builder for {@link io.helidon.build.copyright.Copyright}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link io.helidon.build.copyright.Copyright}.
+     */
+    public static class Builder {
+        private static final DateTimeFormatter YEAR_FORMATTER = DateTimeFormatter.ofPattern("yyyy");
+
+        private final String currentYear = YEAR_FORMATTER.format(ZonedDateTime.now());
+        private final Validator.ValidatorConfig.Builder validatorConfigBuilder = Validator.ValidatorConfig.builder();
+        // values with defaults
+        private String masterBranch = "master";
+        private String yearSeparator = ", ";
+        private boolean checkFormatOnly = false;
+        private boolean checkAll = false;
+        private boolean scmOnly = true;
+
+        // values that must be provided
+        private Path root;
+        private Path checkPath;
+        private Path excludesFile;
+        private Path templateFile;
+        private List<Exclude> excludes;
+
+        private Validator.ValidatorConfig validatorConfig;
+        private List<TemplateLine> templateLines;
+
+        private Builder() {
+        }
+
+        public Copyright build() {
+            if (checkPath == null) {
+                throw new CopyrightException("The directory to check must be defined");
+            }
+
+            validatorConfig = validatorConfigBuilder
+                    .checkFormatOnly(checkFormatOnly)
+                    .yearSeparator(yearSeparator)
+                    .build();
+
+            if (templateFile == null) {
+                Log.verbose("Parsing default template file (Apache 2).");
+                this.templateLines = TemplateLine.parseTemplate(validatorConfig, defaultCopyrightTemplate());
+            } else {
+                Log.verbose("Parsing template file: " + templateFile.toAbsolutePath());
+                this.templateLines = TemplateLine.parseTemplate(validatorConfig, FileSystem.toLines(templateFile));
+            }
+
+            excludes = parseExcludes();
+            root = Git.repositoryRoot(checkPath);
+            return new Copyright(this);
+        }
+
+        private List<String> defaultCopyrightTemplate() {
+            InputStream is = Copyright.class.getResourceAsStream("apache.txt");
+
+            List<String> lines = new LinkedList<>();
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    lines.add(line);
+                }
+            } catch (IOException e) {
+                throw new CopyrightException("Failed to read default template from classpath");
+            }
+            return lines;
+        }
+
+        /**
+         * Git branch to check from, defaults to {@code master}.
+         *
+         * @param masterBranch name of the master branch
+         * @return updated builder
+         */
+        public Builder masterBranch(String masterBranch) {
+            this.masterBranch = masterBranch;
+            return this;
+        }
+
+        /**
+         * Path to check.
+         *
+         * @param checkPath directory to check
+         * @return updated builder
+         */
+        public Builder path(Path checkPath) {
+            this.checkPath = checkPath;
+            return this;
+        }
+
+        /**
+         * File with excludes.
+         *
+         * @param excludesFile excludes file
+         * @return updated builder
+         */
+        public Builder excludesFile(Path excludesFile) {
+            this.excludesFile = excludesFile;
+            return this;
+        }
+
+        /**
+         * File with copyright template.
+         *
+         * @param templateFile template file
+         * @return updated builder
+         */
+        public Builder templateFile(Path templateFile) {
+            this.templateFile = templateFile;
+            return this;
+        }
+
+        /**
+         * Year separator, defaults to {@code , }.
+         * The result is {@code 2019, 2021}.
+         * Only the first and last year are used.
+         *
+         * @param yearSeparator separator of years
+         * @return updated builder
+         */
+        public Builder yearSeparator(String yearSeparator) {
+            this.yearSeparator = yearSeparator;
+            return this;
+        }
+
+        /**
+         * Whether to only check format, or also year (default).
+         *
+         * @param checkFormatOnly whether to check format only, defaults to {@code false}
+         * @return updated builder
+         */
+        public Builder checkFormatOnly(boolean checkFormatOnly) {
+            this.checkFormatOnly = checkFormatOnly;
+            return this;
+        }
+
+        /**
+         * Whether to check all files, or only modified (default).
+         *
+         * @param checkAll whether to check all files, defaults to {@code false}
+         * @return updated builder
+         */
+        public Builder checkAll(boolean checkAll) {
+            this.checkAll = checkAll;
+            return this;
+        }
+
+        /**
+         * Only include files that are version managed by git.
+         * This is ignored unless {@link #checkAll(boolean)} is set to {@code true}.
+         *
+         * @param scmOnly only check files that are version managed by git, defaults to {@code true}
+         * @return updated builder
+         */
+        public Builder scmOnly(boolean scmOnly) {
+            this.scmOnly = scmOnly;
+            return this;
+        }
+
+        private List<Exclude> parseExcludes() {
+            if (excludesFile == null) {
+                return List.of();
+            }
+
+            try {
+                Log.verbose("Parsing exclude file: " + excludesFile.toAbsolutePath());
+                return Files.readAllLines(excludesFile)
+                        .stream()
+                        .map(String::trim)
+                        .filter(it -> !it.startsWith("#"))
+                        .filter(it -> !it.isBlank())
+                        .map(Exclude::create)
+                        .collect(Collectors.toList());
+            } catch (IOException e) {
+                throw new CopyrightException("Failed to parse excludes file: " + excludesFile, e);
+            }
+        }
+    }
+
+    private static class ValidPath {
+        private final FileRequest file;
+        private final String modifiedYear;
+
+        ValidPath(FileRequest file, String modifiedYear) {
+            this.file = file;
+            this.modifiedYear = modifiedYear;
+        }
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Copyright.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Copyright.java
@@ -287,6 +287,11 @@ public class Copyright {
         private Builder() {
         }
 
+        /**
+         * Build a new copyright.
+         *
+         * @return copyright from this builder
+         */
         public Copyright build() {
             if (checkPath == null) {
                 throw new CopyrightException("The directory to check must be defined");

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/CopyrightException.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/CopyrightException.java
@@ -19,7 +19,7 @@ package io.helidon.build.copyright;
 /**
  * Exception thrown by copyright checking.
  */
-public class CopyrightException extends RuntimeException{
+public class CopyrightException extends RuntimeException {
     /**
      * Exception with message.
      * @param message message

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/CopyrightException.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/CopyrightException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+/**
+ * Exception thrown by copyright checking.
+ */
+public class CopyrightException extends RuntimeException{
+    /**
+     * Exception with message.
+     * @param message message
+     */
+    public CopyrightException(String message) {
+        super(message);
+    }
+
+    /**
+     * Exception with message and cause.
+     *
+     * @param message message
+     * @param cause cause
+     */
+    public CopyrightException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/CopyrightMojo.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/CopyrightMojo.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import io.helidon.build.util.Log;
+import io.helidon.build.util.MavenLogWriter;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Copyright check plugin.
+ *
+ */
+@Mojo(name = "check",
+      defaultPhase = LifecyclePhase.VALIDATE,
+      threadSafe = true)
+public class CopyrightMojo extends AbstractMojo {
+    /**
+     * Skip execution for this plugin.
+     */
+    @Parameter(defaultValue = "false", property = "log.skip")
+    private boolean skip;
+
+    /**
+     * Fail if copyright is invalid.
+     */
+    @Parameter(property = "failOnError", defaultValue = "false")
+    private Boolean failOnError;
+
+    /**
+     * Base directory for project.
+     */
+    @Parameter(defaultValue = "${project.basedir}")
+    private File baseDirectory;
+
+    /**
+     * File with the template to use for copyright.
+     */
+    @Parameter(property = "copyright.template")
+    private File templateFile;
+
+    /**
+     * File with excludes.
+     */
+    @Parameter(property = "copyright.exclude")
+    private File excludeFile;
+
+    /**
+     * Git branch to check changes (the current branch must have this branch in its history).
+     * Defaults to {@code master}.
+     */
+    @Parameter(property = "copyright.branch", defaultValue = "master")
+    private String gitBranch;
+
+    /**
+     * Copyright year separator.
+     */
+    @Parameter(property = "copyright.year-separator", defaultValue = ", ")
+    private String yearSeparator;
+
+    /**
+     * Whether to use only files tracked by git.
+     */
+    @Parameter(property = "copyright.scm-only", defaultValue = "true")
+    private boolean scmOnly;
+
+    /**
+     * Whether to only check format and ignore year.
+     */
+    @Parameter(property = "copyright.check-format-only", defaultValue = "false")
+    private boolean checkFormatOnly;
+
+    /**
+     * Whether to check all files, including unmodified ones.
+     */
+    @Parameter(property = "copyright.check-all", defaultValue = "false")
+    private boolean checkAll;
+
+    /**
+     * The {@link MavenSession}.
+     */
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping execution.");
+            return;
+        }
+
+        Path path = baseDirectory.toPath().toAbsolutePath();
+        Path rootDir = Paths.get(session.getExecutionRootDirectory());
+
+        if (!path.equals(rootDir) && path.startsWith(rootDir)) {
+            // this is not the root dir, and the root dir is my parent
+            getLog().info("Parent path " + rootDir + " already checked");
+            return;
+        }
+
+        getLog().info("Checking copyright for " + path);
+
+        MavenLogWriter.install(getLog());
+
+        Copyright.Builder builder = Copyright.builder()
+                .checkAll(checkAll)
+                .checkFormatOnly(checkFormatOnly)
+                .scmOnly(scmOnly)
+                .yearSeparator(yearSeparator)
+                .masterBranch(gitBranch)
+                .path(path);
+
+        if (templateFile != null) {
+            builder.templateFile(templateFile.toPath());
+        }
+        if (excludeFile != null) {
+            builder.excludesFile(excludeFile.toPath());
+        }
+
+        List<String> errors;
+        try {
+            errors = builder.build().check();
+        } catch (CopyrightException e) {
+            throw new MojoFailureException("Failed to validate copyright", e);
+        }
+
+        if (errors.isEmpty()) {
+            return;
+        }
+
+        Log.Level logLevel;
+        if (failOnError) {
+            logLevel = Log.Level.ERROR;
+        } else {
+            logLevel = Log.Level.WARN;
+        }
+
+        Log.log(logLevel, "Copyright failures:");
+        for (String error : errors) {
+            Log.log(logLevel, error);
+        }
+
+        if (failOnError) {
+            throw new MojoExecutionException("Failed to validate copyright.");
+        }
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Exclude.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Exclude.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+interface Exclude {
+    /**
+     *
+     * @param file file information
+     * @return true if the file matches current exclude
+     */
+    boolean exclude(FileRequest file);
+
+    static Exclude create(String line) {
+        // if starts with ., it is a suffix
+        if (line.startsWith(".")) {
+            // .ico
+            return new SuffixExclude(line);
+        }
+        if (line.startsWith("/")) {
+            // /etc/txt - from repo root
+            return new StartsWithExclude(line.substring(1));
+        }
+        if (line.endsWith("/")) {
+            // src/main/proto/
+            return new DirectoryExclude(line);
+        }
+        if (line.contains(".") && !line.contains("/")) {
+            // jaxb.index
+            return new NameExclude(line);
+        }
+        return new ContainsExclude(line);
+    }
+
+    class StartsWithExclude implements Exclude {
+        // exact path from repository root, such as /etc/copyright.txt
+        private final String exclude;
+
+        StartsWithExclude(String exclude) {
+            this.exclude = exclude;
+        }
+
+        @Override
+        public boolean exclude(FileRequest file) {
+            return file.relativePath().startsWith(exclude);
+        }
+    }
+
+    class DirectoryExclude implements Exclude {
+        private final ContainsExclude contains;
+        private final StartsWithExclude startWith;
+
+        DirectoryExclude(String directory) {
+            // either the directory is within the tree
+            this.contains = new ContainsExclude("/" + directory);
+            // or the tree starts with it
+            this.startWith = new StartsWithExclude(directory);
+        }
+
+        @Override
+        public boolean exclude(FileRequest file) {
+            return contains.exclude(file) || startWith.exclude(file);
+        }
+    }
+
+    class ContainsExclude implements Exclude {
+        // such as /src/main/proto/
+        private final String contains;
+
+        ContainsExclude(String contains) {
+            this.contains = contains;
+        }
+
+        @Override
+        public boolean exclude(FileRequest file) {
+            return file.relativePath().contains(contains);
+        }
+    }
+
+    class NameExclude implements Exclude {
+        private final String name;
+
+        NameExclude(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean exclude(FileRequest file) {
+            return file.fileName().equals(name);
+        }
+    }
+
+    class SuffixExclude implements Exclude {
+        private final String suffix;
+
+        SuffixExclude(String suffix) {
+            this.suffix = suffix;
+        }
+
+        @Override
+        public boolean exclude(FileRequest file) {
+            return file.suffix().equals(suffix);
+        }
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/FileRequest.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/FileRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.nio.file.Path;
+
+/**
+ * Information about the current file.
+ */
+public class FileRequest {
+    private final Path path;
+    private final String relativePath;
+    private final String fileName;
+    private final String suffix;
+
+    private FileRequest(Path path, String relativePath, String fileName, String suffix) {
+        this.path = path;
+        this.relativePath = relativePath;
+        this.fileName = fileName;
+        this.suffix = suffix;
+    }
+
+    /**
+     * @param rootPath root path of the repository
+     * @param relativePath relative path from the rootPath
+     * @return a new file request
+     */
+    static FileRequest create(Path rootPath, String relativePath) {
+        Path file = rootPath.resolve(relativePath);
+        String fileName = file.getFileName().toString();
+        String fileSuffix = fileSuffix(fileName);
+
+        return new FileRequest(file, relativePath, fileName, fileSuffix);
+    }
+
+    // testing only
+    static FileRequest create(String relativePath) {
+        int i = relativePath.lastIndexOf('/');
+        String fileName;
+        if (i > -1) {
+            fileName = relativePath.substring(i + 1);
+        } else {
+            fileName = relativePath;
+        }
+
+        return new FileRequest(null, relativePath, fileName, fileSuffix(fileName));
+    }
+
+    /**
+     * Full path to the file.
+     *
+     * @return path
+     */
+    public Path path() {
+        return path;
+    }
+
+    /**
+     * Relative path string, not starting with /, using forward slash as path separator.
+     *
+     * @return relative path
+     */
+    public String relativePath() {
+        return relativePath;
+    }
+
+    /**
+     * File name (such as "README.md").
+     *
+     * @return name of the file
+     */
+    public String fileName() {
+        return fileName;
+    }
+
+    /**
+     * File suffix (such as ".md"), including the leading dot.
+     *
+     * @return file suffix
+     */
+    public String suffix() {
+        return suffix;
+    }
+
+    private static String fileSuffix(String fileName) {
+        int index = fileName.lastIndexOf('.');
+        if (index < 0) {
+            return "";
+        }
+        return fileName.substring(index);
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/FileSystem.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/FileSystem.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+// file system utilities
+final class FileSystem {
+    private FileSystem() {
+    }
+
+    static long size(Path path) {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to get size of file " + path.toAbsolutePath(), e);
+        }
+    }
+
+    static List<String> toLines(Path path) {
+        try {
+            return Files.readAllLines(path, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to read lines of file " + path.toAbsolutePath(), e);
+        }
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Git.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Git.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+// git utility class
+final class Git {
+    private static final Pattern DATE_PATTERN = Pattern.compile("(\\d\\d\\d\\d)-\\d\\d-\\d\\d");
+
+    private Git() {
+    }
+
+    static Path repositoryRoot(Path checkPath) {
+        ProcessBuilder processBuilder = new ProcessBuilder("git",
+                                                           "rev-parse",
+                                                           "--show-toplevel")
+                .redirectErrorStream(true)
+                .directory(checkPath.toFile());
+
+        Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to start git process to find modified year", e);
+        }
+
+        // git rev-parse --show-toplevel
+        // /a/b/c/repo-root
+
+        // no input from our side
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+        }
+
+        List<String> output = new LinkedList<>();
+        Path path;
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line = reader.readLine();
+
+            // this should be exactly one line
+            if (line == null) {
+                throw new CopyrightException(
+                        "Failed to find git repository root, no output for command"
+                                + " \"git rev-parse --show-toplevel\" in directory "
+                                + checkPath.toAbsolutePath());
+            } else {
+                String trimmed = line.trim();
+
+                path = Paths.get(trimmed);
+                if (!Files.exists(path)) {
+                    output.add(line);
+                    while ((line = reader.readLine()) != null) {
+                        output.add(line);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to read output of git process", e);
+        }
+
+        try {
+            int i = process.waitFor();
+            if (i != 0) {
+                throw new CopyrightException("Failed to find locally modified files, git exit code: " + i + ", process output: "
+                                                     + output);
+            }
+        } catch (InterruptedException ex) {
+            throw new CopyrightException("Git process was interrupted", ex);
+        }
+
+        if (output.isEmpty()) {
+            return path;
+        }
+        throw new CopyrightException("Git root directory " + path.toAbsolutePath() + " does not exist. Full output: " + output);
+    }
+
+    static Optional<String> yearModified(Path root, String relativePath, List<String> messages) {
+        ProcessBuilder processBuilder = new ProcessBuilder("git",
+                                                           "log",
+                                                           "-1",
+                                                           "--pretty=%cd",
+                                                           "--date=short",
+                                                           relativePath)
+                .redirectErrorStream(true)
+                .directory(root.toFile());
+
+        Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to start git process to find modified year", e);
+        }
+
+        // git log -1 --pretty="%cd" --date=short pom.xml
+        // 2021-03-30
+
+        // no input from our side
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+        }
+
+        String year = null;
+
+        List<String> output = new LinkedList<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line = reader.readLine();
+
+            // this should be exactly one line
+            if (line == null) {
+                messages.add("Failed to read timestamp from git for " + relativePath);
+            } else {
+                String trimmed = line.trim();
+                Matcher matcher = DATE_PATTERN.matcher(trimmed);
+                if (matcher.matches()) {
+                    year = matcher.group(1);
+                } else {
+                    messages.add("Failed to read timestamp from git for " + relativePath + ", got " + line);
+                    output.add(line);
+                    while ((line = reader.readLine()) != null) {
+                        output.add(line);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to read output of git process", e);
+        }
+
+        try {
+            int i = process.waitFor();
+            if (i != 0) {
+                throw new CopyrightException("Failed to find locally modified files, git exit code: " + i + ", process output: "
+                                                     + output);
+            }
+        } catch (InterruptedException ex) {
+            throw new CopyrightException("Git process was interrupted", ex);
+        }
+
+        return Optional.ofNullable(year);
+    }
+
+    static Set<String> gitTracked(Path root, Path checkPath) {
+        ProcessBuilder processBuilder = new ProcessBuilder("git",
+                                                           "ls-tree",
+                                                           "-r",
+                                                           "HEAD",
+                                                           "--name-only")
+                .redirectErrorStream(true)
+                .directory(root.toFile());
+
+        Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to start git process to get modified files", e);
+        }
+
+        // no input from our side
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+        }
+
+        Set<String> changedFiles = new HashSet<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String trimmed = line.trim();
+                if (trimmed.isBlank()) {
+                    // commit line (would contain id and message, but now it is empty thanks to formatting
+                    continue;
+                }
+                changedFiles.add(trimmed.replace('\\', '/'));
+            }
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to read output of git process", e);
+        }
+
+        try {
+            int i = process.waitFor();
+            if (i != 0) {
+                throw new CopyrightException("Failed to read modified files, git exit code: " + i + ", process output: " + changedFiles);
+            }
+        } catch (InterruptedException ex) {
+            throw new CopyrightException("Process to get modified files was interrupted", ex);
+        }
+
+        // changed files are relative to the root, we need to filter our changed files outside of check path
+        String prefix = root.relativize(checkPath).toString();
+
+        return changedFiles.stream()
+                .filter(relativePath -> relativePath.startsWith(prefix))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Files modified in commits from a branch.
+     *
+     * @param root the root directory
+     * @param checkPath directory of interest
+     * @param branchName name of master branch
+     * @return set of files in the directory of interest that were modified since the master branch
+     */
+    static Set<String> gitModified(Path root, Path checkPath, String branchName) {
+        ProcessBuilder processBuilder = new ProcessBuilder("git",
+                                                           "log",
+                                                           "--no-merges",
+                                                           "--pretty=",
+                                                           "--name-only",
+                                                           branchName + "..")
+                .redirectErrorStream(true)
+                .directory(root.toFile());
+
+        Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to start git process to get modified files", e);
+        }
+
+        // no input from our side
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+        }
+
+        Set<String> changedFiles = new HashSet<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String trimmed = line.trim();
+                if (trimmed.isBlank()) {
+                    // commit line (would contain id and message, but now it is empty thanks to formatting
+                    continue;
+                }
+                changedFiles.add(trimmed.replace('\\', '/'));
+            }
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to read output of git process", e);
+        }
+
+        try {
+            int i = process.waitFor();
+            if (i != 0) {
+                throw new CopyrightException("Failed to read modified files, git exit code: " + i + ", process output: " + changedFiles);
+            }
+        } catch (InterruptedException ex) {
+            throw new CopyrightException("Process to get modified files was interrupted", ex);
+        }
+
+        // changed files are relative to the root, we need to filter our changed files outside of check path
+        String prefix = root.relativize(checkPath).toString();
+
+        return changedFiles.stream()
+                .filter(relativePath -> relativePath.startsWith(prefix))
+                .collect(Collectors.toSet());
+    }
+
+    static Set<String> locallyModified(Path root, Path checkPath) {
+        ProcessBuilder processBuilder = new ProcessBuilder("git", "status", "-s")
+                .redirectErrorStream(true)
+                .directory(root.toFile());
+
+        Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to start git process to find locally modified files", e);
+        }
+
+        // no input from our side
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+        }
+
+        Set<String> changedFiles = new HashSet<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("M") || trimmed.startsWith("A")) {
+                    changedFiles.add(trimmed.substring(1).trim().replace('\\', '/'));
+                }
+            }
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to read output of git command", e);
+        }
+
+        try {
+            int i = process.waitFor();
+            if (i != 0) {
+                throw new CopyrightException("Failed to find locally modified files, git exit code: " + i + ", process output: "
+                                                     + changedFiles);
+            }
+        } catch (InterruptedException ex) {
+            throw new CopyrightException("Git process was interrupted", ex);
+        }
+
+        // changed files are relative to the root, we need to filter our changed files outside of check path
+        String prefix = root.relativize(checkPath).toString();
+
+        return changedFiles.stream()
+                .filter(relativePath -> relativePath.startsWith(prefix))
+                .collect(Collectors.toSet());
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Git.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Git.java
@@ -211,7 +211,8 @@ final class Git {
         try {
             int i = process.waitFor();
             if (i != 0) {
-                throw new CopyrightException("Failed to read modified files, git exit code: " + i + ", process output: " + changedFiles);
+                throw new CopyrightException("Failed to read modified files, git exit code: "
+                                                     + i + ", process output: " + changedFiles);
             }
         } catch (InterruptedException ex) {
             throw new CopyrightException("Process to get modified files was interrupted", ex);
@@ -275,7 +276,8 @@ final class Git {
         try {
             int i = process.waitFor();
             if (i != 0) {
-                throw new CopyrightException("Failed to read modified files, git exit code: " + i + ", process output: " + changedFiles);
+                throw new CopyrightException("Failed to read modified files, git exit code: "
+                                                     + i + ", process output: " + changedFiles);
             }
         } catch (InterruptedException ex) {
             throw new CopyrightException("Process to get modified files was interrupted", ex);

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Main.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Main.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+import io.helidon.build.util.Log;
+import io.helidon.build.util.SystemLogWriter;
+
+/**
+ * Main class for copyright checking. The path to check must be a git repository (or a path within a git repository),
+ * otherwise you can only use mode that scans all files and ignores SCM ({@code -y -a}).
+ *
+ * This file will use Java Util Logging, so verbosity can be controlled through it.
+ * <p>
+ * Usage: {@code java -jar this-library.jar [options] directory?}
+ * <p>
+ * Options:
+ * <ul>
+ *     <li>{@code -C file.txt} - path to copyright template with YYYY placeholder for line containing licensor and copyright
+ *     year</li>
+ *     <li>{@code -X file.txt} - path to excludes file, defaults to no excludes</li>
+ *     <li>{@code -b master} - name of the git branch to find changes from, defaults to {@code master}</li>
+ *     <li>{@code -Y "-"} - year separator, defaults to {@code ", "} - quotes are stripped</li>
+ *     <li>{@code -y} - check format only (ignore last modification timestamp), by default the copyright year is checked</li>
+ *     <li>{@code -a} - check all files ignoring if modified, by default only modified files are checked</li>
+ *     <li>{@code -S} - check all files, even files not under source control, by default only files known by git are checked</li>
+ *     <li>{@code -v} - verbose output</li>
+ *     <li>{@code -d} - debug output</li>
+ *     <li>directory - if not defined, current directory is used</li>
+ * </ul>
+ *
+ * Example template file (very simple):
+ * <code><pre>
+ * Copyright (c) YYYY Oracle and/or its affiliates.
+ *
+ * This program is made available under the Apache 2.0 license.
+ * </pre></code>
+ */
+public class Main {
+    /**
+     * Invoke the copyright check.
+     *
+     * @param args options as documented on {@link io.helidon.build.copyright.Main}
+     */
+    public static void main(String[] args) {
+        SystemLogWriter.install(Log.Level.INFO);
+
+        Copyright.Builder builder = Copyright.builder();
+        boolean verbose = false;
+        boolean debug = false;
+        builder.path(Paths.get(".").toAbsolutePath());
+
+        for (int optionIndex = 0; optionIndex < args.length; optionIndex++) {
+            String option = args[optionIndex];
+
+            switch (option) {
+            case "-C":
+                // copyright template
+                String templatePath = nextArg("-C", ++optionIndex, args, "Copyright template path");
+                builder.templateFile(Paths.get(templatePath));
+                break;
+            case "-X":
+                // exclude file
+                String excludeFile = nextArg("-X", ++optionIndex, args, "Copyright exclude file path");
+                builder.excludesFile(Paths.get(excludeFile));
+                break;
+            case "-b":
+                // branch name
+                String branchName = nextArg("-b", ++optionIndex, args, "git branch name");
+                builder.masterBranch(branchName);
+                break;
+            case "-Y":
+                // year separator
+                String yearSeparator = nextArg("-Y", ++optionIndex, args, "year separator");
+                builder.yearSeparator(yearSeparator);
+                break;
+            case "-S":
+                builder.scmOnly(false);
+                break;
+            case "-y":
+                builder.checkFormatOnly(true);
+                break;
+            case "-a":
+                builder.checkAll(true);
+                break;
+            case "-v":
+                verbose = true;
+                break;
+            case "-d":
+                debug = true;
+                break;
+            case "--help":
+            case "-h":
+            case "/?":
+                help();
+                return;
+            default:
+                if (option.startsWith("-")) {
+                    // unknown option
+                    unknownOption(option);
+                }
+                // path (but only if last option)
+                if (optionIndex == args.length - 1) {
+                    builder.path(Paths.get(option).toAbsolutePath());
+                } else {
+                    unknownOption(option);
+                }
+                break;
+            }
+        }
+
+        if (debug) {
+            SystemLogWriter.install(Log.Level.DEBUG);
+        } else if (verbose) {
+            SystemLogWriter.install(Log.Level.VERBOSE);
+        }
+
+        Copyright copyright = builder.build();
+
+        List<String> errors = copyright.check();
+        if (errors.isEmpty()) {
+            Log.info("Copyright OK");
+            return;
+        }
+
+        Log.error("Copyright failures:");
+        for (String error : errors) {
+            Log.error(error);
+        }
+
+        System.exit(147);
+    }
+
+    private static void unknownOption(String option) {
+        System.err.println("Unknown option " + option);
+        help();
+        System.exit(12);
+    }
+
+    private static void help() {
+        System.out.println("Usage: copyright [options] directory?");
+        System.out.println("Options:");
+        helpOption("-C", "path", "Copyright template file path");
+        helpOption("-X", "path", "Copyright excludes file path");
+        helpOption("-b", "branch", "Git branch to find changed since");
+        helpOption("-Y", "text", "Year separator in copyright statement");
+        helpOption("-S", "Check all files, not just Git tracked, only with -a");
+        helpOption("-y", "Only check format, ignore last modified year");
+        helpOption("-a", "Check all files, not just modified ones");
+        helpOption("-d", "Enable debug output");
+        helpOption("-v", "Enable verbose output (less than debug)");
+        helpOption("-h", "Print this help information");
+    }
+
+    private static void helpOption(String flag, String description) {
+        System.out.println("  " + flag + "        " + description);
+    }
+
+    private static void helpOption(String flag, String value, String description) {
+        String filler = " ".repeat(7 - value.length());
+        System.out.println("  " + flag + " " + value + filler + description);
+    }
+
+    private static String nextArg(String flag, int index, String[] args, String description) {
+        if (args.length <= index) {
+            System.err.println("Option " + flag + " requires a value: " + description);
+            System.exit(13);
+        }
+        return args[index];
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Main.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Main.java
@@ -52,7 +52,10 @@ import io.helidon.build.util.SystemLogWriter;
  * This program is made available under the Apache 2.0 license.
  * </pre></code>
  */
-public class Main {
+public final class Main {
+    private Main() {
+    }
+
     /**
      * Invoke the copyright check.
      *

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/TemplateLine.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/TemplateLine.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.build.util.Log;
+
+import static io.helidon.build.copyright.Copyright.logBad;
+import static io.helidon.build.copyright.Copyright.logGood;
+
+/**
+ * Represents a single line in a template to easily validate files.
+ * The line may be blank, text, or copyright line with year information
+ */
+public abstract class TemplateLine {
+    /**
+     * Validate an actual line against this template line.
+     *
+     * @param actualLine line to validate
+     * @param expectedYear expected year in copyright (unless validating only format)
+     * @param lineNumber line number within the copyright comment
+     * @return problem with copyright if discovered, empty if OK
+     */
+    public abstract Optional<String> validate(String actualLine, String expectedYear, int lineNumber);
+
+    /**
+     * Parse template lines. If the template does not contain a line with year, it will be added as
+     * the first line.
+     *
+     * @param config validator configuration
+     * @param lines lines of the copyright template
+     * @return template lines
+     */
+    public static List<TemplateLine> parseTemplate(Validator.ValidatorConfig config, List<String> lines) {
+        List<TemplateLine> templateLines = new ArrayList<>(lines.size() + 1);
+
+        boolean hasCopyright = false;
+
+        for (String line : lines) {
+            if (line.contains("YYYY")) {
+                templateLines.add(new CopyrightLine(config, line));
+                hasCopyright = true;
+                continue;
+            }
+            if (line.isBlank()) {
+                templateLines.add(new BlankLine());
+                continue;
+            }
+
+            templateLines.add(new TextLine(line));
+        }
+
+        if (!hasCopyright) {
+            templateLines.add(0, new CopyrightLine(config));
+        }
+
+        return templateLines;
+    }
+
+    private static class TextLine extends TemplateLine {
+        private final String line;
+
+        private TextLine(String line) {
+            this.line = line;
+        }
+
+        @Override
+        public Optional<String> validate(String actualLine, String expectedYear, int lineNumber) {
+            if (line.equals(actualLine)) {
+                return Optional.empty();
+            }
+
+            return Optional.of(lineNumber + ": Invalid copyright line. Expected / actual. \n" + line + "\n" + actualLine);
+        }
+    }
+
+    private static class BlankLine extends TemplateLine {
+        private BlankLine() {
+        }
+
+        @Override
+        public Optional<String> validate(String actualLine, String expectedYear, int lineNumber) {
+            if (actualLine.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional.of(lineNumber + ": Expected empty line, but got \"" + actualLine + "\"");
+        }
+    }
+
+    private static class CopyrightLine extends TemplateLine {
+        private final String prefix;
+        private final String licensor;
+        private final String suffix;
+        private final String yearSeparator;
+        private final String expectedLine;
+        private final String logExpectedLine;
+
+        private final int minLength;
+        private final int prefixLength;
+        private final int suffixLength;
+        private final int licensorLength;
+        private final int yearSeparatorLength;
+        private final boolean checkFormatOnly;
+
+        private CopyrightLine(CopyrightLineSetup setup) {
+            this.prefix = setup.prefix;
+            this.licensor = setup.licensor;
+            this.suffix = setup.suffix;
+            this.yearSeparator = setup.yearSeparator;
+            this.expectedLine = prefix + "YYYY[" + yearSeparator + "YYYY] " + licensor + suffix;
+            this.logExpectedLine = logGood(expectedLine);
+            this.checkFormatOnly = setup.checkFormatOnly;
+
+            this.prefixLength = prefix.length();
+            this.licensorLength = licensor.length();
+            this.suffixLength = suffix.length();
+            this.yearSeparatorLength = yearSeparator.length();
+            this.minLength = prefixLength + licensorLength + suffixLength + 5;
+        }
+
+        CopyrightLine(Validator.ValidatorConfig config) {
+            this(new CopyrightLineSetup("Copyright (c) ",
+                                        config.licensor(),
+                                        ".",
+                                        config.yearSeparator(),
+                                        config.checkFormatOnly()));
+        }
+
+        CopyrightLine(Validator.ValidatorConfig config, String line) {
+            this(parse(config, line));
+        }
+
+        private static CopyrightLineSetup parse(Validator.ValidatorConfig config, String line) {
+            // line in template
+            // Copyright (c) YYYY Oracle and/or its affiliates.
+            int yyyy = line.indexOf("YYYY");
+
+            int dot = line.indexOf(".", yyyy);
+            if (dot < 0) {
+                dot = line.length();
+            }
+
+            return new CopyrightLineSetup(
+                    line.substring(0, yyyy),
+                    line.substring(yyyy + 5, dot),
+                    line.substring(dot),
+                    config.yearSeparator(),
+                    config.checkFormatOnly());
+        }
+
+        @Override
+        public Optional<String> validate(String actualLine, String expectedYear, int lineNumber) {
+            try {
+                doValidate(actualLine, expectedYear);
+                return Optional.empty();
+            } catch (CopyrightException e) {
+                return Optional.of(lineNumber + ": " + e.getMessage());
+            }
+        }
+
+        private void doValidate(String actualLine, String expectedYear) {
+            //Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+            //Copyright (c) 2021 Oracle and/or its affiliates.
+            if (actualLine.length() < minLength) {
+                throw new CopyrightException("line is too short: " + logBad(actualLine) + ", expected: " + logExpectedLine);
+            }
+
+            int lineLength = actualLine.length();
+
+            String actualPrefix = actualLine.substring(0, prefixLength);
+            int suffixStart = lineLength - suffixLength;
+            String actualSuffix = actualLine.substring(suffixStart, lineLength);
+            int licensorStart = suffixStart - licensorLength;
+            String actualLicensor = actualLine.substring(licensorStart, suffixStart);
+            String yearSection = actualLine.substring(prefixLength, licensorStart).trim();
+
+            // start validation
+            if (!actualPrefix.equals(prefix)) {
+                throw new CopyrightException("line starts with "
+                                                     + logBad(actualPrefix)
+                                                     + ", but its format should be "
+                                                     + logExpectedLine);
+            }
+
+            if (!actualSuffix.equals(suffix)) {
+                throw new CopyrightException("line ends with "
+                                                     + logBad(actualSuffix)
+                                                     + ", but its format should be "
+                                                     + logExpectedLine);
+            }
+
+            if (!actualLicensor.equals(licensor)) {
+                throw new CopyrightException("wrong format. Is "
+                                                     + logBad(actualLine)
+                                                     + ", should be "
+                                                     + logExpectedLine);
+            }
+
+            if (yearSection.length() == 4) {
+                // this is the year - make sure all numbers
+
+                validateYearFormat(actualLine, yearSection);
+
+                if (!checkFormatOnly) {
+                    Log.debug("Expected year: " + expectedYear + ", actual year: " + yearSection);
+                    validateYear(yearSection, expectedYear);
+                }
+            } else {
+                if (yearSection.length() == (8 + yearSeparatorLength)) {
+                    // expected length
+                    String firstYear = yearSection.substring(0, 4);
+                    String actualSeparator = yearSection.substring(4, 4 + yearSeparatorLength);
+                    String secondYear = yearSection.substring(4 + yearSeparatorLength);
+                    validateYearFormat(actualLine, firstYear);
+                    validateYearFormat(actualLine, secondYear);
+                    if (!actualSeparator.equals(this.yearSeparator)) {
+                        throw new CopyrightException("Year separator is "
+                                                             + logBad(actualSeparator)
+                                                             + ", but should be "
+                                                             + logGood(yearSeparator)
+                                                             + " on line " + logBad(actualLine));
+                    }
+                    if (!checkFormatOnly) {
+                        Log.debug("Expected year: " + expectedYear + ", actual years: " + yearSection);
+                        validateYear(firstYear, secondYear, expectedYear);
+                    }
+                } else {
+                    throw new CopyrightException("copyright year is "
+                                                         + logBad(yearSection)
+                                                         + ", but should be "
+                                                         + logGood("yyyy" + yearSeparator + expectedYear));
+                }
+            }
+        }
+
+        private void validateYear(String actualFrom, String actualTo, String expectedYear) {
+            if (!actualTo.equals(expectedYear)) {
+                throw new CopyrightException("copyright year is "
+                                                     + logBad(actualFrom + yearSeparator + actualTo)
+                                                     + ", but should be "
+                                                     + logGood(actualFrom + yearSeparator + expectedYear));
+            }
+        }
+
+        private void validateYear(String actualYear, String expectedYear) {
+            if (!actualYear.equals(expectedYear)) {
+                throw new CopyrightException("copyright year is "
+                                                     + logBad(actualYear)
+                                                     + ", but should be "
+                                                     + logGood(actualYear + yearSeparator + expectedYear));
+            }
+        }
+
+        void validateYearFormat(String line, String year) {
+            try {
+                Integer.parseInt(year);
+            } catch (NumberFormatException e) {
+                throw new CopyrightException("year should be 4 digits, but is "
+                                                     + logBad(year)
+                                                     + ", on line "
+                                                     + logBad(line));
+            }
+        }
+
+        private static class CopyrightLineSetup {
+            private final String prefix;
+            private final String licensor;
+            private final String suffix;
+            private final String yearSeparator;
+            private final boolean checkFormatOnly;
+
+            private CopyrightLineSetup(String prefix,
+                                       String licensor,
+                                       String suffix,
+                                       String yearSeparator,
+                                       boolean checkFormatOnly) {
+                this.prefix = prefix;
+                this.licensor = licensor;
+                this.suffix = suffix;
+                this.yearSeparator = yearSeparator;
+                this.checkFormatOnly = checkFormatOnly;
+            }
+        }
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Validator.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/Validator.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.copyright;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A validator for a certain type of files.
+ */
+public interface Validator {
+    /**
+     * Return a set of suffixes this validator supports. If a suffix is supported, no further checks are done.
+     *
+     * @return set of suffixes including the {@code .}, such as {@code .java}
+     * @see #supports(java.nio.file.Path)
+     */
+    Set<String> supportedSuffixes();
+
+    /**
+     * Return {@code true} if this validator supports the provided path. This may be used for more
+     * complex analysis of the file content when a suffix is not sufficient.
+     *
+     * @param path path of the file
+     * @return {@code true} if this validator can process the file
+     */
+    default boolean supports(Path path) {
+        return false;
+    }
+
+    /**
+     * Validate copyright of the file.
+     *
+     * @param path path of the file
+     * @param modifiedYear expected last modification year
+     * @return empty if validation is successful, problem description otherwise
+     *      (such as copyright year should be 2019, 2021, but was 2019)
+     */
+    Optional<String> validate(Path path, String modifiedYear);
+
+    /**
+     * Validator configuration.
+     */
+    interface ValidatorConfig {
+        /**
+         * A new builder.
+         * @return new fluent API builder
+         */
+        static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Separator to use between years in copyright (when using 2).
+         *
+         * @return year separator
+         */
+        String yearSeparator();
+
+        /**
+         * Validator should only check format, not validity of years.
+         *
+         * @return whether to check only format
+         */
+        boolean checkFormatOnly();
+
+        /**
+         * Expected licensor (the company) in copyright header.
+         *
+         * @return name of the expected licensor
+         */
+        String licensor();
+
+        /**
+         * Fluent API builder to build {@link io.helidon.build.copyright.Validator.ValidatorConfig}.
+         */
+        class Builder {
+            private String yearSeparator = ", ";
+            private boolean checkFormatOnly;
+            private String defaultLicensor = "Oracle and/or its affiliates";
+
+            private Builder() {
+            }
+
+            public ValidatorConfig build() {
+                return new ValidatorConfigImpl(this);
+            }
+
+            /**
+             * String to separate years in copyright header.
+             *
+             * @param yearSeparator separator to use, such as {@code ", "}
+             * @return updated builder
+             */
+            public Builder yearSeparator(String yearSeparator) {
+                this.yearSeparator = yearSeparator;
+                return this;
+            }
+
+            /**
+             * Whether to check only format and ignore last modified year.
+             *
+             * @param checkFormatOnly {@code true} to only check format
+             * @return updated builder
+             */
+            public Builder checkFormatOnly(boolean checkFormatOnly) {
+                this.checkFormatOnly = checkFormatOnly;
+                return this;
+            }
+
+            /**
+             * Configure the default licensor.
+             *
+             * @param defaultLicensor default licensor in copyright header
+             * @return updated builder
+             */
+            public Builder defaultLicensor(String defaultLicensor) {
+                this.defaultLicensor = defaultLicensor;
+                return this;
+            }
+
+            private static class ValidatorConfigImpl implements ValidatorConfig {
+                private final String yearSeparator;
+                private final boolean checkFormatOnly;
+                private final String licensor;
+
+                private ValidatorConfigImpl(Builder builder) {
+                    this.yearSeparator = builder.yearSeparator;
+                    this.checkFormatOnly = builder.checkFormatOnly;
+                    this.licensor = builder.defaultLicensor;
+                }
+
+                @Override
+                public String yearSeparator() {
+                    return yearSeparator;
+                }
+
+                @Override
+                public boolean checkFormatOnly() {
+                    return checkFormatOnly;
+                }
+
+                @Override
+                public String licensor() {
+                    return licensor;
+                }
+            }
+        }
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorAsciidoc.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorAsciidoc.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorAsciidoc extends ValidatorBase {
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("    ");
+
+    protected ValidatorAsciidoc(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".adoc");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return "/".repeat(79);
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return "/".repeat(79);
+    }
+
+    @Override
+    protected boolean allowLeadAndTrailingLines() {
+        return true;
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+
+    @Override
+    protected boolean movePreamble() {
+        return true;
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("=");
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorBase.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorBase.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.build.util.Log;
+
+import static io.helidon.build.copyright.Copyright.logBad;
+import static io.helidon.build.copyright.Copyright.logGood;
+
+/**
+ * Base class for validators.
+ */
+public abstract class ValidatorBase implements Validator {
+    private final List<TemplateLine> templateLines;
+
+    /**
+     * Create a new instance.
+     *
+     * @param validatorConfig validator config
+     * @param templateLines lines of the template
+     */
+    protected ValidatorBase(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        this.templateLines = templateLines;
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return false;
+    }
+
+    @Override
+    public Optional<String> validate(Path path, String modifiedYear) {
+        Log.verbose("Processing file: " + path);
+        List<String> copyrightComment;
+
+        try (BufferedReader br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            copyrightComment = readComment(br);
+        } catch (CopyrightException e) {
+            return Optional.of(e.getMessage());
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to read file " + path.toString(), e);
+        }
+
+        if (copyrightComment.size() != templateLines.size()) {
+            if (copyrightComment.isEmpty()) {
+                return Optional.of("Expecting copyright with " + logGood(String.valueOf(templateLines.size()))
+                                           + " lines, but it was " + logBad("empty"));
+            } else {
+                return Optional.of("Expecting copyright with "
+                                           + logGood(String.valueOf(templateLines.size()))
+                                           + " lines, but it contained "
+                                           + logBad(String.valueOf(copyrightComment.size()))
+                                           + " lines");
+            }
+        }
+
+        for (int i = 0; i < copyrightComment.size(); i++) {
+            String actualLine = copyrightComment.get(i);
+            TemplateLine templateLine = templateLines.get(i);
+
+            Optional<String> validate = templateLine.validate(actualLine, modifiedYear, i);
+            if (validate.isPresent()) {
+                return validate;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Read comment from a reader.
+     *
+     * @param reader read for the file
+     * @return the comment that should contain copyright
+     * @throws IOException in case of I/O problems
+     */
+    protected List<String> readComment(BufferedReader reader) throws IOException {
+        String line;
+
+        // skip beginning of file
+        while ((line = reader.readLine()) != null) {
+            if (line.isBlank()) {
+                continue;
+            }
+            if (isPreamble(line.trim())) {
+                continue;
+            }
+            // we got a real line
+            break;
+        }
+
+        if (line == null) {
+            return List.of();
+        }
+
+        // now we must have comment - otherwise there is no copyright
+        // also the first line must be empty otherwise
+        if (!isCommentStart(line.trim())) {
+            return List.of();
+        }
+
+        List<String> comment = new ArrayList<>();
+        int lineNumber = -1;
+        while ((line = reader.readLine()) != null) {
+            lineNumber++;
+
+            if (supportsBlockComments()) {
+                if (line.trim().startsWith(blockCommentEnd())) {
+                    // end of comment
+                    break;
+                }
+            } else {
+                if (!line.trim().startsWith(lineCommentStart().orElseThrow(() -> new CopyrightException(
+                        "When block comment is not supported, line comment must be defined.")))) {
+                    // end of comment
+                    break;
+                }
+            }
+            line = removeComment(line, lineNumber);
+            comment.add(line);
+        }
+
+        if (comment.isEmpty()) {
+            return comment;
+        }
+
+        if (allowLeadAndTrailingLines()) {
+            // allow one line before and one after
+            if (comment.get(0).isBlank()) {
+                comment.remove(0);
+            }
+            if (comment.get(comment.size() - 1).isBlank()) {
+                comment.remove(comment.size() - 1);
+            }
+        }
+
+        if (!supportsBlockComments()) {
+            // last line may be empty
+            if (comment.get(comment.size() - 1).isBlank()) {
+                comment.remove(comment.size() - 1);
+            }
+        }
+        return comment;
+    }
+
+    /**
+     * Whether we can have an additional line before and after the copyright text within the comment.
+     *
+     * @return whether to allow these lines
+     */
+    protected boolean allowLeadAndTrailingLines() {
+        return false;
+    }
+
+    /**
+     * Remove comment from a line.
+     *
+     * @param line line text
+     * @param lineNumber line number
+     * @return line stripped of comment prefix
+     */
+    protected String removeComment(String line, int lineNumber) {
+        if (supportsBlockComments()) {
+            if (blockCommentPrefix().isPresent()) {
+                String block = blockCommentPrefix().get();
+                if (block.isBlank() || block.startsWith(" ")) {
+                    // prefixed by spaces or tabs
+                    if (line.startsWith(block)) {
+                        return line.substring(block.length());
+                    }
+                    if (line.isBlank()) {
+                        return "";
+                    }
+                } else {
+                    String trimmed = line.trim();
+                    if (trimmed.startsWith(block)) {
+                        // we expect a space after the block
+                        if (trimmed.length() == block.length()) {
+                            return "";
+                        }
+                        if (trimmed.charAt(block.length()) != ' ') {
+                            throw new CopyrightException(lineNumber + ": expected prefix "
+                                                                 + logGood(block) + ", but line is "
+                                                                 + logBad(line));
+                        }
+                        return trimmed.substring(block.length() + 1);
+                    }
+                }
+                throw new CopyrightException(lineNumber + ": expected prefix "
+                                                     + logGood(block) + ", but line is "
+                                                     + logBad(line));
+            }
+        }
+
+        if (lineCommentStart().isPresent()) {
+            String lineComment = lineCommentStart().get();
+            if (line.startsWith(lineComment)) {
+                String substring = line.substring(lineComment.length());
+                if (substring.startsWith(" ")) {
+                    substring = substring.substring(1);
+                }
+                return substring;
+            }
+        }
+
+        return line;
+    }
+
+    /**
+     * Does this line start a multiline comment, or is it a comment.
+     *
+     * @param line line text
+     * @return whether the line is start of multiline comment or a single line comment
+     */
+    protected boolean isCommentStart(String line) {
+        if (supportsBlockComments()) {
+            return line.startsWith(blockCommentStart());
+        }
+        return line.startsWith(lineCommentStart().orElseThrow(() -> new CopyrightException(
+                "When block comment is not supported, line comment must be defined.")));
+    }
+
+    /**
+     * Whether the file starts with the provided prefix.
+     * Utility method to "peek" into the file.
+     *
+     * @param path path of the file
+     * @param prefix prefix to look for
+     * @return whether the file starts with the prefix
+     */
+    protected final boolean startsWith(Path path, String prefix) {
+        return startsWith(path, prefix.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Whether the file starts with the provided prefix.
+     * Utility method to "peek" into the file.
+     *
+     * @param path path of the file
+     * @param prefix prefix to look for
+     * @return whether the file starts with the prefix
+     */
+    protected final boolean startsWith(Path path, byte[] prefix) {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            byte[] chunk = new byte[prefix.length];
+            int read = inputStream.read(chunk);
+            if (read < chunk.length) {
+                return false;
+            }
+            return Arrays.equals(prefix, chunk);
+        } catch (IOException e) {
+            throw new CopyrightException("Failed to check file from prefix. Path: " + path, e);
+        }
+    }
+
+    /**
+     * Whether this validator supports multiline (block) comments.
+     *
+     * @return whether block comments are supported
+     */
+    protected boolean supportsBlockComments() {
+        return false;
+    }
+
+    /**
+     * Start of block comment (if supported).
+     *
+     * @return beginning of block comment
+     */
+    protected String blockCommentStart() {
+        return null;
+    }
+
+    /**
+     * End of block comment (if supported).
+     *
+     * @return end of block comment
+     */
+    protected String blockCommentEnd() {
+        return null;
+    }
+
+    /**
+     * Optional prefix used on lines within a block comment.
+     *
+     * @return prefix
+     */
+    protected Optional<String> blockCommentPrefix() {
+        return Optional.empty();
+    }
+
+    /**
+     * Whether to move preamble and put copyright before it.
+     * Not used for now, as we do not have update copyright implemented.
+     *
+     * @return whether to move preamble after copyright
+     */
+    protected boolean movePreamble() {
+        return false;
+    }
+
+    /**
+     * Beginning of single line comment, only used if {@link #supportsBlockComments()}
+     * is set to false.
+     *
+     * @return beginning of line comment
+     */
+    protected Optional<String> lineCommentStart() {
+        return Optional.empty();
+    }
+
+    /**
+     * Whether the current line is a preamble (such as {@code package} statement in Java).
+     *
+     * @param line line text
+     * @return whether the line is a preamble
+     */
+    protected boolean isPreamble(String line) {
+        return false;
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorBat.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorBat.java
@@ -17,17 +17,21 @@
 package io.helidon.build.copyright;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
-/**
- * Java service loader interface to extend the functionality of copyright checking.
- */
-public interface ValidatorProvider {
-    /**
-     * Create a custom validator.
-     *
-     * @param config configuration
-     * @param templateLines lines of copyright template
-     * @return a new validator instance
-     */
-    Validator validator(Validator.ValidatorConfig config, List<TemplateLine> templateLines);
+class ValidatorBat extends ValidatorBase {
+    protected ValidatorBat(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".bat");
+    }
+
+    @Override
+    protected Optional<String> lineCommentStart() {
+        return Optional.of("@REM");
+    }
 }

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorJava.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorJava.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorJava extends ValidatorBase {
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("*");
+
+    protected ValidatorJava(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".java",
+                      ".g",
+                      ".c",
+                      ".h",
+                      ".css",
+                      ".js");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return super.startsWith(path, "/*\n");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return "/*";
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return "*/";
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+
+    @Override
+    protected boolean movePreamble() {
+        return true;
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("package ");
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorJsp.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorJsp.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorJsp extends ValidatorBase {
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("    ");
+    public static final String BLOCK_COMMENT_START = "<%--";
+    public static final String BLOCK_COMMENT_END = "--%>";
+
+    protected ValidatorJsp(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".jsp");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return path.getFileName().toString().equals("build.properties") && super.startsWith(path, "<");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return BLOCK_COMMENT_START;
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return BLOCK_COMMENT_END;
+    }
+
+    @Override
+    protected boolean allowLeadAndTrailingLines() {
+        return true;
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorProperties.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorProperties.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorProperties extends ValidatorBase {
+    protected ValidatorProperties(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".properties",
+                      ".prefs",
+                      ".py",
+                      ".sh",
+                      ".ksh");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        String fileName = path.getFileName().toString();
+        if (fileName.startsWith("Makefile")) {
+            return true;
+        }
+        if (fileName.startsWith("GNUmakefile")) {
+            return true;
+        }
+        if (fileName.startsWith("Rakefile")) {
+            return true;
+        }
+        if (fileName.startsWith("Dockerfile")) {
+            return true;
+        }
+        if (fileName.equals("osgi.bundle")) {
+            return true;
+        }
+
+        return startsWith(path, "#");
+    }
+
+    @Override
+    protected boolean movePreamble() {
+        return false;
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("#!");
+    }
+
+    @Override
+    protected Optional<String> lineCommentStart() {
+        return Optional.of("#");
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorProvider.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+/**
+ * Java service loader interface to extend the functionality of copyright checking.
+ */
+public interface ValidatorProvider {
+    /**
+     * Create a custom validator.
+     *
+     * @param config configuration
+     * @return a new validator instance
+     */
+    Validator validator(Validator.ValidatorConfig config);
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorText.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorText.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorText extends ValidatorBase {
+    protected ValidatorText(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of();
+    }
+
+    @Override
+    protected Optional<String> lineCommentStart() {
+        return Optional.of("#");
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorXml.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/ValidatorXml.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorXml extends ValidatorBase {
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("    ");
+
+    protected ValidatorXml(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".xml",
+                      ".xsl",
+                      ".html",
+                      ".xhtml",
+                      ".htm",
+                      ".dtd",
+                      ".xsd",
+                      ".wsdl",
+                      ".inc",
+                      ".jnlp",
+                      ".tld",
+                      ".xcs",
+                      ".jsf",
+                      ".hs",
+                      ".jhm");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return path.getFileName().toString().equals("build.properties") && super.startsWith(path, "<");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return "<!--";
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return "-->";
+    }
+
+    @Override
+    protected boolean allowLeadAndTrailingLines() {
+        return true;
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("<?xml ")
+                || line.startsWith("<!DOCTYPE")
+                || line.startsWith("<html")
+                || line.startsWith("<head>")
+                || line.startsWith("<meta");
+    }
+}

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/package-info.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Maven copyright plugin and command line copyright tool.
+ *
+ * @see io.helidon.build.copyright.CopyrightMojo
+ * @see io.helidon.build.copyright.Main
+ */
+package io.helidon.build.copyright;

--- a/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/package-info.java
+++ b/copyright-maven-plugin/src/main/java/io/helidon/build/copyright/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Maven copyright plugin and command line copyright tool.
  *

--- a/copyright-maven-plugin/src/main/resources/io/helidon/build/maven/copyright/apache.txt
+++ b/copyright-maven-plugin/src/main/resources/io/helidon/build/maven/copyright/apache.txt
@@ -1,0 +1,14 @@
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/copyright-maven-plugin/src/test/java/io/helidon/build/copyright/ExcludeTest.java
+++ b/copyright-maven-plugin/src/test/java/io/helidon/build/copyright/ExcludeTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ExcludeTest {
+    @Test
+    void testSuffix() {
+        Exclude exclude = Exclude.create(".ico");
+
+        boolean excluded;
+        excluded = exclude.exclude(FileRequest.create("src/main/icon.ico"));
+        assertThat("Should exclude icon", excluded, is(true));
+
+        excluded = exclude.exclude(FileRequest.create("scr/main/icon.ico.txt"));
+        assertThat("Should not exclude icon.ico.txt", excluded, is(false));
+    }
+
+    @Test
+    void testStartsWith() {
+        // excludes with exact path from repository root
+        Exclude exclude = Exclude.create("/etc/copyright.txt");
+
+        boolean excluded;
+        excluded = exclude.exclude(FileRequest.create("etc/copyright.txt"));
+        assertThat("Should exclude exact match", excluded, is(true));
+
+        excluded = exclude.exclude(FileRequest.create("webserver/etc/copyright.txt"));
+        assertThat("Should not exclude subpath match", excluded, is(false));
+    }
+
+    @Test
+    void testDirectory() {
+        Exclude exclude = Exclude.create("target/");
+
+        boolean excluded;
+        excluded = exclude.exclude(FileRequest.create("webserver/target/classes/test.class"));
+        assertThat("Should exclude nested target directory", excluded, is(true));
+
+        excluded = exclude.exclude(FileRequest.create("target/classes/test.class"));
+        assertThat("Should exclude target directory", excluded, is(true));
+
+        excluded = exclude.exclude(FileRequest.create("targets/classes/test.class"));
+        assertThat("Should not exclude targets directory", excluded, is(false));
+
+        excluded = exclude.exclude(FileRequest.create("webserver/targets/classes/test.class"));
+        assertThat("Should not exclude targets directory", excluded, is(false));
+
+        excluded = exclude.exclude(FileRequest.create("webtarget/classes/test.class"));
+        assertThat("Should not exclude webtarget directory", excluded, is(false));
+
+        excluded = exclude.exclude(FileRequest.create("webserver/webtarget/classes/test.class"));
+        assertThat("Should not exclude webtarget directory", excluded, is(false));
+    }
+
+    @Test
+    void testName() {
+        // test file name
+        Exclude exclude = Exclude.create("copyright.txt");
+
+        boolean excluded;
+        excluded = exclude.exclude(FileRequest.create("copyright.txt"));
+        assertThat("Should exclude copyright.txt", excluded, is(true));
+
+        excluded = exclude.exclude(FileRequest.create("webserver/etc/copyright.txt"));
+        assertThat("Should exclude copyright.txt in directory", excluded, is(true));
+    }
+
+    @Test
+    void testContains() {
+        Exclude exclude = Exclude.create("src/resources/bin");
+
+        boolean excluded;
+        excluded = exclude.exclude(FileRequest.create("src/resources/bin/copyright.txt"));
+        assertThat("Should exclude directory", excluded, is(true));
+
+        excluded = exclude.exclude(FileRequest.create("webserver/src/resources/bin/copyright.txt"));
+        assertThat("Should exclude nested directory", excluded, is(true));
+
+        excluded = exclude.exclude(FileRequest.create("src/resources/sbin/copyright.txt"));
+        assertThat("Should not exclude directory", excluded, is(false));
+    }
+}

--- a/copyright-maven-plugin/src/test/java/io/helidon/build/copyright/TemplateLineTest.java
+++ b/copyright-maven-plugin/src/test/java/io/helidon/build/copyright/TemplateLineTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.copyright;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TemplateLineTest {
+    @Test
+    void testCopyrightLine() {
+        Validator.ValidatorConfig validatorConfig = Validator.ValidatorConfig.builder()
+                .build();
+        String templateLineString = "(c) YYYY Oracle and/or its affiliates.";
+        TemplateLine templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(0);
+
+        Optional<String> validate = templateLine.validate("", "2021", 177);
+        assertThat(validate, not(Optional.empty()));
+        String message = validate.get();
+        assertThat(message, startsWith("177: "));
+
+        validate = templateLine.validate("Some test", "2021", 177);
+        assertThat(validate, not(Optional.empty()));
+        message = validate.get();
+        assertThat(message, startsWith("177: "));
+
+        validate = templateLine.validate("(c) 2020 Oracle and/or its affiliates.", "2021", 177);
+        assertThat(validate, not(Optional.empty()));
+        message = validate.get();
+        assertThat(message, startsWith("177: "));
+        assertThat(message, containsString("2020"));
+        assertThat(message, containsString("2020, 2021"));
+
+        validate = templateLine.validate("(c) 2020, 2021 Oracle and/or its affiliates.", "2021", 177);
+        assertThat(validate, is(Optional.empty()));
+
+        validatorConfig = Validator.ValidatorConfig.builder()
+                .checkFormatOnly(true)
+                .build();
+        templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(0);
+        validate = templateLine.validate("(c) 2020 Oracle and/or its affiliates.", "2021", 177);
+        assertThat(validate, is(Optional.empty()));
+
+    }
+
+    @Test
+    void testTextLine() {
+        Validator.ValidatorConfig validatorConfig = Validator.ValidatorConfig.builder()
+                .build();
+        String templateLineString = "  Cogito ergo sum";
+        // first line is always copyright, unless explicitly defined
+        TemplateLine templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(1);
+
+        Optional<String> validate = templateLine.validate("", "2021", 177);
+        assertThat(validate, not(Optional.empty()));
+        String message = validate.get();
+        assertThat(message, startsWith("177: "));
+
+        validate = templateLine.validate("\t", "2021", 177);
+        assertThat(validate, not(Optional.empty()));
+        message = validate.get();
+        assertThat(message, startsWith("177: "));
+
+        validate = templateLine.validate("Cogito ergo sum", "2021", 147);
+        assertThat(validate, not(Optional.empty()));
+        message = validate.get();
+        assertThat(message, startsWith("147: "));
+
+        validate = templateLine.validate("Copyright", "2021", 147);
+        assertThat(validate, not(Optional.empty()));
+        message = validate.get();
+        assertThat(message, startsWith("147: "));
+
+        validate = templateLine.validate("  Cogito ergo sum", "2021", 147);
+        assertThat(validate, is(Optional.empty()));
+    }
+
+    @Test
+    void testBlankLine() {
+        Validator.ValidatorConfig validatorConfig = Validator.ValidatorConfig.builder()
+                .build();
+        String templateLineString = "\t ";
+        // first line is always copyright, unless explicitly defined
+        TemplateLine templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(1);
+
+        Optional<String> validate = templateLine.validate("", "2021", 1);
+        assertThat(validate, is(Optional.empty()));
+
+        validate = templateLine.validate("\t", "2021", 0);
+        assertThat(validate, is(Optional.empty()));
+
+        validate = templateLine.validate("Copyright", "2021", 147);
+        assertThat(validate, not(Optional.empty()));
+
+        String message = validate.get();
+        assertThat(message, startsWith("147: "));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
         <module>dev-loop</module>
         <module>stager-maven-plugin</module>
         <module>build-cache-maven-plugin</module>
+        <module>copyright-maven-plugin</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Copyright maven plugin.

Diffs from the glassfish plugin:

- supports git only
- supports a single template file
- checks only files modified locally or since the `master` branch (name configurable)
- only modified files are queried for changed year 
- does not support update of copyright, only validates the files
- works on the whole subtree, so the check is done only once per maven build, on the top level module
- template is pure text (not java format as we have now)
- excludes support more fine grained config
- the plugin is much more strict (prefixes must be exactly as configured, such as in XML, in java we do not allow empty lines before and after in comments, must use the correct year separator, cannot have `All Rights Reserved.`)

Excludes:
- exclude a directory `target/`
- exclude a from repository root `/etc/scripts`
- exclude a file suffix `.ico`
- exclude a file name `README.md`

copyright script would be:
```
mvn ${MAVEN_ARGS} \
        -f ${WS_DIR}/pom.xml \
        -Pexamples,docs,ossrh-releases,tests,copyright \
        -N \
        validate
```

