### PR TITLE
fix windows native-image build

### DIFF
--- a/helidon-cli/impl/pom.xml
+++ b/helidon-cli/impl/pom.xml
@@ -230,12 +230,9 @@
                                         <argument>-H:Path=${build.dir}</argument>
                                         <argument>-H:Name=${finalName}</argument>
                                         <argument>-H:+PrintAnalysisCallTree</argument>
-                                        <argument>-H:+ReportExceptionStackTraces</argument>
-                                        <argument>-H:-ParseRuntimeOptions</argument>
-                                        <argument>--no-server</argument>
                                         <argument>--no-fallback</argument>
                                         <argument>-cp</argument>
-                                        <argument>${build.dir}/${finalName}.jar:${build.dir}/libs/*:${build.dir}/native</argument>
+                                        <argument>${build.dir}${file.separator}${finalName}.jar${path.separator}${build.dir}${file.separator}libs${file.separator}*${path.separator}${build.dir}${file.separator}native</argument>
                                         <argument>${mainClass}</argument>
                                     </arguments>
                                 </configuration>

--- a/helidon-cli/impl/src/main/resources/META-INF/native-image/native-image.properties
+++ b/helidon-cli/impl/src/main/resources/META-INF/native-image/native-image.properties
@@ -14,4 +14,6 @@
 # limitations under the License.
 #
 Args=-H:IncludeResources=plugins/cli-plugins-${buildNumber}.jar \
-     -H:IncludeResources=io/helidon/build/cli/impl/build.properties
+     -H:IncludeResources=io/helidon/build/cli/impl/build.properties \
+     -H:-ParseRuntimeOptions \
+     -H:+ReportExceptionStackTraces

--- a/pom.xml
+++ b/pom.xml
@@ -125,13 +125,13 @@
         <version.lib.diffutils>2.2</version.lib.diffutils>
         <version.lib.doxia>1.9.1</version.lib.doxia>
         <version.lib.freemarker>2.3.23</version.lib.freemarker>
-        <version.lib.graalvm-sdk>21.0.0.2</version.lib.graalvm-sdk>
+        <version.lib.graalvm-sdk>20.2.0</version.lib.graalvm-sdk>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.invoker>3.0.1</version.lib.invoker>
         <version.lib.jaxb-api>2.3.3</version.lib.jaxb-api>
         <version.lib.jaxb-core>2.3.0.1</version.lib.jaxb-core>
         <version.lib.jaxb-impl>2.3.3</version.lib.jaxb-impl>
-        <version.lib.junit>5.6.0</version.lib.junit>
+        <version.lib.junit>5.8.0-M1</version.lib.junit>
         <version.lib.maven>3.6.2</version.lib.maven>
         <version.lib.maven-annotations>3.5</version.lib.maven-annotations>
         <version.lib.maven-archiver>3.5.0</version.lib.maven-archiver>


### PR DESCRIPTION
Use path.separator and file.separator in the native-image execution command line. 
Downgrade GraalVM SDK to 20.2.0 to match the pipeline install