### PR TITLE
2.x: Do not error if we can't determine maven version. Allows support of shims

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/MavenCommand.java
+++ b/utils/src/main/java/io/helidon/build/util/MavenCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Back port of fix for #364  to 2.x branch
