### PR TITLE
Do not error if we can't determine maven version. Allows support of shims.

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/MavenCommand.java
+++ b/utils/src/main/java/io/helidon/build/util/MavenCommand.java
@@ -206,8 +206,8 @@ public class MavenCommand {
             // Could not determine the Maven version. The code to do so is fragile and is known
             // not to work in some environments (especially where shims are involved). So
             // don't fail if we can't determine the maven version.
-            Log.debug("Could not determine Maven version: " + ex.toString() +
-                    " Assuming version is acceptable.");
+            Log.debug("Could not determine Maven version: " + ex.toString()
+                    + " Assuming version is acceptable.");
             return;
         }
         // If we were able to determine the maven version, go ahead and make sure it is acceptable.

--- a/utils/src/main/java/io/helidon/build/util/MavenCommand.java
+++ b/utils/src/main/java/io/helidon/build/util/MavenCommand.java
@@ -193,7 +193,17 @@ public class MavenCommand {
      * @throws IllegalStateException If the installed version does not meet the requirement.
      */
     public static void assertRequiredMavenVersion(MavenVersion requiredMinimumVersion) {
-        MavenVersion installed = installedVersion();
+        MavenVersion installed;
+        try {
+            installed = installedVersion();
+        } catch (Exception ex) {
+            // Could not determine the Maven version. The code to do so is fragile and is known
+            // not to work in some environments (especially where shims are involved). So
+            // don't fail if we can't determine the maven version.
+            Log.debug("Could not determine Maven version: " + ex.toString() +
+                    " Assuming version is acceptable.");
+            return;
+        }
         Requirements.require(installed.isGreaterThanOrEqualTo(requiredMinimumVersion),
                 VERSION_ERROR, installed, requiredMinimumVersion, MAVEN_DOWNLOAD_URL);
     }

--- a/utils/src/main/java/io/helidon/build/util/MavenCommand.java
+++ b/utils/src/main/java/io/helidon/build/util/MavenCommand.java
@@ -193,6 +193,12 @@ public class MavenCommand {
      * @throws IllegalStateException If the installed version does not meet the requirement.
      */
     public static void assertRequiredMavenVersion(MavenVersion requiredMinimumVersion) {
+        // This catches if we can find the mvn executable or not. We want to
+        // catch this error independently of getting the maven version (since
+        // getting the maven version is fragile).
+        Path executable = mavenExecutable();
+        Log.debug("Found maven executable " + executable);
+
         MavenVersion installed;
         try {
             installed = installedVersion();
@@ -204,6 +210,7 @@ public class MavenCommand {
                     " Assuming version is acceptable.");
             return;
         }
+        // If we were able to determine the maven version, go ahead and make sure it is acceptable.
         Requirements.require(installed.isGreaterThanOrEqualTo(requiredMinimumVersion),
                 VERSION_ERROR, installed, requiredMinimumVersion, MAVEN_DOWNLOAD_URL);
     }


### PR DESCRIPTION
Fixes issue #364 