### PR TITLE
Backport Enforcer Plugin to 2.x

### DIFF
--- a/enforcer-maven-plugin/pom.xml
+++ b/enforcer-maven-plugin/pom.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools</groupId>
+        <artifactId>helidon-build-tools-project</artifactId>
+        <version>2.1.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-enforcer-plugin</artifactId>
+    <name>Helidon Enforcer Plugin</name>
+    <packaging>maven-plugin</packaging>
+
+    <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+        <mainClass>io.helidon.build.maven.enforcer.copyright.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.build-tools</groupId>
+            <artifactId>helidon-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <configuration>
+                    <goalPrefix>helidon-copyright</goalPrefix>
+                    <skipErrorNoDescriptorsFound>false</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>invoker-install</id>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>invoker-it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <ignoreFailures>false</ignoreFailures>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <pomIncludes>
+                                <pomInclude>projects/*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>verify</goal>
+                            </goals>
+                            <streamLogs>true</streamLogs>
+                            <showErrors>true</showErrors>
+                            <!--suppress UnresolvedMavenProperty, MavenModelInspection -->
+                            <skipInvocation>${skipTests}</skipInvocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>libs</classpathPrefix>
+                            <mainClass>${mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${version.plugin.dependency}</version>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                            <excludeScope>test</excludeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerException.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+/**
+ * Exception thrown by copyright checking.
+ */
+public class EnforcerException extends RuntimeException {
+    /**
+     * Exception with message.
+     * @param message message
+     */
+    public EnforcerException(String message) {
+        super(message);
+    }
+
+    /**
+     * Exception with message and cause.
+     *
+     * @param message message
+     * @param cause cause
+     */
+    public EnforcerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerMojo.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerMojo.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.build.maven.enforcer.copyright.Copyright;
+import io.helidon.build.maven.enforcer.copyright.CopyrightConfig;
+import io.helidon.build.maven.enforcer.typo.TypoConfig;
+import io.helidon.build.maven.enforcer.typo.TyposRule;
+import io.helidon.build.util.Log;
+import io.helidon.build.util.MavenLogWriter;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Enforcer plugin.
+ * Built in rules:
+ * <ul>
+ *     <li>copyright - validate copyright of files</li>
+ *     <li>typos - validate that files do not contain certain strings</li>
+ * </ul>
+ */
+@Mojo(name = "check",
+      defaultPhase = LifecyclePhase.VALIDATE,
+      threadSafe = true)
+public class EnforcerMojo extends AbstractMojo {
+    /**
+     * Configuration of copyright rule.
+     */
+    @Parameter
+    private CopyrightConfig copyrightConfig;
+
+    /**
+     * Configuration of typos rule.
+     */
+    @Parameter
+    private TypoConfig typosConfig;
+
+    /**
+     * Root of the repository.
+     * When within git, this is not needed and will be computed using git command.
+     */
+    @Parameter
+    private File repositoryRoot;
+
+    /**
+     * Use git. When configured to {@code false}, all files will be checked and their last modification timestamp used.
+     */
+    @Parameter(property = "helidon.enforcer.use-git", defaultValue = "true")
+    private boolean useGit;
+
+    /**
+     * Whether to use git ignore to matches files.
+     */
+    @Parameter(property = "helidon.enforcer.honor-gitignore", defaultValue = "true")
+    private boolean honorGitIgnore;
+
+    /**
+     * File to write output to.
+     * Output is plain text, one failure per line, starts with either
+     * {@code ENFORCER OK} or {@code ENFORCER ERROR}.
+     */
+    @Parameter(property = "helidon.enforcer.output.file")
+    private File enforcerOutputFile;
+
+    /**
+     * Whether this plugin should fail on error.
+     */
+    @Parameter(property = "helidon.enforcer.failOnError", defaultValue = "true")
+    private boolean failOnError;
+
+    /**
+     * Enforcer rules to execute.
+     * Currently supported (and configured) are {@code copyright} and {@code todos}.
+     */
+    @Parameter(property = "helidon.enforcer.rules", defaultValue = "copyright,todos")
+    private String[] rules;
+
+    /**
+     * Base directory for project.
+     */
+    @Parameter(defaultValue = "${project.basedir}", readonly = true)
+    private File baseDirectory;
+
+    /**
+     * Skip execution of this plugin (all rules).
+     */
+    @Parameter(defaultValue = "false", property = "helidon.enforcer.skip")
+    private boolean skip;
+
+    /**
+     * The {@link MavenSession}.
+     */
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        MavenLogWriter.install(getLog());
+
+        if (skip) {
+            Log.info("Skipping execution.");
+            return;
+        }
+
+        Path path = baseDirectory.toPath().toAbsolutePath();
+        Path rootDir = Paths.get(session.getExecutionRootDirectory());
+
+        if (!path.equals(rootDir) && path.startsWith(rootDir)) {
+            // this is not the root dir, and the root dir is my parent
+            // all rules run on the whole subpath of current module, so this always makes sense
+            getLog().info("Parent path " + rootDir + " already checked");
+            return;
+        }
+
+        if (rules.length == 0) {
+            Log.info("No rules enabled.");
+            return;
+        }
+
+        // let's get the files
+        FileFinder.Builder fileConfigBuilder = FileFinder.builder()
+                .useGit(useGit)
+                .honorGitIgnore(honorGitIgnore);
+
+        if (repositoryRoot != null) {
+            fileConfigBuilder.repositoryRoot(repositoryRoot.toPath());
+        }
+
+        FileFinder fileConfig = fileConfigBuilder.build();
+
+        Log.verbose("File config: " + fileConfig);
+        FoundFiles filesToCheck = fileConfig.findFiles(baseDirectory.toPath());
+        Log.verbose("Discovered " + filesToCheck.fileRequests().size() + " files");
+
+        // now run the rules
+        Map<String, List<RuleFailure>> failuresByRule = new HashMap<>();
+        Map<String, List<RuleFailure>> warningsByRule = new HashMap<>();
+
+        for (String rule : rules) {
+            switch (rule) {
+            case "copyright":
+                runCopyright(filesToCheck, failuresByRule, warningsByRule);
+                break;
+            case "typos":
+                runTypos(filesToCheck, failuresByRule, warningsByRule);
+                break;
+            default:
+                throw new MojoExecutionException("Unsupported rule defined: " + rule);
+            }
+        }
+
+        if (enforcerOutputFile != null) {
+            Path enforcerOutputPath = enforcerOutputFile.toPath();
+            if (warningsByRule.isEmpty()) {
+                FileSystem.write(enforcerOutputPath, "ENFORCER OK", Map.of());
+            } else {
+                FileSystem.write(enforcerOutputPath, "ENFORCER ERROR", warningsByRule);
+            }
+        }
+
+        if (!failuresByRule.isEmpty()) {
+            Log.info("-- $(MAGENTA enforcer results)");
+            failuresByRule.forEach((rule, failures) -> {
+                Log.error("Rule $(magenta " + rule + ") failed. Errors:");
+                for (RuleFailure failure : failures) {
+                    Log.error("  "
+                                      + failure.fr().relativePath()
+                                      + ":"
+                                      + failure.line()
+                                      + ": "
+                                      + failure.message());
+                }
+            });
+
+            if (failOnError) {
+                throw new MojoExecutionException("Failed to validate rules: " + String.join(", " + failuresByRule.keySet()));
+            } else {
+                Log.warn("Plugin is configured not to fail on error");
+            }
+        }
+    }
+
+    private void runTypos(FoundFiles filesToCheck,
+                          Map<String, List<RuleFailure>> failuresByRule,
+                          Map<String, List<RuleFailure>> warningsByRule) throws MojoFailureException {
+        Log.info("-- typos rule");
+        Log.verbose("Typos config: " + typosConfig);
+
+        TyposRule typoRule = TyposRule.builder()
+                .config(typosConfig)
+                .build();
+
+        List<RuleFailure> errors;
+        try {
+            errors = typoRule.check(filesToCheck);
+        } catch (EnforcerException e) {
+            throw new MojoFailureException("Failed to validate typos", e);
+        }
+
+        if (!errors.isEmpty()) {
+            warningsByRule.put("typos", errors);
+            if (typosConfig.failOnError()) {
+                failuresByRule.put("typos", errors);
+            } else {
+                for (RuleFailure error : errors) {
+                    Log.warn(error.fr().relativePath() + ":" + error.line() + " " + error.message());
+                }
+            }
+        }
+    }
+
+    private void runCopyright(FoundFiles filesToCheck,
+                              Map<String, List<RuleFailure>> failuresByRule,
+                              Map<String, List<RuleFailure>> warningsByRule) throws MojoFailureException {
+        Log.info("-- copyright rule");
+
+        Log.verbose("Copyright config: " + copyrightConfig);
+        Copyright.Builder copyrightBuilder = Copyright.builder()
+                .config(copyrightConfig);
+
+        Copyright copyright = copyrightBuilder.build();
+
+        List<RuleFailure> errors;
+        try {
+            errors = copyright.check(filesToCheck);
+        } catch (EnforcerException e) {
+            throw new MojoFailureException("Failed to validate copyright", e);
+        }
+
+        if (!errors.isEmpty()) {
+            warningsByRule.put("copyright", errors);
+            if (copyrightConfig.failOnError()) {
+                failuresByRule.put("copyright", errors);
+            } else {
+                for (RuleFailure error : errors) {
+                    Log.warn(error.fr().relativePath() + ":" + error.line() + " " + error.message());
+                }
+            }
+        }
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileFinder.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileFinder.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.helidon.build.util.Log;
+
+/**
+ * Configuration of discovery of files to check.
+ */
+public class FileFinder {
+    private static final DateTimeFormatter YEAR_FORMATTER = DateTimeFormatter.ofPattern("yyyy");
+
+    private final String currentYear = YEAR_FORMATTER.format(ZonedDateTime.now());
+    private final Path repositoryRoot;
+    private final boolean useGit;
+    private final boolean honorGitIgnore;
+
+    private FileFinder(Builder builder) {
+        useGit = builder.useGit;
+        honorGitIgnore = builder.honorGitIgnore;
+        repositoryRoot = builder.repositoryRoot;
+    }
+
+    /**
+     * Builder to set up file config.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Get files to check based on this file config.
+     *
+     * @param basePath path to use
+     * @return found files
+     */
+    public FoundFiles findFiles(Path basePath) {
+        // find repository root if not configured
+        Path gitRepoDir = (repositoryRoot == null ? GitCommands.repositoryRoot(basePath) : repositoryRoot);
+
+        List<FileMatcher> excludes = new ArrayList<>();
+        if (useGit && honorGitIgnore) {
+            addGitIgnore(gitRepoDir, excludes);
+        }
+
+        Set<FileRequest> foundFiles;
+        Set<FileRequest> locallyModified;
+
+        if (useGit) {
+            locallyModified = GitCommands.locallyModified(gitRepoDir, basePath, currentYear);
+            foundFiles = new HashSet<>(locallyModified);
+
+            foundFiles.addAll(GitCommands.gitTracked(gitRepoDir, basePath));
+        } else {
+            foundFiles = findAllFiles(gitRepoDir, basePath);
+            locallyModified = foundFiles;
+        }
+
+        List<FileRequest> fileRequests = foundFiles.stream()
+                .filter(file -> isValid(file, excludes))
+                .collect(Collectors.toList());
+
+        Set<String> filteredLocallyModified = exclude(excludes, locallyModified);
+        fileRequests.sort(FileRequest::compareTo);
+
+        return FoundFiles.create(gitRepoDir, fileRequests, filteredLocallyModified, useGit);
+    }
+
+    @Override
+    public String toString() {
+        return "FileConfig{"
+                + "repositoryRoot=" + repositoryRoot
+                + ", useGit=" + useGit
+                + ", honorGitIgnore=" + honorGitIgnore
+                + '}';
+    }
+
+    private void addGitIgnore(Path gitRepoDir, List<FileMatcher> excludes) {
+        Path gitIgnore = gitRepoDir.resolve(".gitignore");
+
+        excludes.addAll(FileMatcher.create(".git/"));
+
+        List<String> lines = FileSystem.toLines(gitIgnore)
+                .stream()
+                .filter(it -> !it.startsWith("#"))
+                .filter(it -> !it.isBlank())
+                .collect(Collectors.toList());
+
+        for (String line : lines) {
+            if (line.contains("*")) {
+                if (line.startsWith("*.")) {
+                    excludes.addAll(FileMatcher.create(line.substring(1)));
+                } else {
+                    if (line.startsWith("*")) {
+                        excludes.add(new NameEndExclude(line.substring(1)));
+                    } else if (line.endsWith("*")) {
+                        excludes.add(new NameStartExclude(line.substring(line.length() - 1)));
+                    } else {
+                        Log.warn("$(YELLOW .gitignore) matches not supported: " + line);
+                    }
+                }
+            } else {
+                excludes.addAll(FileMatcher.create(line));
+            }
+        }
+    }
+
+    private Set<FileRequest> findAllFiles(Path gitRepoDir, Path basePath) {
+        Set<FileRequest> result = new HashSet<>();
+
+        try {
+            Files.walkFileTree(basePath, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    result.add(FileRequest.create(gitRepoDir, gitRepoDir.relativize(file).toString(), lastModifiedYear(file)));
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to list files", e);
+        }
+
+        return result;
+    }
+
+    private String lastModifiedYear(Path file) {
+        try {
+            return YEAR_FORMATTER.format(ZonedDateTime.ofInstant(Files.getLastModifiedTime(file).toInstant(), ZoneId.of("GMT")));
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to parse last modified year from local file: " + file, e);
+        }
+    }
+
+    private Set<String> exclude(List<FileMatcher> excludes, Set<FileRequest> locallyModified) {
+        return locallyModified.stream()
+                .filter(it -> {
+                    for (FileMatcher exclude : excludes) {
+                        if (exclude.matches(it)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                })
+                .map(FileRequest::relativePath)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean isValid(FileRequest file,
+                            List<FileMatcher> excludes) {
+
+        // file may have been deleted from GIT (or locally)
+        if (!Files.exists(file.path())) {
+            Log.debug("File " + file.relativePath() + " does not exist, ignoring.");
+            return false;
+        }
+
+        for (FileMatcher exclude : excludes) {
+            if (exclude.matches(file)) {
+                Log.debug("Excluding " + file.relativePath());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@code FileConfig} builder static inner class.
+     */
+    public static final class Builder {
+        private Path repositoryRoot;
+        private boolean useGit = true;
+        private boolean honorGitIgnore = true;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the {@code useGit} and returns a reference to this Builder so that the methods can be chained together.
+         * @param useGit the {@code useGit} to set
+         * @return a reference to this Builder
+         */
+        public Builder useGit(boolean useGit) {
+            this.useGit = useGit;
+            return this;
+        }
+
+        /**
+         * Sets the {@code honorGitIgnore} and returns a reference to this Builder so that the methods can be chained together.
+         * @param honorGitIgnore the {@code honorGitIgnore} to set
+         * @return a reference to this Builder
+         */
+        public Builder honorGitIgnore(boolean honorGitIgnore) {
+            this.honorGitIgnore = honorGitIgnore;
+            return this;
+        }
+
+        /**
+         * Sets the root of the repository, if it cannot be determined using git.
+         *
+         * @param repositoryRoot root of repo
+         * @return updated builder
+         */
+        public Builder repositoryRoot(Path repositoryRoot) {
+            this.repositoryRoot = repositoryRoot;
+            return this;
+        }
+
+        /**
+         * Returns a {@code FileConfig} built from the parameters previously set.
+         *
+         * @return a {@code FileConfig} built with parameters of this {@code FileConfig.Builder}
+         */
+        public FileFinder build() {
+            return new FileFinder(this);
+        }
+    }
+
+    private static final class NameEndExclude implements FileMatcher {
+        private final String end;
+
+        private NameEndExclude(String end) {
+            this.end = end;
+        }
+
+        @Override
+        public boolean matches(FileRequest file) {
+            return file.fileName().endsWith(end);
+        }
+    }
+
+    private static final class NameStartExclude implements FileMatcher {
+        private final String start;
+
+        private NameStartExclude(String start) {
+            this.start = start;
+        }
+
+        @Override
+        public boolean matches(FileRequest file) {
+            return file.fileName().startsWith(start);
+        }
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileMatcher.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileMatcher.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import java.util.List;
+
+/**
+ * A matcher for files created from a list of excludes or includes.
+ * Supports the following patterns:
+ * <ul>
+ *     <li>{@code .txt} - matches files with this suffix and files with the same exact file name</li>
+ *     <li>{@code *.txt} - matches files with this suffix</li>
+ *     <li>{@code /etc/txt} - matches files with relative path starting with the provided String</li>
+ *     <li>{@code main/src/} - matches directory (would match both /main/src and /module/main/src)</li>
+ *     <li>{@code Dockerfile.native} - matches exact file name</li>
+ *     <li>Other text - matches a substring of the relative path</li>
+ * </ul>
+ */
+public interface FileMatcher {
+    /**
+     * Create matcher(s) from pattern.
+     *
+     * @param pattern  pattern to parse
+     * @return one or more matchers that can be matched against a {@link io.helidon.build.maven.enforcer.FileRequest}
+     */
+    static List<FileMatcher> create(String pattern) {
+        // if starts with ., it is a suffix
+        if (pattern.startsWith(".") && !pattern.endsWith("/")) {
+            // .ico
+            return List.of(new SuffixMatcher(pattern), new NameMatcher(pattern));
+        }
+        if (pattern.startsWith("*.")) {
+            // *.ico (.gitignore)
+            return List.of(new SuffixMatcher(pattern.substring(1)));
+        }
+        if (pattern.startsWith("/")) {
+            // /etc/txt - from repo root
+            return List.of(new StartsWithMatcher(pattern.substring(1)));
+        }
+        if (pattern.endsWith("/")) {
+            // src/main/proto/
+            return List.of(new DirectoryMatcher(pattern));
+        }
+        if (pattern.contains(".") && !pattern.contains("/")) {
+            // jaxb.index
+            return List.of(new NameMatcher(pattern));
+        }
+        return List.of(new ContainsMatcher(pattern));
+    }
+
+    /**
+     * Whether the file matches.
+     *
+     * @param file file information
+     * @return true if the file matches the rule
+     */
+    boolean matches(FileRequest file);
+
+    /**
+     * Matches relative paths that start with the provided string.
+     */
+    class StartsWithMatcher implements FileMatcher {
+        // exact path from repository root, such as etc/copyright.txt
+        private final String pattern;
+
+        StartsWithMatcher(String pattern) {
+            this.pattern = pattern;
+        }
+
+        /**
+         * Create a new matcher from pattern. Note that the pattern must not have leading slash.
+         *
+         * @param startsWith string the relative path must start with to match
+         * @return new matcher
+         */
+        public static StartsWithMatcher create(String startsWith) {
+            return new StartsWithMatcher(startsWith);
+        }
+
+        @Override
+        public boolean matches(FileRequest file) {
+            return file.relativePath().startsWith(pattern);
+        }
+    }
+
+    /**
+     * Matches relative paths that contain the directory.
+     */
+    class DirectoryMatcher implements FileMatcher {
+        private final ContainsMatcher contains;
+        private final StartsWithMatcher startWith;
+
+        DirectoryMatcher(String directory) {
+            // either the directory is within the tree
+            this.contains = new ContainsMatcher("/" + directory);
+            // or the tree starts with it
+            this.startWith = new StartsWithMatcher(directory);
+        }
+
+        /**
+         * Create a new matcher from a directory string.
+         *
+         * @param directoryString directory to match (can be more than one), never with leading slash
+         * @return a new matcher
+         */
+        public static DirectoryMatcher create(String directoryString) {
+            return new DirectoryMatcher(directoryString);
+        }
+
+        @Override
+        public boolean matches(FileRequest file) {
+            return contains.matches(file) || startWith.matches(file);
+        }
+    }
+
+    /**
+     * Matches relative paths that contain the string.
+     */
+    class ContainsMatcher implements FileMatcher {
+        // such as src/main/proto
+        private final String contains;
+
+        ContainsMatcher(String contains) {
+            this.contains = contains;
+        }
+
+        /**
+         * Create a new matcher.
+         *
+         * @param contains string that must be contained ({@link java.lang.String#contains(CharSequence)}) in the relative path
+         * @return a new matcher
+         */
+        public static ContainsMatcher create(String contains) {
+            return new ContainsMatcher(contains);
+        }
+
+        @Override
+        public boolean matches(FileRequest file) {
+            return file.relativePath().contains(contains);
+        }
+    }
+
+    /**
+     * Matches file name.
+     */
+    class NameMatcher implements FileMatcher {
+        private final String name;
+
+        NameMatcher(String name) {
+            this.name = name;
+        }
+
+        /**
+         * A new matcher that matches the provided file name.
+         *
+         * @param name name of the file to match, in any directory (such as {@code README.md})
+         * @return a new matcher
+         */
+        public static NameMatcher create(String name) {
+            return new NameMatcher(name);
+        }
+
+        @Override
+        public boolean matches(FileRequest file) {
+            return file.fileName().equals(name);
+        }
+    }
+
+    /**
+     * Matches file suffix.
+     */
+    class SuffixMatcher implements FileMatcher {
+        private final String suffix;
+
+        SuffixMatcher(String suffix) {
+            this.suffix = suffix;
+        }
+
+        /**
+         * Create a new suffix matcher.
+         *
+         * @param suffix suffix to match, must include the leading dot
+         * @return a new matcher
+         */
+        public static SuffixMatcher create(String suffix) {
+            return new SuffixMatcher(suffix);
+        }
+
+        @Override
+        public boolean matches(FileRequest file) {
+            return file.suffix().equals(suffix);
+        }
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileRequest.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileRequest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * Information about the current file.
+ */
+public class FileRequest implements Comparable<FileRequest> {
+    private final Path path;
+    private final String relativePath;
+    private final String fileName;
+    private final String suffix;
+    private final String lastModifiedYear;
+
+    private FileRequest(Path path, String relativePath, String fileName, String suffix, String lastModifiedYear) {
+        this.path = path;
+        this.relativePath = relativePath;
+        this.fileName = fileName;
+        this.suffix = suffix;
+        this.lastModifiedYear = lastModifiedYear;
+    }
+
+    /**
+     * @param rootPath root path of the repository
+     * @param relativePath relative path from the rootPath
+     * @param lastModifiedYear year the file was last modified
+     * @return a new file request
+     */
+    public static FileRequest create(Path rootPath, String relativePath, String lastModifiedYear) {
+        Path file = rootPath.resolve(relativePath);
+        String fileName = file.getFileName().toString();
+        String fileSuffix = fileSuffix(fileName);
+
+        return new FileRequest(file, relativePath, fileName, fileSuffix, lastModifiedYear);
+    }
+
+    /**
+     * Path relative to working directory.
+     *
+     * @param relativePath relative path (to the current directory)
+     * @param lastModifiedYear year the file was last modified
+     * @return a new file request
+     */
+    public static FileRequest create(String relativePath, String lastModifiedYear) {
+        Path filePath = Paths.get(relativePath);
+        String fileName = filePath.getFileName().toString();
+        String fileSuffix = fileSuffix(fileName);
+
+        return new FileRequest(filePath, relativePath, fileName, fileSuffix, lastModifiedYear);
+    }
+
+    // testing only
+    static FileRequest create(String relativePath) {
+        int i = relativePath.lastIndexOf('/');
+        String fileName;
+        if (i > -1) {
+            fileName = relativePath.substring(i + 1);
+        } else {
+            fileName = relativePath;
+        }
+
+        return new FileRequest(null, relativePath, fileName, fileSuffix(fileName), "2021");
+    }
+
+    private static String fileSuffix(String fileName) {
+        int index = fileName.lastIndexOf('.');
+        if (index < 0) {
+            return "";
+        }
+        return fileName.substring(index);
+    }
+
+    /**
+     * Full path to the file.
+     *
+     * @return path
+     */
+    public Path path() {
+        return path;
+    }
+
+    /**
+     * Relative path string, not starting with /, using forward slash as path separator.
+     *
+     * @return relative path
+     */
+    public String relativePath() {
+        return relativePath;
+    }
+
+    /**
+     * File name (such as "README.md").
+     *
+     * @return name of the file
+     */
+    public String fileName() {
+        return fileName;
+    }
+
+    /**
+     * File suffix (such as ".md"), including the leading dot.
+     *
+     * @return file suffix
+     */
+    public String suffix() {
+        return suffix;
+    }
+
+    /**
+     * Last modification year of this file.
+     *
+     * @return year last modified
+     */
+    public String lastModifiedYear() {
+        return lastModifiedYear;
+    }
+
+    @Override
+    public int compareTo(FileRequest o) {
+        return this.relativePath.compareTo(o.relativePath);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FileRequest that = (FileRequest) o;
+        return relativePath.equals(that.relativePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(relativePath);
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileSystem.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FileSystem.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.build.util.Style;
+import io.helidon.build.util.StyleRenderer;
+
+/**
+ * File system utilities that only throw runtime exceptions.
+ */
+public final class FileSystem {
+    private FileSystem() {
+    }
+
+    /**
+     * Get the size of the file.
+     *
+     * @param path file to get size of
+     * @return size in bytes
+     * @throws io.helidon.build.maven.enforcer.EnforcerException in case of I/O issues
+     */
+    public static long size(Path path) {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to get size of file " + path.toAbsolutePath(), e);
+        }
+    }
+
+    /**
+     * Read all lines of a file.
+     *
+     * @param path file to read
+     * @return list of lines
+     * @throws io.helidon.build.maven.enforcer.EnforcerException in case of I/O problems
+     */
+    public static List<String> toLines(Path path) {
+        try {
+            return Files.readAllLines(path, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to read lines of file " + path.toAbsolutePath(), e);
+        }
+    }
+
+    /**
+     * Write failures to a file.
+     *
+     * @param path path to write
+     * @param firstLine first line (such as "ENFORCER OK")
+     * @param failures list of failures, each is written with "[ERROR"] prefix
+     * @throws io.helidon.build.maven.enforcer.EnforcerException in case of I/O problem
+     */
+    public static void write(Path path, String firstLine, Map<String, List<RuleFailure>> failures) {
+        List<String> lines = new LinkedList<>();
+        lines.add(firstLine);
+        failures.forEach((rule, ruleFails) -> {
+            lines.add(rule.toUpperCase() + ":");
+            ruleFails.stream()
+                    .map(FileSystem::toFileLine)
+                    .forEach(lines::add);
+        });
+
+        try {
+            Files.write(path, lines, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to write output file " + path.toAbsolutePath(), e);
+        }
+    }
+
+    private static String toFileLine(RuleFailure failure) {
+        return "[ERROR] " + failure.fr().relativePath() + ":" + failure.line() + ": " + Style
+                .strip(StyleRenderer.render(failure.message()));
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FoundFiles.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/FoundFiles.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Files found based on changes in git and local changes.
+ * Result of {@link io.helidon.build.maven.enforcer.FileFinder#findFiles(java.nio.file.Path)}
+ */
+public class FoundFiles {
+    private final Path gitRepoDir;
+    private final List<FileRequest> fileRequests;
+    private final Set<String> locallyModified;
+    private final boolean useGit;
+
+    private FoundFiles(Path gitRepoDir, List<FileRequest> fileRequests, Set<String> locallyModified, boolean useGit) {
+        this.gitRepoDir = gitRepoDir;
+        this.fileRequests = fileRequests;
+        this.locallyModified = locallyModified;
+        this.useGit = useGit;
+    }
+
+    /**
+     * Create new found files.
+     *
+     * @param gitRepoDir path of git repository root
+     * @param fileRequests file requests to process
+     * @param locallyModified list of files that were locally modified
+     * @param useGit whether git is in use
+     * @return new found files
+     */
+    public static FoundFiles create(Path gitRepoDir,
+                                    List<FileRequest> fileRequests,
+                                    Set<String> locallyModified,
+                                    boolean useGit) {
+        return new FoundFiles(gitRepoDir, fileRequests, locallyModified, useGit);
+    }
+
+    /**
+     * Root of git repository.
+     *
+     * @return root
+     */
+    public Path gitRepoDir() {
+        return gitRepoDir;
+    }
+
+    /**
+     * Files to process.
+     * @return files
+     */
+    public List<FileRequest> fileRequests() {
+        return fileRequests;
+    }
+
+    /**
+     * Locally modified paths (relative paths).
+     *
+     * @return locally modified files
+     */
+    public Set<String> locallyModified() {
+        return locallyModified;
+    }
+
+    /**
+     * Whether to use git.
+     *
+     * @return use git
+     */
+    public boolean useGit() {
+        return useGit;
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/GitCommands.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/GitCommands.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for git commands.
+ */
+public final class GitCommands {
+    private static final Pattern DATE_PATTERN = Pattern.compile("(\\d\\d\\d\\d)-\\d\\d-\\d\\d");
+
+    private GitCommands() {
+    }
+
+    /**
+     * Get the root of the git repository.
+     *
+     * @param checkPath path within a repository
+     * @return root of the repository
+     */
+    static Path repositoryRoot(Path checkPath) {
+        // git rev-parse --show-toplevel
+        // /a/b/c/repo-root
+        Path path = Paths.get(singleLine(checkPath,
+                                         "find git repository root",
+                                         "rev-parse",
+                                         "--show-toplevel"));
+
+        if (!Files.exists(path)) {
+            throw new EnforcerException("Git root path does not exist: " + path.toAbsolutePath());
+        }
+
+        return path;
+    }
+
+    /**
+     * Get all files in a directory tracked by the repository.
+     * This may return files that were locally deleted.
+     *
+     * @param root root of the repository
+     * @param checkPath path to check (within the repository)
+     * @return list of files tracked within the checkPath
+     */
+    static Set<FileRequest> gitTracked(Path root, Path checkPath) {
+
+        Process process = startProcess(root, "log", "--pretty=%cd", "--date=short", "--name-status", "--reverse");
+
+        Map<String, Integer> fileToYear = new HashMap<>();
+        int lastYear = -1;
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                Matcher matcher = DATE_PATTERN.matcher(line);
+                if (matcher.matches()) {
+                    lastYear = Integer.parseInt(matcher.group(1));
+                    continue;
+                }
+                if (lastYear == -1) {
+                    throw new EnforcerException("Failed to parse output, expecting date to be present");
+                }
+
+                GitOperation gitOp = gitOp(line);
+                String relativePath = stripGitOp(line);
+
+                switch (gitOp) {
+                case DELETE:
+                    fileToYear.remove(relativePath);
+                    break;
+                case RENAME:
+                    rename(fileToYear, relativePath, lastYear);
+                    break;
+                case COPY:
+                    copy(fileToYear, relativePath, lastYear);
+                    break;
+                case ADD:
+                case MODIFY:
+                default:
+                    // any other type modifies the timestamp
+                    fileToYear.put(relativePath, lastYear);
+                    // do nothing, it is already in
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to read output when getting tracked files", e);
+        }
+
+        waitFor(process, String.valueOf(List.of()));
+
+        List<FileRequest> files = new LinkedList<>();
+        fileToYear.forEach((found, year) -> files.add(FileRequest.create(root, found, String.valueOf(year))));
+
+        // changed files are relative to the root, we need to filter our changed files outside of check path
+        String prefix = root.relativize(checkPath).toString();
+
+        return files.stream()
+                .filter(fr -> fr.relativePath().startsWith(prefix))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Files locally modified.
+     * Ignores deleted files - the user of these methods must consider files that no longer exist to be locally deleted.
+     *
+     * @param root the root directory
+     * @param checkPath directory of interest
+     * @param currentYear current year
+     * @return set of files in the directory of interest that were locally modified
+     */
+    static Set<FileRequest> locallyModified(Path root, Path checkPath, String currentYear) {
+
+        Set<String> changedFiles = multiLine(root,
+                                             "get locally modified files",
+                                             s -> !s.startsWith("??") && !s.startsWith("D"),
+                                             s -> {
+                                                 int firstSpace = s.indexOf(' ');
+                                                 if (firstSpace < 0) {
+                                                     throw new EnforcerException("Cannot parse status line: " + s);
+                                                 }
+                                                 String fileLocation = s.substring(firstSpace).trim().replace('\\', '/');
+                                                 // moved files
+                                                 if (s.startsWith("R")) {
+                                                     // renamed
+                                                     // relative/path.java -> new/relative/path.java
+                                                     int arrow = fileLocation.indexOf(" -> ");
+                                                     if (arrow < 0) {
+                                                         throw new EnforcerException("Cannot parse renamed status line. " + s);
+                                                     }
+                                                     fileLocation = fileLocation.substring(arrow + 4).trim();
+                                                 }
+                                                 return fileLocation;
+                                             },
+                                             "status", "-s");
+
+        // changed files are relative to the root, we need to filter our changed files outside of check path
+        String prefix = root.relativize(checkPath).toString();
+
+        return changedFiles.stream()
+                .filter(relativePath -> relativePath.startsWith(prefix))
+                .map(relativePath -> FileRequest.create(root, relativePath, currentYear))
+                .collect(Collectors.toSet());
+    }
+
+    private static void waitFor(Process process, String output) {
+        try {
+            int i = process.waitFor();
+            if (i != 0) {
+                throw new EnforcerException("Failed to find locally modified files, git exit code: " + i + ", process output: "
+                                                    + output);
+            }
+        } catch (InterruptedException ex) {
+            throw new EnforcerException("Git process was interrupted", ex);
+        }
+
+    }
+
+    private static Process startProcess(Path path, String... command) {
+        String[] allCommands = new String[command.length + 1];
+        allCommands[0] = "git";
+        System.arraycopy(command, 0, allCommands, 1, command.length);
+
+        ProcessBuilder processBuilder = new ProcessBuilder(allCommands)
+                .redirectErrorStream(true)
+                .directory(path.toFile());
+
+        Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to start git process to find modified year", e);
+        }
+
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+        }
+        return process;
+    }
+
+    private static Set<String> multiLine(Path path,
+                                         String message,
+                                         Predicate<String> predicate,
+                                         Function<String, String> mapper,
+                                         String... command) {
+        Process process = startProcess(path, command);
+
+        List<String> fullOutput = new LinkedList<>();
+        Set<String> wantedOutput = new LinkedHashSet<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                fullOutput.add(line);
+                String trimmed = line.trim();
+                if (predicate.test(trimmed)) {
+                    wantedOutput.add(mapper.apply(trimmed));
+                }
+            }
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to read output to " + message, e);
+        }
+
+        waitFor(process, String.valueOf(fullOutput));
+
+        return wantedOutput;
+    }
+
+    private static String singleLine(Path path, String message, String... command) {
+        Process process = startProcess(path, command);
+
+        List<String> output = new LinkedList<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line = reader.readLine();
+
+            // this should be exactly one line
+            if (line == null) {
+                throw new EnforcerException(
+                        "Failed to " + message + ", no output for command"
+                                + " \"" + command + "\" in directory "
+                                + path.toAbsolutePath());
+            } else {
+                String trimmed = line.trim();
+
+                output.add(trimmed);
+                while ((line = reader.readLine()) != null) {
+                    output.add(line);
+                }
+                if (trimmed.isBlank() || output.size() != 1) {
+                    throw new EnforcerException(
+                            "Failed to " + message + ", expected single line output for command"
+                                    + " \"" + command + "\" in directory "
+                                    + path.toAbsolutePath() + ", but got: " + output);
+                }
+                return trimmed;
+            }
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to read output of git process", e);
+        } finally {
+            waitFor(process, String.valueOf(output));
+        }
+    }
+
+    private static void rename(Map<String, Integer> fileToYear, String relativePath, int lastYear) {
+        int i = relativePath.indexOf('\t');
+        if (i < 0) {
+            throw new EnforcerException("Failed to process renamed for path: " + relativePath);
+        }
+        String first = relativePath.substring(0, i).trim();
+        String second = relativePath.substring(i + 1).trim();
+        fileToYear.remove(first);
+        fileToYear.put(second, lastYear);
+    }
+
+    private static void copy(Map<String, Integer> fileToYear, String relativePath, int lastYear) {
+        int i = relativePath.indexOf('\t');
+        if (i < 0) {
+            throw new EnforcerException("Failed to process copy for path: " + relativePath);
+        }
+        String second = relativePath.substring(i + 1).trim();
+        fileToYear.put(second, lastYear);
+    }
+
+    private static String stripGitOp(String line) {
+        int index = line.indexOf('\t');
+        if (index < 1) {
+            throw new EnforcerException("Failed to strip git op for line " + line);
+        }
+        return line.substring(index).trim();
+    }
+
+    private static GitOperation gitOp(String line) {
+        if (line.startsWith("A\t")) {
+            return GitOperation.ADD;
+        }
+        if (line.startsWith("D\t")) {
+            return GitOperation.DELETE;
+        }
+        if (line.startsWith("M\t")) {
+            return GitOperation.MODIFY;
+        }
+        if (line.startsWith("C\t")) {
+            return GitOperation.COPY;
+        }
+        if (line.startsWith("R")) {
+            return GitOperation.RENAME;
+        }
+
+        throw new EnforcerException("Could not parse line " + line);
+    }
+
+    private enum GitOperation {
+        ADD,
+        DELETE,
+        MODIFY,
+        RENAME,
+        COPY
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+/**
+ * Rule failure.
+ */
+public class RuleFailure {
+    private final FileRequest fr;
+    private final String message;
+    private final int line;
+
+    private RuleFailure(FileRequest fr, int line, String message) {
+        this.fr = fr;
+        this.line = line;
+        this.message = message;
+    }
+
+    /**
+     * Create a new rule failure.
+     *
+     * @param fr File request
+     * @param line line within the file
+     * @param message description of the failure
+     * @return a new rule failure
+     */
+    public static RuleFailure create(FileRequest fr, int line, String message) {
+        return new RuleFailure(fr, line, message);
+    }
+
+    /**
+     * File request.
+     *
+     * @return file request causing this failure
+     */
+    public FileRequest fr() {
+        return fr;
+    }
+
+    /**
+     * Descriptive message.
+     * @return message
+     */
+    public String message() {
+        return message;
+    }
+
+    /**
+     * Line within the file, or {@code 0} if cannot be determined.
+     *
+     * @return line number starting from {@code 1}
+     */
+    public int line() {
+        return line;
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailureException.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailureException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+/**
+ * Exception with failure information.
+ */
+public class RuleFailureException extends RuntimeException {
+
+    private final RuleFailure failure;
+
+    /**
+     * Create a new exception that builds {@link io.helidon.build.maven.enforcer.RuleFailure}.
+     *
+     * @param file file request related
+     * @param lineNumber line number within the file
+     * @param error descriptive error message
+     */
+    public RuleFailureException(FileRequest file, int lineNumber, String error) {
+        super(error);
+        this.failure = RuleFailure.create(file, lineNumber, error);
+    }
+
+    /**
+     * Get the failure associated with this exception.
+     *
+     * @return rule failure
+     */
+    public RuleFailure failure() {
+        return failure;
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Copyright.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Copyright.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+import io.helidon.build.maven.enforcer.EnforcerException;
+import io.helidon.build.maven.enforcer.FileMatcher;
+import io.helidon.build.maven.enforcer.FileRequest;
+import io.helidon.build.maven.enforcer.FileSystem;
+import io.helidon.build.maven.enforcer.FoundFiles;
+import io.helidon.build.maven.enforcer.RuleFailure;
+import io.helidon.build.maven.enforcer.RuleFailureException;
+import io.helidon.build.maven.enforcer.copyright.spi.ValidatorProvider;
+import io.helidon.build.util.Log;
+
+/**
+ * Copyright checking.
+ *
+ * @see Copyright.Builder
+ * @see #builder()
+ * @see #check(io.helidon.build.maven.enforcer.FoundFiles)
+ */
+public class Copyright {
+    // quick lookup of validators that handle a file suffix
+    private final Map<String, Validator> suffixToValidator = new HashMap<>();
+    // list of all validators for files not handled by a specific one
+    private final List<Validator> allValidators = new LinkedList<>();
+
+    private final List<FileMatcher> excludes;
+    private final Validator textValidator;
+
+    private Copyright(Builder builder) {
+        this.excludes = builder.excludes;
+
+        // add all validators
+        ServiceLoader<ValidatorProvider> loader = ServiceLoader.load(ValidatorProvider.class);
+        for (ValidatorProvider validatorProvider : loader) {
+            Validator validator = validatorProvider.validator(builder.validatorConfig, builder.templateLines);
+            allValidators.add(validator);
+            for (String suffix : validator.supportedSuffixes()) {
+                suffixToValidator.putIfAbsent(suffix, validator);
+            }
+        }
+        // now add built-in validators
+        List<Validator> builtIns = new LinkedList<>();
+
+        builtIns.add(new ValidatorJava(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorProperties(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorXml(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorAsciidoc(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorBat(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorJsp(builder.validatorConfig, builder.templateLines));
+        this.textValidator = new ValidatorText(builder.validatorConfig, builder.templateLines);
+        builtIns.add(this.textValidator);
+
+        for (Validator validator : builtIns) {
+            allValidators.add(validator);
+            for (String suffix : validator.supportedSuffixes()) {
+                suffixToValidator.putIfAbsent(suffix, validator);
+            }
+        }
+
+    }
+
+    static String logGood(String good) {
+        return "\"$(GREEN " + good.replace(")", "\\)") + ")\"";
+    }
+
+    static String logBad(String bad) {
+        return "\"$(YELLOW " + bad.replace(")", "\\)") + ")\"";
+    }
+
+    /**
+     * Fluent API builder for {@link Copyright}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Check copyrights of files and return a list of found problems.
+     *
+     * @param files files discovered from git and local file system
+     * @return list of problems
+     */
+    public List<RuleFailure> check(FoundFiles files) {
+        Log.info("Obtaining last modified year for up to " + files.fileRequests().size() + " files");
+        // find files to check and their last modified year (if checking year as well)
+        List<FileRequest> validPaths = findFilesToCheck(files);
+
+        List<RuleFailure> failures = new LinkedList<>();
+
+        // perform copyright check on all files
+        for (FileRequest fileRequest : validPaths) {
+            checkCopyright(fileRequest, failures);
+        }
+
+        return failures;
+    }
+
+    private void checkCopyright(FileRequest file, List<RuleFailure> messages) {
+        Path path = file.path();
+        String relativePath = file.relativePath();
+
+        if (!Files.isReadable(path)) {
+            messages.add(RuleFailure.create(file, -1, "not readable"));
+            return;
+        }
+        if (FileSystem.size(path) == 0L) {
+            Log.debug(relativePath + ": ignoring empty file");
+            return;
+        }
+
+        Validator validator = suffixToValidator.get(file.suffix());
+        if (validator == null) {
+            for (Validator candidate : allValidators) {
+                if (candidate.supports(path)) {
+                    validator = candidate;
+                    break;
+                }
+            }
+        }
+        if (validator == null) {
+            Log.debug(relativePath + ": using fallback text validator.");
+            validator = textValidator;
+        }
+
+        Log.verbose(relativePath + " checking copyright with " + validator.getClass().getName());
+        try {
+            validator.validate(file, path);
+        } catch (RuleFailureException e) {
+            messages.add(e.failure());
+        }
+    }
+
+    private List<FileRequest> findFilesToCheck(FoundFiles files) {
+
+        List<FileRequest> validPaths = new LinkedList<>();
+
+        for (FileRequest fileRequest : files.fileRequests()) {
+            addValidFile(fileRequest, validPaths);
+        }
+
+        return validPaths;
+    }
+
+    private void addValidFile(FileRequest file,
+                              List<FileRequest> validPaths) {
+
+        for (FileMatcher exclude : excludes) {
+            if (exclude.matches(file)) {
+                Log.debug("Excluding " + file.relativePath());
+                return;
+            }
+        }
+
+        // now I need to get last modified date from git
+        Log.debug("Including " + file.relativePath() + " with modified year (" + file.lastModifiedYear() + ")");
+        validPaths.add(file);
+    }
+
+    /**
+     * Builder for {@link Copyright}.
+     */
+    public static class Builder {
+        private static final DateTimeFormatter YEAR_FORMATTER = DateTimeFormatter.ofPattern("yyyy");
+
+        private final String currentYear = YEAR_FORMATTER.format(ZonedDateTime.now());
+        private final Validator.ValidatorConfig.Builder validatorConfigBuilder = Validator.ValidatorConfig.builder();
+        // values with defaults
+        private String yearSeparator = ", ";
+
+        // values that must be provided
+        private Path excludesFile;
+        private Path templateFile;
+        private List<FileMatcher> excludes;
+
+        private Validator.ValidatorConfig validatorConfig;
+        private List<TemplateLine> templateLines;
+
+        private Builder() {
+        }
+
+        /**
+         * Build a new copyright.
+         *
+         * @return copyright from this builder
+         */
+        public Copyright build() {
+            validatorConfig = validatorConfigBuilder
+                    .yearSeparator(yearSeparator)
+                    .currentYear(currentYear)
+                    .build();
+
+            if (templateFile == null) {
+                Log.verbose("Parsing default template file (Apache 2).");
+                this.templateLines = TemplateLine.parseTemplate(validatorConfig, defaultCopyrightTemplate());
+            } else {
+                Log.verbose("Parsing template file: " + templateFile.toAbsolutePath());
+                this.templateLines = TemplateLine.parseTemplate(validatorConfig, FileSystem.toLines(templateFile));
+            }
+
+            excludes = parseExcludes();
+            return new Copyright(this);
+        }
+
+        /**
+         * Update configuration from copyright config (when using Maven).
+         *
+         * @param config configuration
+         * @return updated builder
+         */
+        public Builder config(CopyrightConfig config) {
+            config.excludeFile().map(File::toPath).ifPresent(this::excludesFile);
+            config.templateFile().map(File::toPath).ifPresent(this::templateFile);
+            config.yearSeparator().ifPresent(this::yearSeparator);
+            return this;
+        }
+
+        /**
+         * File with excludes.
+         *
+         * @param excludesFile excludes file
+         * @return updated builder
+         */
+        public Builder excludesFile(Path excludesFile) {
+            this.excludesFile = excludesFile;
+            return this;
+        }
+
+        /**
+         * File with copyright template.
+         *
+         * @param templateFile template file
+         * @return updated builder
+         */
+        public Builder templateFile(Path templateFile) {
+            this.templateFile = templateFile;
+            return this;
+        }
+
+        /**
+         * Year separator, defaults to {@code , }.
+         * The result is {@code 2019, 2021}.
+         * Only the first and last year are used.
+         *
+         * @param yearSeparator separator of years
+         * @return updated builder
+         */
+        public Builder yearSeparator(String yearSeparator) {
+            this.yearSeparator = yearSeparator;
+            return this;
+        }
+
+        private List<String> defaultCopyrightTemplate() {
+            InputStream is = Copyright.class.getResourceAsStream("apache.txt");
+
+            List<String> lines = new LinkedList<>();
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    lines.add(line);
+                }
+            } catch (IOException e) {
+                throw new EnforcerException("Failed to read default template from classpath");
+            }
+            return lines;
+        }
+
+        private List<FileMatcher> parseExcludes() {
+            if (excludesFile == null) {
+                return List.of();
+            }
+
+            try {
+                Log.verbose("Parsing matches file: " + excludesFile.toAbsolutePath());
+                return Files.readAllLines(excludesFile)
+                        .stream()
+                        .map(String::trim)
+                        .filter(it -> !it.startsWith("#"))
+                        .filter(it -> !it.isBlank())
+                        .map(FileMatcher::create)
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList());
+            } catch (IOException e) {
+                throw new EnforcerException("Failed to parse excludes file: " + excludesFile, e);
+            }
+        }
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/CopyrightConfig.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/CopyrightConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Copyright configuration to be used with Maven plugin.
+ *
+ * @see io.helidon.build.maven.enforcer.EnforcerMojo
+ */
+public class CopyrightConfig {
+    /**
+     * Fail if copyright is invalid.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean failOnError;
+
+    /**
+     * File with the template to use for copyright.
+     */
+    @Parameter
+    private File templateFile;
+
+    /**
+     * File with excludes.
+     */
+    @Parameter
+    private File excludeFile;
+
+    /**
+     * Copyright year separator.
+     */
+    @Parameter(defaultValue = ", ")
+    private String yearSeparator;
+
+    @Override
+    public String toString() {
+        return "CopyrightConfig{"
+                + ", failOnError=" + failOnError
+                + ", templateFile=" + templateFile
+                + ", excludeFile=" + excludeFile
+                + ", yearSeparator='" + yearSeparator
+                + '}';
+    }
+
+    /**
+     * Whether this rule is configured to fail on error.
+     *
+     * @return whether to fail on error
+     */
+    public boolean failOnError() {
+        return failOnError;
+    }
+
+    Optional<File> templateFile() {
+        return Optional.ofNullable(templateFile);
+    }
+
+    Optional<File> excludeFile() {
+        return Optional.ofNullable(excludeFile);
+    }
+
+    Optional<String> yearSeparator() {
+        return Optional.ofNullable(yearSeparator);
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/FileLine.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/FileLine.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+/**
+ * Numbered file line.
+ */
+class FileLine {
+    private final int lineNumber;
+    private final String line;
+
+    private FileLine(int lineNumber, String line) {
+        this.lineNumber = lineNumber;
+        this.line = line;
+    }
+
+    static FileLine create(int lineNumber, String line) {
+        return new FileLine(lineNumber, line);
+    }
+
+    int lineNumber() {
+        return lineNumber;
+    }
+
+    String line() {
+        return line;
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Main.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Main.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import io.helidon.build.maven.enforcer.FileFinder;
+import io.helidon.build.maven.enforcer.RuleFailure;
+import io.helidon.build.util.Log;
+import io.helidon.build.util.SystemLogWriter;
+
+/**
+ * Main class for copyright checking. The path to check must be a git repository (or a path within a git repository),
+ * otherwise you can only use mode that scans all files and ignores SCM ({@code -a -G}).
+ *
+ * This file will use Java Util Logging, so verbosity can be controlled through it.
+ * <p>
+ * Usage: {@code java -jar this-library.jar [options] directory?}
+ * <p>
+ * Options:
+ * <ul>
+ *     <li>{@code -C file.txt} - path to copyright template with YYYY placeholder for line containing licensor and copyright
+ *     year</li>
+ *     <li>{@code -X file.txt} - path to excludes file, defaults to no excludes</li>
+ *     <li>{@code -Y "-"} - year separator, defaults to {@code ", "} - quotes are stripped</li>
+ *     <li>{@code -G} - do not use git</li>
+ *     <li>{@code -v} - verbose output</li>
+ *     <li>{@code -d} - debug output</li>
+ *     <li>directory - if not defined, current directory is used</li>
+ * </ul>
+ *
+ * Example template file (very simple):
+ * <code><pre>
+ * Copyright (c) YYYY Oracle and/or its affiliates.
+ *
+ * This program is made available under the Apache 2.0 license.
+ * </pre></code>
+ */
+public final class Main {
+    private Main() {
+    }
+
+    /**
+     * Invoke the copyright check.
+     *
+     * @param args options as documented on {@link Main}
+     */
+    public static void main(String[] args) {
+        SystemLogWriter.install(Log.Level.INFO);
+
+        FileFinder.Builder filesBuilder = FileFinder.builder();
+        Copyright.Builder copyrightBuilder = Copyright.builder();
+        boolean verbose = false;
+        boolean debug = false;
+        Path baseDirectory = Paths.get(".").toAbsolutePath();
+
+        for (int optionIndex = 0; optionIndex < args.length; optionIndex++) {
+            String option = args[optionIndex];
+
+            switch (option) {
+            case "-C":
+                // copyright template
+                String templatePath = nextArg("-C", ++optionIndex, args, "Copyright template path");
+                copyrightBuilder.templateFile(Paths.get(templatePath));
+                break;
+            case "-X":
+                // matches file
+                String excludeFile = nextArg("-X", ++optionIndex, args, "Copyright matches file path");
+                copyrightBuilder.excludesFile(Paths.get(excludeFile));
+                break;
+            case "-Y":
+                // year separator
+                String yearSeparator = nextArg("-Y", ++optionIndex, args, "year separator");
+                copyrightBuilder.yearSeparator(yearSeparator);
+                break;
+            case "-G":
+                filesBuilder.useGit(false);
+                break;
+            case "-v":
+                verbose = true;
+                break;
+            case "-d":
+                debug = true;
+                break;
+            case "--help":
+            case "-h":
+            case "/?":
+                help();
+                return;
+            default:
+                if (option.startsWith("-")) {
+                    // unknown option
+                    unknownOption(option);
+                }
+                // path (but only if last option)
+                if (optionIndex == args.length - 1) {
+                    baseDirectory = Paths.get(option).toAbsolutePath();
+                } else {
+                    unknownOption(option);
+                }
+                break;
+            }
+        }
+
+        if (debug) {
+            SystemLogWriter.install(Log.Level.DEBUG);
+        } else if (verbose) {
+            SystemLogWriter.install(Log.Level.VERBOSE);
+        }
+
+        Copyright copyright = copyrightBuilder.build();
+
+        List<RuleFailure> errors = copyright.check(filesBuilder.build().findFiles(baseDirectory));
+        if (errors.isEmpty()) {
+            Log.info("Copyright OK");
+            return;
+        }
+
+        Log.error("Copyright failures (" + errors.size() + "):");
+        for (RuleFailure failure : errors) {
+            Log.error(failure.fr().relativePath() + ":" + failure.line() + " " + failure.message());
+        }
+
+        System.exit(147);
+    }
+
+    private static void unknownOption(String option) {
+        System.err.println("Unknown option " + option);
+        help();
+        System.exit(12);
+    }
+
+    private static void help() {
+        System.out.println("Usage: copyright [options] directory?");
+        System.out.println("Options:");
+        helpOption("-C", "path", "Copyright template file path");
+        helpOption("-X", "path", "Copyright excludes file path");
+        helpOption("-Y", "text", "Year separator in copyright statement");
+        helpOption("-G", "Do not use git, only with -a");
+        helpOption("-d", "Enable debug output");
+        helpOption("-v", "Enable verbose output (less than debug)");
+        helpOption("-h", "Print this help information");
+    }
+
+    private static void helpOption(String flag, String description) {
+        System.out.println("  " + flag + "        " + description);
+    }
+
+    private static void helpOption(String flag, String value, String description) {
+        String filler = " ".repeat(7 - value.length());
+        System.out.println("  " + flag + " " + value + filler + description);
+    }
+
+    private static String nextArg(String flag, int index, String[] args, String description) {
+        if (args.length <= index) {
+            System.err.println("Option " + flag + " requires a value: " + description);
+            System.exit(13);
+        }
+        return args[index];
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/TemplateLine.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/TemplateLine.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import io.helidon.build.maven.enforcer.FileRequest;
+import io.helidon.build.maven.enforcer.RuleFailureException;
+import io.helidon.build.util.Log;
+
+import static io.helidon.build.maven.enforcer.copyright.Copyright.logBad;
+import static io.helidon.build.maven.enforcer.copyright.Copyright.logGood;
+
+/**
+ * Represents a single line in a template to easily validate files.
+ * The line may be blank, text, or copyright line with year information
+ */
+public abstract class TemplateLine {
+    /**
+     * Parse template lines. If the template does not contain a line with year, it will be added as
+     * the first line.
+     *
+     * @param config validator configuration
+     * @param lines lines of the copyright template
+     * @return template lines
+     */
+    public static List<TemplateLine> parseTemplate(Validator.ValidatorConfig config, List<String> lines) {
+        List<TemplateLine> templateLines = new ArrayList<>(lines.size() + 1);
+
+        boolean hasCopyright = false;
+
+        for (String line : lines) {
+            if (line.contains("YYYY")) {
+                templateLines.add(new CopyrightLine(config, line));
+                hasCopyright = true;
+                continue;
+            }
+            if (line.isBlank()) {
+                templateLines.add(new BlankLine());
+                continue;
+            }
+
+            templateLines.add(new TextLine(line));
+        }
+
+        if (!hasCopyright) {
+            templateLines.add(0, new CopyrightLine(config));
+        }
+
+        return templateLines;
+    }
+
+    /**
+     * Validate an actual line against this template line.
+     *
+     *
+     * @param file file request
+     * @param actualLine line to validate
+     * @param lineNumber line number within the copyright comment
+     * @throws io.helidon.build.maven.enforcer.RuleFailureException for validation failures
+     */
+    public abstract void validate(FileRequest file,
+                                  String actualLine,
+                                  int lineNumber) throws RuleFailureException;
+
+    private static class TextLine extends TemplateLine {
+        private final String line;
+
+        private TextLine(String line) {
+            this.line = line;
+        }
+
+        @Override
+        public void validate(FileRequest file,
+                             String actualLine,
+                             int lineNumber) {
+            if (line.equals(actualLine)) {
+                return;
+            }
+
+            throw new RuleFailureException(file,
+                                           lineNumber,
+                                           "Invalid line. Expected " + logGood(line)
+                                                   + ", is " + logBad(actualLine));
+        }
+    }
+
+    private static class BlankLine extends TemplateLine {
+        private BlankLine() {
+        }
+
+        @Override
+        public void validate(FileRequest file,
+                             String actualLine,
+                             int lineNumber) {
+            if (actualLine.isBlank()) {
+                return;
+            }
+            throw new RuleFailureException(file,
+                                           lineNumber,
+                                           "Expected empty line, is " + logBad(actualLine));
+        }
+    }
+
+    private static class CopyrightLine extends TemplateLine {
+        private static final Pattern YEAR = Pattern.compile("\\d\\d\\d\\d ");
+
+        private final String prefix;
+        private final String licensor;
+        private final String suffix;
+        private final String yearSeparator;
+        private final String logExpectedLine;
+
+        private final int minLength;
+        private final int prefixLength;
+        private final int suffixLength;
+        private final int licensorLength;
+        private final int yearSeparatorLength;
+        private final boolean checkFormatOnly;
+        private final Pattern yearsPattern;
+        private final CopyrightLine backup;
+        private final String currentYear;
+
+        private CopyrightLine(CopyrightLineSetup setup, CopyrightLineSetup backup) {
+            this.prefix = setup.prefix;
+            this.licensor = setup.licensor;
+            this.suffix = setup.suffix;
+            this.yearSeparator = setup.yearSeparator;
+            String expectedLine = prefix + "YYYY[" + yearSeparator + "YYYY] " + licensor + suffix;
+            this.logExpectedLine = logGood(expectedLine);
+            this.checkFormatOnly = setup.checkFormatOnly;
+
+            this.prefixLength = prefix.length();
+            this.licensorLength = licensor.length();
+            this.suffixLength = suffix.length();
+            this.yearSeparatorLength = yearSeparator.length();
+            this.minLength = prefixLength + licensorLength + suffixLength + 5;
+            this.yearsPattern = Pattern.compile("\\d\\d\\d\\d" + yearSeparator + "\\d\\d\\d\\d ");
+            this.currentYear = setup.currentYear;
+
+            if (setup.licensor.contains("Oracle")) {
+                this.backup = (backup == null ? null : new CopyrightLine(backup, null));
+            } else {
+                this.backup = null;
+            }
+        }
+
+        CopyrightLine(Validator.ValidatorConfig config) {
+            this(new CopyrightLineSetup(config,
+                                        "Copyright (c) ",
+                                        config.licensor(),
+                                        "."),
+                 null);
+        }
+
+        CopyrightLine(Validator.ValidatorConfig config, String line) {
+            this(parse(config, line), parse(config, line + " All rights reserved."));
+        }
+
+        private static CopyrightLineSetup parse(Validator.ValidatorConfig config, String line) {
+            // line in template
+            // Copyright (c) YYYY Oracle and/or its affiliates.
+            int yyyy = line.indexOf("YYYY");
+
+            int dot = line.indexOf(".", yyyy);
+            if (dot < 0) {
+                dot = line.length();
+            }
+
+            return new CopyrightLineSetup(
+                    config,
+                    line.substring(0, yyyy),
+                    line.substring(yyyy + 5, dot),
+                    line.substring(dot));
+        }
+
+        @Override
+        public void validate(FileRequest file,
+                             String actualLine,
+                             int lineNumber) {
+            try {
+                doValidate(file, actualLine, file.lastModifiedYear(), lineNumber);
+            } catch (RuleFailureException e) {
+                // for older files, we allow "All rights reserved." suffix
+                if (backup != null && !file.lastModifiedYear().equals(currentYear)) {
+                    try {
+                        backup.validate(file, actualLine, lineNumber);
+                    } catch (RuleFailureException ignored) {
+                        throw e;
+                    }
+                } else {
+                    // current year - cannot have this
+                    throw e;
+                }
+            }
+        }
+
+        private void doValidate(FileRequest file, String actualLine, String expectedYear, int lineNumber) {
+            //Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+            //Copyright (c) 2021 Oracle and/or its affiliates.
+            if (actualLine.length() < minLength) {
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Line too short. Expected " + logExpectedLine + ", is " + logBad(actualLine));
+            }
+
+            int lineLength = actualLine.length();
+
+            // Copyright line:
+            //      Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+
+            // "Copyright (c) "
+            String actualPrefix = actualLine.substring(0, prefixLength);
+
+            // expected starts
+            int suffixStart = lineLength - suffixLength;
+            int licensorStart = suffixStart - licensorLength;
+            String yearSection;
+            // after prefix, we should have the year section - either yyyy or yyyy, yyyy
+            if (isYears(actualLine, prefixLength)) {
+                // year section without the trailing space
+                yearSection = actualLine.substring(prefixLength, prefixLength + 10);
+                licensorStart = prefixLength + 11;
+            } else if (isYear(actualLine, prefixLength)) {
+                // year section without the trailing space
+                yearSection = actualLine.substring(prefixLength, prefixLength + 4);
+                licensorStart = prefixLength + 5;
+            } else {
+                yearSection = actualLine.substring(prefixLength, licensorStart).trim();
+            }
+
+            String actualSuffix = actualLine.substring(suffixStart, lineLength);
+            String actualLicensor = actualLine.substring(licensorStart, suffixStart);
+
+            // start validation
+            if (!actualPrefix.equals(prefix)) {
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Wrong prefix. Expected " + logExpectedLine
+                                                       + ", is " + logBad(actualPrefix));
+            }
+
+            if (!actualSuffix.equals(suffix)) {
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Wrong suffix. Expected " + logExpectedLine
+                                                       + ", is " + logBad(actualSuffix));
+            }
+
+            if (!actualLicensor.equals(licensor)) {
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Wrong format. Expected "
+                                                       + logGood(licensor)
+                                                       + ", is "
+                                                       + logBad(actualLicensor));
+            }
+
+            if (yearSection.length() == 4) {
+                // this is the year - make sure all numbers
+
+                validateYearFormat(file, lineNumber, actualLine, yearSection);
+
+                if (!checkFormatOnly) {
+                    Log.debug("Expected year: " + expectedYear + ", actual year: " + yearSection);
+                    validateYear(file, lineNumber, yearSection, expectedYear);
+                }
+            } else {
+                if (yearSection.length() == (8 + yearSeparatorLength)) {
+                    // expected length
+                    String firstYear = yearSection.substring(0, 4);
+                    String actualSeparator = yearSection.substring(4, 4 + yearSeparatorLength);
+                    String secondYear = yearSection.substring(4 + yearSeparatorLength);
+                    validateYearFormat(file, lineNumber, actualLine, firstYear);
+                    validateYearFormat(file, lineNumber, actualLine, secondYear);
+                    if (!actualSeparator.equals(this.yearSeparator)) {
+                        throw new RuleFailureException(file,
+                                                       lineNumber,
+                                                       "Wrong year separator. Expected  "
+                                                               + logGood(yearSeparator)
+                                                               + ", is "
+                                                               + logBad(actualSeparator)
+                                                               + ", on line "
+                                                               + logBad(actualLine));
+                    }
+                    if (!checkFormatOnly) {
+                        Log.debug("Expected year: " + expectedYear + ", actual years: " + yearSection);
+                        validateYear(file, lineNumber, firstYear, secondYear, expectedYear);
+                    }
+                } else {
+                    throw new RuleFailureException(file,
+                                                   lineNumber,
+                                                   "Wrong year. Expected "
+                                                           + logGood("yyyy" + yearSeparator + expectedYear)
+                                                           + ", is "
+                                                           + logBad(yearSection));
+                }
+            }
+        }
+
+        private boolean isYear(String actualLine, int prefixLength) {
+            // 2019
+            if (actualLine.length() >= prefixLength + 5) {
+                String years = actualLine.substring(prefixLength, prefixLength + 5);
+                return YEAR.matcher(years).matches();
+            }
+
+            return false;
+        }
+
+        private boolean isYears(String actualLine, int prefixLength) {
+            // 2019, 2021
+            if (actualLine.length() >= prefixLength + 11) {
+                String years = actualLine.substring(prefixLength, prefixLength + 11);
+                return yearsPattern.matcher(years).matches();
+            }
+
+            return false;
+        }
+
+        private void validateYear(FileRequest file, int lineNumber, String actualFrom, String actualTo, String expectedYear) {
+            if (!actualTo.equals(expectedYear)) {
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Wrong year. Expected "
+                                                       + logGood(actualFrom + yearSeparator + expectedYear)
+                                                       + ", is "
+                                                       + logBad(actualFrom + yearSeparator + actualTo));
+            }
+        }
+
+        private void validateYear(FileRequest file, int lineNumber, String actualYear, String expectedYear) {
+            if (!actualYear.equals(expectedYear)) {
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Wrong year. Expected "
+                                                       + logGood(actualYear + yearSeparator + expectedYear)
+                                                       + ", is "
+                                                       + logBad(actualYear));
+            }
+        }
+
+        void validateYearFormat(FileRequest file, int lineNumber, String line, String year) {
+            try {
+                Integer.parseInt(year);
+            } catch (NumberFormatException e) {
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Wrong year format. Expected "
+                                                       + logGood("4 digits")
+                                                       + ", is "
+                                                       + logBad(year)
+                                                       + ", on line "
+                                                       + logBad(line));
+            }
+        }
+
+        private static class CopyrightLineSetup {
+            private final String prefix;
+            private final String licensor;
+            private final String suffix;
+            private final String yearSeparator;
+            private final boolean checkFormatOnly;
+            private final String currentYear;
+
+            private CopyrightLineSetup(Validator.ValidatorConfig config,
+                                       String prefix,
+                                       String licensor,
+                                       String suffix) {
+                this.prefix = prefix;
+                this.licensor = licensor;
+                this.suffix = suffix;
+                this.yearSeparator = config.yearSeparator();
+                this.checkFormatOnly = config.checkFormatOnly();
+                this.currentYear = config.currentYear();
+            }
+        }
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Validator.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Validator.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import io.helidon.build.maven.enforcer.FileRequest;
+import io.helidon.build.maven.enforcer.RuleFailureException;
+
+/**
+ * A validator for a certain type of files.
+ */
+public interface Validator {
+    /**
+     * Return a set of suffixes this validator supports. If a suffix is supported, no further checks are done.
+     *
+     * @return set of suffixes including the {@code .}, such as {@code .java}
+     * @see #supports(java.nio.file.Path)
+     */
+    Set<String> supportedSuffixes();
+
+    /**
+     * Return {@code true} if this validator supports the provided path. This may be used for more
+     * complex analysis of the file content when a suffix is not sufficient.
+     *
+     * @param path path of the file
+     * @return {@code true} if this validator can process the file
+     */
+    default boolean supports(Path path) {
+        return false;
+    }
+
+    /**
+     * Validate copyright of the file.
+     *
+     *
+     * @param file the file request
+     * @param path path of the file
+     * @throws io.helidon.build.maven.enforcer.RuleFailureException (such as copyright year should be 2019, 2021, but was 2019)
+     */
+    void validate(FileRequest file, Path path) throws RuleFailureException;
+
+    /**
+     * Validator configuration.
+     */
+    interface ValidatorConfig {
+        /**
+         * A new builder.
+         * @return new fluent API builder
+         */
+        static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Separator to use between years in copyright (when using 2).
+         *
+         * @return year separator
+         */
+        String yearSeparator();
+
+        /**
+         * Validator should only check format, not validity of years.
+         *
+         * @return whether to check only format
+         */
+        boolean checkFormatOnly();
+
+        /**
+         * Expected licensor (the company) in copyright header.
+         *
+         * @return name of the expected licensor
+         */
+        String licensor();
+
+        /**
+         * Current year.
+         *
+         * @return this year
+         */
+        String currentYear();
+
+        /**
+         * Fluent API builder to build {@link Validator.ValidatorConfig}.
+         */
+        class Builder {
+            private String yearSeparator = ", ";
+            private boolean checkFormatOnly;
+            private String defaultLicensor = "Oracle and/or its affiliates";
+            private String currentYear;
+
+            private Builder() {
+            }
+
+            public ValidatorConfig build() {
+                return new ValidatorConfigImpl(this);
+            }
+
+            /**
+             * String to separate years in copyright header.
+             *
+             * @param yearSeparator separator to use, such as {@code ", "}
+             * @return updated builder
+             */
+            public Builder yearSeparator(String yearSeparator) {
+                this.yearSeparator = yearSeparator;
+                return this;
+            }
+
+            /**
+             * Whether to check only format and ignore last modified year.
+             *
+             * @param checkFormatOnly {@code true} to only check format
+             * @return updated builder
+             */
+            public Builder checkFormatOnly(boolean checkFormatOnly) {
+                this.checkFormatOnly = checkFormatOnly;
+                return this;
+            }
+
+            /**
+             * Configure the default licensor.
+             *
+             * @param defaultLicensor default licensor in copyright header
+             * @return updated builder
+             */
+            public Builder defaultLicensor(String defaultLicensor) {
+                this.defaultLicensor = defaultLicensor;
+                return this;
+            }
+
+            public Builder currentYear(String currentYear) {
+                this.currentYear = currentYear;
+                return this;
+            }
+
+            private static class ValidatorConfigImpl implements ValidatorConfig {
+                private final String yearSeparator;
+                private final boolean checkFormatOnly;
+                private final String licensor;
+                private final String currentYear;
+
+                private ValidatorConfigImpl(Builder builder) {
+                    this.yearSeparator = builder.yearSeparator;
+                    this.checkFormatOnly = builder.checkFormatOnly;
+                    this.licensor = builder.defaultLicensor;
+                    this.currentYear = builder.currentYear;
+                }
+
+                @Override
+                public String yearSeparator() {
+                    return yearSeparator;
+                }
+
+                @Override
+                public boolean checkFormatOnly() {
+                    return checkFormatOnly;
+                }
+
+                @Override
+                public String licensor() {
+                    return licensor;
+                }
+
+                @Override
+                public String currentYear() {
+                    return currentYear;
+                }
+            }
+        }
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorAsciidoc.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorAsciidoc.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorAsciidoc extends ValidatorBase {
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("    ");
+
+    protected ValidatorAsciidoc(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".adoc");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return "/".repeat(79);
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return "/".repeat(79);
+    }
+
+    @Override
+    protected boolean allowLeadEmptyLine() {
+        return true;
+    }
+
+    @Override
+    protected boolean allowTrailEmptyLine(String modifiedYear) {
+        return true;
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("=");
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorBase.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorBase.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.build.maven.enforcer.EnforcerException;
+import io.helidon.build.maven.enforcer.FileRequest;
+import io.helidon.build.maven.enforcer.RuleFailureException;
+import io.helidon.build.util.Log;
+
+import static io.helidon.build.maven.enforcer.copyright.Copyright.logBad;
+import static io.helidon.build.maven.enforcer.copyright.Copyright.logGood;
+
+/**
+ * Base class for validators.
+ */
+public abstract class ValidatorBase implements Validator {
+    private final List<TemplateLine> templateLines;
+    private final String currentYear;
+
+    /**
+     * Create a new instance.
+     *
+     * @param validatorConfig validator configuration
+     * @param templateLines lines of the template
+     */
+    protected ValidatorBase(ValidatorConfig validatorConfig,
+                            List<TemplateLine> templateLines) {
+        this.templateLines = templateLines;
+        this.currentYear = validatorConfig.currentYear();
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return false;
+    }
+
+    @Override
+    public void validate(FileRequest file, Path path) {
+        Log.verbose("Processing file: " + path);
+
+        List<FileLine> copyrightComment;
+
+        try (BufferedReader br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            copyrightComment = readComment(file, br);
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to read file " + path, e);
+        }
+
+        if (copyrightComment.size() != templateLines.size()) {
+            if (copyrightComment.isEmpty()) {
+                throw new RuleFailureException(file,
+                                               0,
+                                               "Expecting copyright with " + logGood(String.valueOf(templateLines.size()))
+                                                       + " lines, but it was " + logBad("empty"));
+            } else {
+                throw new RuleFailureException(file,
+                                               copyrightComment.iterator().next().lineNumber(),
+                                               "Expecting copyright with "
+                                                       + logGood(String.valueOf(templateLines.size()))
+                                                       + " lines, but it contained "
+                                                       + logBad(String.valueOf(copyrightComment.size()))
+                                                       + " lines");
+            }
+        }
+
+        for (int i = 0; i < copyrightComment.size(); i++) {
+            FileLine actualLine = copyrightComment.get(i);
+            TemplateLine templateLine = templateLines.get(i);
+
+            templateLine.validate(file, actualLine.line(), actualLine.lineNumber());
+        }
+    }
+
+    /**
+     * Read comment from a reader.
+     *
+     *
+     * @param file file request
+     * @param reader read for the file
+     * @return the comment that should contain copyright
+     * @throws IOException in case of I/O problems
+     */
+    protected List<FileLine> readComment(FileRequest file,
+                                         BufferedReader reader) throws IOException {
+        String line;
+        int lineNumber = 0;
+
+        // skip beginning of file
+        while ((line = reader.readLine()) != null) {
+            lineNumber++;
+            if (line.isBlank()) {
+                continue;
+            }
+            if (isPreamble(line.trim())) {
+                if (copyrightBeforePreamble()) {
+                    return List.of();
+                }
+                continue;
+            }
+            // we got a real line
+            break;
+        }
+
+        if (line == null) {
+            return List.of();
+        }
+
+        // now we must have comment - otherwise there is no copyright
+        // also the first line must be empty otherwise
+        if (!isCommentStart(line.trim())) {
+            throw new RuleFailureException(file, lineNumber, "No comment found");
+        }
+
+        List<FileLine> comment = new ArrayList<>();
+
+        while ((line = reader.readLine()) != null) {
+            lineNumber++;
+
+            if (supportsBlockComments()) {
+                if (line.trim().startsWith(blockCommentEnd())) {
+                    // end of comment
+                    break;
+                }
+            } else {
+                if (!line.trim().startsWith(lineCommentStart().orElseThrow(() -> new EnforcerException(
+                        "When block comment is not supported, line comment must be defined.")))) {
+                    // end of comment
+                    break;
+                }
+            }
+            line = removeComment(file, line, lineNumber);
+            comment.add(FileLine.create(lineNumber, line));
+        }
+
+        if (comment.isEmpty()) {
+            throw new RuleFailureException(file, lineNumber, "No comment found");
+        }
+
+        if (allowLeadEmptyLine()) {
+            // allow one line before
+            if (comment.get(0).line().isBlank()) {
+                comment.remove(0);
+            }
+        }
+
+        if (allowTrailEmptyLine(file.lastModifiedYear())) {
+            // allow one line after
+            if (comment.get(comment.size() - 1).line().isBlank()) {
+                containsTrailingEmptyLine(file);
+                comment.remove(comment.size() - 1);
+            }
+        }
+
+        if (!supportsBlockComments()) {
+            // last line may be empty
+            if (comment.get(comment.size() - 1).line().isBlank()) {
+                comment.remove(comment.size() - 1);
+            }
+        }
+        return comment;
+    }
+
+    /**
+     * Called if a trailing empty line exists in a copyright comment.
+     *
+     * @param file file
+     */
+    protected void containsTrailingEmptyLine(FileRequest file) {
+    }
+
+    /**
+     * Whether we can have an additional line before the copyright text within the comment.
+     *
+     * @return whether to allow leading empty line
+     */
+    protected boolean allowLeadEmptyLine() {
+        return false;
+    }
+
+    /**
+     * Whether we can have an additional line after the copyright text within the comment.
+     *
+     * @return whether to allow trailing empty line
+     * @param modifiedYear year of last modification
+     */
+    protected boolean allowTrailEmptyLine(String modifiedYear) {
+        return false;
+    }
+
+    /**
+     * Whether copyright should be before preamble (if one is supported).
+     *
+     * @return whether copyright should be before preamble ({@code true} by default)
+     */
+    protected boolean copyrightBeforePreamble() {
+        return true;
+    }
+
+    /**
+     * Remove comment from a line.
+     *
+     *
+     * @param file file request
+     * @param line line text
+     * @param lineNumber line number
+     * @return line stripped of comment prefix
+     */
+    protected String removeComment(FileRequest file, String line, int lineNumber) {
+        if (supportsBlockComments()) {
+            if (blockCommentPrefix().isPresent()) {
+                String block = blockCommentPrefix().get();
+                if (block.isBlank() || block.startsWith(" ")) {
+                    // prefixed by spaces or tabs
+                    if (line.startsWith(block)) {
+                        return line.substring(block.length());
+                    }
+                    if (line.isBlank()) {
+                        return "";
+                    }
+                } else {
+                    String trimmed = line.trim();
+                    if (trimmed.startsWith(block)) {
+                        // we expect a space after the block
+                        if (trimmed.length() == block.length()) {
+                            return "";
+                        }
+                        if (trimmed.charAt(block.length()) != ' ') {
+                            throw new RuleFailureException(file,
+                                                           lineNumber,
+                                                           "Expected prefix "
+                                                                   + logGood(block) + ", but line is "
+                                                                   + logBad(line));
+                        }
+                        return trimmed.substring(block.length() + 1);
+                    }
+                }
+                throw new RuleFailureException(file,
+                                               lineNumber,
+                                               "Expected prefix "
+                                                       + logGood(block) + ", but line is "
+                                                       + logBad(line));
+            }
+        }
+
+        if (lineCommentStart().isPresent()) {
+            String lineComment = lineCommentStart().get();
+            if (line.startsWith(lineComment)) {
+                String substring = line.substring(lineComment.length());
+                if (substring.startsWith(" ")) {
+                    substring = substring.substring(1);
+                }
+                return substring;
+            }
+        }
+
+        return line;
+    }
+
+    /**
+     * Does this line start a multiline comment, or is it a comment.
+     *
+     * @param line line text
+     * @return whether the line is start of multiline comment or a single line comment
+     */
+    protected boolean isCommentStart(String line) {
+        if (supportsBlockComments()) {
+            return line.startsWith(blockCommentStart());
+        }
+        return line.startsWith(lineCommentStart().orElseThrow(() -> new EnforcerException(
+                "When block comment is not supported, line comment must be defined.")));
+    }
+
+    /**
+     * Whether the file starts with the provided prefix.
+     * Utility method to "peek" into the file.
+     *
+     * @param path path of the file
+     * @param prefix prefix to look for
+     * @return whether the file starts with the prefix
+     */
+    protected final boolean startsWith(Path path, String prefix) {
+        return startsWith(path, prefix.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Whether the file starts with the provided prefix.
+     * Utility method to "peek" into the file.
+     *
+     * @param path path of the file
+     * @param prefix prefix to look for
+     * @return whether the file starts with the prefix
+     */
+    protected final boolean startsWith(Path path, byte[] prefix) {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            byte[] chunk = new byte[prefix.length];
+            int read = inputStream.read(chunk);
+            if (read < chunk.length) {
+                return false;
+            }
+            return Arrays.equals(prefix, chunk);
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to check file from prefix. Path: " + path, e);
+        }
+    }
+
+    /**
+     * Whether this validator supports multiline (block) comments.
+     *
+     * @return whether block comments are supported
+     */
+    protected boolean supportsBlockComments() {
+        return false;
+    }
+
+    /**
+     * Start of block comment (if supported).
+     *
+     * @return beginning of block comment
+     */
+    protected String blockCommentStart() {
+        return null;
+    }
+
+    /**
+     * End of block comment (if supported).
+     *
+     * @return end of block comment
+     */
+    protected String blockCommentEnd() {
+        return null;
+    }
+
+    /**
+     * Optional prefix used on lines within a block comment.
+     *
+     * @return prefix
+     */
+    protected Optional<String> blockCommentPrefix() {
+        return Optional.empty();
+    }
+
+    /**
+     * Beginning of single line comment, only used if {@link #supportsBlockComments()}
+     * is set to false.
+     *
+     * @return beginning of line comment
+     */
+    protected Optional<String> lineCommentStart() {
+        return Optional.empty();
+    }
+
+    /**
+     * Whether the current line is a preamble (such as {@code package} statement in Java).
+     *
+     * @param line line text
+     * @return whether the line is a preamble
+     */
+    protected boolean isPreamble(String line) {
+        return false;
+    }
+
+    /**
+     * Current year.
+     *
+     * @return current year
+     */
+    protected final String currentYear() {
+        return currentYear;
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorBat.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorBat.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorBat extends ValidatorBase {
+    protected ValidatorBat(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".bat");
+    }
+
+    @Override
+    protected Optional<String> lineCommentStart() {
+        return Optional.of("@REM");
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorJava.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorJava.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.build.maven.enforcer.FileRequest;
+import io.helidon.build.util.Log;
+
+class ValidatorJava extends ValidatorBase {
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("*");
+
+    protected ValidatorJava(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".java",
+                      ".g",
+                      ".c",
+                      ".h",
+                      ".css",
+                      ".js");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return super.startsWith(path, "/*\n");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return "/*";
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return "*/";
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("package ");
+    }
+
+    @Override
+    protected boolean allowTrailEmptyLine(String modifiedYear) {
+        // we have a leeway here - for files modified before current year, we allow a trailing line
+        //return !currentYear().equals(modifiedYear);
+        return true;
+    }
+
+    @Override
+    protected void containsTrailingEmptyLine(FileRequest file) {
+        Log.warn("File " + file.relativePath() + " contains trailing empty line in copyright comment.");
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorJsp.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorJsp.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorJsp extends ValidatorBase {
+    public static final String BLOCK_COMMENT_START = "<%--";
+    public static final String BLOCK_COMMENT_END = "--%>";
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("    ");
+
+    protected ValidatorJsp(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".jsp");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return path.getFileName().toString().equals("build.properties") && super.startsWith(path, "<");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return BLOCK_COMMENT_START;
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return BLOCK_COMMENT_END;
+    }
+
+    @Override
+    protected boolean allowLeadEmptyLine() {
+        return true;
+    }
+
+    @Override
+    protected boolean allowTrailEmptyLine(String modifiedYear) {
+        return true;
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorProperties.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorProperties.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorProperties extends ValidatorBase {
+    protected ValidatorProperties(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".properties",
+                      ".prefs",
+                      ".py",
+                      ".sh",
+                      ".ksh");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        String fileName = path.getFileName().toString();
+        if (fileName.startsWith("Makefile")) {
+            return true;
+        }
+        if (fileName.startsWith("GNUmakefile")) {
+            return true;
+        }
+        if (fileName.startsWith("Rakefile")) {
+            return true;
+        }
+        if (fileName.startsWith("Dockerfile")) {
+            return true;
+        }
+        if (fileName.equals("osgi.bundle")) {
+            return true;
+        }
+
+        return startsWith(path, "#");
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("#!");
+    }
+
+    @Override
+    protected boolean copyrightBeforePreamble() {
+        return false;
+    }
+
+    @Override
+    protected Optional<String> lineCommentStart() {
+        return Optional.of("#");
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorText.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorText.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorText extends ValidatorBase {
+    protected ValidatorText(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of();
+    }
+
+    @Override
+    protected Optional<String> lineCommentStart() {
+        return Optional.of("#");
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorXml.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorXml.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+class ValidatorXml extends ValidatorBase {
+    private static final Optional<String> BLOCK_COMMENT_PREFIX = Optional.of("    ");
+
+    protected ValidatorXml(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".xml",
+                      ".xsl",
+                      ".html",
+                      ".xhtml",
+                      ".htm",
+                      ".dtd",
+                      ".xsd",
+                      ".wsdl",
+                      ".inc",
+                      ".jnlp",
+                      ".tld",
+                      ".xcs",
+                      ".jsf",
+                      ".hs",
+                      ".jhm");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return path.getFileName().toString().equals("build.properties") && super.startsWith(path, "<");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return "<!--";
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return "-->";
+    }
+
+    @Override
+    protected boolean allowLeadEmptyLine() {
+        return true;
+    }
+
+    @Override
+    protected boolean allowTrailEmptyLine(String modifiedYear) {
+        return true;
+    }
+
+    @Override
+    protected Optional<String> blockCommentPrefix() {
+        return BLOCK_COMMENT_PREFIX;
+    }
+
+    @Override
+    protected boolean copyrightBeforePreamble() {
+        return false;
+    }
+
+    @Override
+    protected boolean isPreamble(String line) {
+        return line.startsWith("<?xml ")
+                || line.startsWith("<!DOCTYPE")
+                || line.startsWith("<html")
+                || line.startsWith("<head>")
+                || line.startsWith("<meta");
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/package-info.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Copyright rule.
+ * Copyright can be launched from command line using {@link io.helidon.build.maven.enforcer.copyright.Main}.
+ */
+package io.helidon.build.maven.enforcer.copyright;

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/spi/ValidatorProvider.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/spi/ValidatorProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright.spi;
+
+import java.util.List;
+
+import io.helidon.build.maven.enforcer.copyright.TemplateLine;
+import io.helidon.build.maven.enforcer.copyright.Validator;
+
+/**
+ * Java service loader interface to extend the functionality of copyright checking.
+ */
+public interface ValidatorProvider {
+    /**
+     * Create a custom validator.
+     *
+     * @param config configuration
+     * @param templateLines lines of copyright template
+     * @return a new validator instance
+     */
+    Validator validator(Validator.ValidatorConfig config, List<TemplateLine> templateLines);
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/spi/package-info.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/spi/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Copyright rule SPI.
+ * Allows for custom {@link io.helidon.build.maven.enforcer.copyright.Validator validators} to be created
+ * with service {@link io.helidon.build.maven.enforcer.copyright.spi.ValidatorProvider}.
+ */
+package io.helidon.build.maven.enforcer.copyright.spi;

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/package-info.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Maven copyright plugin and command line copyright tool.
+ *
+ * @see io.helidon.build.maven.enforcer.EnforcerMojo
+ * @see io.helidon.build.maven.enforcer.copyright.Main
+ */
+package io.helidon.build.maven.enforcer;

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/typo/TypoConfig.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/typo/TypoConfig.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.typo;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Configuration of typos rule, used by {@link io.helidon.build.maven.enforcer.EnforcerMojo}.
+ */
+public class TypoConfig {
+    /**
+     * Fail if typos found.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean failOnError;
+
+    /**
+     * List of typos to look for.
+     */
+    @Parameter(required = true)
+    private String[] typos;
+
+    /**
+     * List of suffixes (such as {@code .js}) and file names (such as {@code Dockerfile}) to include.
+     */
+    @Parameter
+    private String[] includes;
+
+    /**
+     * List of suffixes (such as {@code .js}) and file names (such as {@code Dockerfile}) to include.
+     */
+    @Parameter
+    private String[] excludes;
+
+    /**
+     * Whether to fail on error.
+     *
+     * @return fail on error
+     */
+    public boolean failOnError() {
+        return failOnError;
+    }
+
+    @Override
+    public String toString() {
+        return "TypoConfig{"
+                + "failOnError=" + failOnError
+                + ", typos=" + Arrays.toString(typos)
+                + ", includes=" + Arrays.toString(includes)
+                + ", excludes=" + Arrays.toString(excludes)
+                + '}';
+    }
+
+    Set<String> typos() {
+        return Arrays.stream(typos)
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+    }
+
+    Set<String> excludes() {
+        if (excludes == null) {
+            return Set.of();
+        }
+        return Set.of(excludes);
+    }
+
+    Set<String> includes() {
+        if (includes == null) {
+            return Set.of();
+        }
+        return Set.of(includes);
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/typo/TyposRule.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/typo/TyposRule.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.typo;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import io.helidon.build.maven.enforcer.EnforcerException;
+import io.helidon.build.maven.enforcer.FileMatcher;
+import io.helidon.build.maven.enforcer.FileRequest;
+import io.helidon.build.maven.enforcer.FoundFiles;
+import io.helidon.build.maven.enforcer.RuleFailure;
+import io.helidon.build.util.Log;
+
+/**
+ * Rule for typos checking.
+ */
+public class TyposRule {
+    private static final Set<String> DEFAULT_INCLUDES = Set.of(".java", ".xml", ".adoc",
+                                                               ".txt", ".md", ".html",
+                                                               ".css", ".properties", ".yaml",
+                                                               ".sh", ".sql", ".conf",
+                                                               ".json", ".kt", ".groovy",
+                                                               ".mustache", ".yml", ".graphql",
+                                                               ".proto", "Dockerfile.native", "Dockerfile.jlink",
+                                                               ".gradle", ".MF");
+    private final Set<String> typos;
+    private final List<FileMatcher> excludes;
+    private final List<FileMatcher> includes;
+
+    private TyposRule(Builder builder) {
+        this.typos = builder.typosConfig.typos();
+        this.excludes = builder.excludes();
+        this.includes = builder.includes();
+    }
+
+    /**
+     * Fluent API builder for typos rule.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Check the files for typos.
+     *
+     * @param filesToCheck files to check
+     * @return list of identified failures
+     */
+    public List<RuleFailure> check(FoundFiles filesToCheck) {
+        List<RuleFailure> failures = new LinkedList<>();
+
+        AtomicInteger count = new AtomicInteger();
+
+        filesToCheck.fileRequests()
+                .stream()
+                .filter(this::include)
+                .forEach(fr -> {
+                    count.incrementAndGet();
+                    processFile(fr, failures);
+                });
+
+        if (failures.size() == 0) {
+            Log.info("Typos processed " + count.get() + " files.");
+        } else {
+            Log.info("Typos processed " + count.get() + " files, found " + failures.size() + " errors");
+        }
+        return failures;
+    }
+
+    private void processFile(FileRequest fr, List<RuleFailure> errors) {
+        try (BufferedReader bufferedReader = Files.newBufferedReader(fr.path(), StandardCharsets.UTF_8)) {
+            String line;
+            int lineNum = 0;
+            List<String> foundTypos = new LinkedList<>();
+            while ((line = bufferedReader.readLine()) != null) {
+                // we want to start from 1
+                lineNum++;
+                for (String typo : typos) {
+                    if (line.toLowerCase().contains(typo)) {
+                        // we have to exclude the definition of the typo itself in plugin config
+                        if (fr.fileName().equals("pom.xml")) {
+                            // this may be a typo definition
+                            if (line.toLowerCase().contains("<typo>" + typo + "</typo>")) {
+                                // yep, this is it
+                                continue;
+                            }
+                        }
+                        foundTypos.add(typo);
+                    }
+                }
+                if (!foundTypos.isEmpty()) {
+                    errors.add(RuleFailure.create(fr, lineNum, "typos found: " + String.join(", ", foundTypos)));
+                }
+                foundTypos.clear();
+            }
+
+        } catch (IOException e) {
+            throw new EnforcerException("Failed to process file for typos: " + fr.relativePath());
+        }
+    }
+
+    private boolean include(FileRequest fr) {
+        for (FileMatcher exclude : excludes) {
+            if (exclude.matches(fr)) {
+                return false;
+            }
+        }
+
+        for (FileMatcher include : includes) {
+            if (include.matches(fr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fluent API builder for {@link io.helidon.build.maven.enforcer.typo.TyposRule}.
+     */
+    public static class Builder {
+        private TypoConfig typosConfig;
+
+        private Builder() {
+        }
+
+        /**
+         * Update builder from maven configuration.
+         *
+         * @param typosConfig maven config
+         * @return updated builder
+         */
+        public Builder config(TypoConfig typosConfig) {
+            this.typosConfig = typosConfig;
+            return this;
+        }
+
+        /**
+         * Build a new instance of {@link io.helidon.build.maven.enforcer.typo.TyposRule}.
+         *
+         * @return new rule
+         */
+        public TyposRule build() {
+            return new TyposRule(this);
+        }
+
+        List<FileMatcher> excludes() {
+            return typosConfig.excludes()
+                    .stream()
+                    .map(FileMatcher::create)
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+        }
+
+        List<FileMatcher> includes() {
+            Set<String> includes = new HashSet<>(DEFAULT_INCLUDES);
+            includes.addAll(typosConfig.includes());
+            return includes.stream()
+                    .map(FileMatcher::create)
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/typo/package-info.java
+++ b/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/typo/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typos rule.
+ */
+package io.helidon.build.maven.enforcer.typo;

--- a/enforcer-maven-plugin/src/main/resources/io/helidon/build/maven/enforcer/copyright/apache.txt
+++ b/enforcer-maven-plugin/src/main/resources/io/helidon/build/maven/enforcer/copyright/apache.txt
@@ -1,0 +1,14 @@
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/ExcludeTest.java
+++ b/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/ExcludeTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ExcludeTest {
+    @Test
+    void testSuffix() {
+        FileMatcher exclude = new FileMatcher.SuffixMatcher(".ico");
+
+        boolean excluded;
+        excluded = exclude.matches(FileRequest.create("src/main/icon.ico"));
+        assertThat("Should matches icon", excluded, is(true));
+
+        excluded = exclude.matches(FileRequest.create("scr/main/icon.ico.txt"));
+        assertThat("Should not matches icon.ico.txt", excluded, is(false));
+    }
+
+    @Test
+    void testStartsWith() {
+        // excludes with exact path from repository root
+        FileMatcher exclude = new FileMatcher.StartsWithMatcher("etc/copyright.txt");
+
+        boolean excluded;
+        excluded = exclude.matches(FileRequest.create("etc/copyright.txt"));
+        assertThat("Should matches exact match", excluded, is(true));
+
+        excluded = exclude.matches(FileRequest.create("webserver/etc/copyright.txt"));
+        assertThat("Should not matches subpath match", excluded, is(false));
+    }
+
+    @Test
+    void testDirectory() {
+        FileMatcher exclude = new FileMatcher.DirectoryMatcher("target/");
+
+        boolean excluded;
+        excluded = exclude.matches(FileRequest.create("webserver/target/classes/test.class"));
+        assertThat("Should matches nested target directory", excluded, is(true));
+
+        excluded = exclude.matches(FileRequest.create("target/classes/test.class"));
+        assertThat("Should matches target directory", excluded, is(true));
+
+        excluded = exclude.matches(FileRequest.create("targets/classes/test.class"));
+        assertThat("Should not matches targets directory", excluded, is(false));
+
+        excluded = exclude.matches(FileRequest.create("webserver/targets/classes/test.class"));
+        assertThat("Should not matches targets directory", excluded, is(false));
+
+        excluded = exclude.matches(FileRequest.create("webtarget/classes/test.class"));
+        assertThat("Should not matches webtarget directory", excluded, is(false));
+
+        excluded = exclude.matches(FileRequest.create("webserver/webtarget/classes/test.class"));
+        assertThat("Should not matches webtarget directory", excluded, is(false));
+    }
+
+    @Test
+    void testName() {
+        // test file name
+        FileMatcher exclude = new FileMatcher.NameMatcher("copyright.txt");
+
+        boolean excluded;
+        excluded = exclude.matches(FileRequest.create("copyright.txt"));
+        assertThat("Should matches copyright.txt", excluded, is(true));
+
+        excluded = exclude.matches(FileRequest.create("webserver/etc/copyright.txt"));
+        assertThat("Should matches copyright.txt in directory", excluded, is(true));
+    }
+
+    @Test
+    void testContains() {
+        FileMatcher exclude = new FileMatcher.ContainsMatcher("src/resources/bin");
+
+        boolean excluded;
+        excluded = exclude.matches(FileRequest.create("src/resources/bin/copyright.txt"));
+        assertThat("Should matches directory", excluded, is(true));
+
+        excluded = exclude.matches(FileRequest.create("webserver/src/resources/bin/copyright.txt"));
+        assertThat("Should matches nested directory", excluded, is(true));
+
+        excluded = exclude.matches(FileRequest.create("src/resources/sbin/copyright.txt"));
+        assertThat("Should not matches directory", excluded, is(false));
+    }
+}

--- a/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/copyright/TemplateLineTest.java
+++ b/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/copyright/TemplateLineTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.util.List;
+import java.util.Random;
+
+import io.helidon.build.maven.enforcer.FileRequest;
+import io.helidon.build.maven.enforcer.RuleFailure;
+import io.helidon.build.maven.enforcer.RuleFailureException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TemplateLineTest {
+    private static final Random RANDOM = new Random();
+
+    @Test
+    void testAllRightsReserved() {
+        FileRequest file = FileRequest.create("UnitTest.java", "2021");
+        Validator.ValidatorConfig validatorConfig = Validator.ValidatorConfig.builder()
+                .currentYear("2021")
+                .build();
+        String templateLineString = "Copyright (c) YYYY Oracle and/or its affiliates.";
+        TemplateLine templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(0);
+
+        shouldFail(templateLine,
+                   file,
+                   "Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.");
+    }
+
+    @Test
+    void testCopyrightLine() {
+        FileRequest file = FileRequest.create("UnitTest.java", "2021");
+        Validator.ValidatorConfig validatorConfig = Validator.ValidatorConfig.builder()
+                .build();
+        String templateLineString = "(c) YYYY Oracle and/or its affiliates.";
+        TemplateLine templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(0);
+
+        shouldFail(templateLine, file, "");
+        shouldFail(templateLine, file, "Some test");
+        shouldFail(templateLine, file, "(c) 2020 Oracle and/or its affiliates.", "2020, 2021");
+
+        // this should succeed
+        templateLine.validate(file, "(c) 2020, 2021 Oracle and/or its affiliates.", 177);
+
+        validatorConfig = Validator.ValidatorConfig.builder()
+                .checkFormatOnly(true)
+                .build();
+        templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(0);
+
+        // this should succeed
+        templateLine.validate(file, "(c) 2020 Oracle and/or its affiliates.", 177);
+    }
+
+    @Test
+    void testTextLine() {
+        FileRequest file = FileRequest.create("UnitTest.java", "2021");
+        Validator.ValidatorConfig validatorConfig = Validator.ValidatorConfig.builder()
+                .build();
+        String templateLineString = "  Cogito ergo sum";
+        // first line is always copyright, unless explicitly defined
+        TemplateLine templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(1);
+
+        shouldFail(templateLine, file, "");
+        shouldFail(templateLine, file, "\t");
+        shouldFail(templateLine, file, "Cogito ergo sum");
+        shouldFail(templateLine, file, "Copyright");
+
+        // success
+        templateLine.validate(file, "  Cogito ergo sum", 147);
+    }
+
+    @Test
+    void testBlankLine() {
+        Validator.ValidatorConfig validatorConfig = Validator.ValidatorConfig.builder()
+                .build();
+        String templateLineString = "\t ";
+        // first line is always copyright, unless explicitly defined
+        TemplateLine templateLine = TemplateLine.parseTemplate(validatorConfig, List.of(templateLineString))
+                .get(1);
+
+        FileRequest file = FileRequest.create("UnitTest.java", "2021");
+        templateLine.validate(file, "", 1);
+        templateLine.validate(file, "\t", 0);
+
+        shouldFail(templateLine, file, "Copyright");
+    }
+
+    private void shouldFail(TemplateLine templateLine,
+                            FileRequest file,
+                            String actualLine,
+                            String... mustContain) {
+
+        int lineNumber = RANDOM.nextInt(278) + 1;
+
+        RuleFailureException fe = assertThrows(RuleFailureException.class,
+                                               () -> templateLine.validate(file,
+                                                                       actualLine,
+                                                                           lineNumber));
+
+        RuleFailure failure = fe.failure();
+
+        assertThat(failure.line(), is(lineNumber));
+        String message = failure.message();
+
+        for (String contains : mustContain) {
+            assertThat(message, containsString(contains));
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,7 @@
         <module>dev-loop</module>
         <module>stager-maven-plugin</module>
         <module>build-cache-maven-plugin</module>
+        <module>enforcer-maven-plugin</module>
     </modules>
 
     <build>


### PR DESCRIPTION
* Copyright maven plugin.

(cherry picked from commit cd4b2244698f86c6a1742667a1a4d65c46e10650)

Fix reading of git status. (#379)

(cherry picked from commit de6247f7ff97c3cc18589eab2939cc2c53b4df8d)

Fix for files that were deleted.

(cherry picked from commit 352ac308b2746fd392197998b5d332bd18d42c9b)

Files are now sorted.

(cherry picked from commit eb1120048de4ad88d6b8ca3a6d29754b1618f933)

Enforcer plugin. (#386)

Copyright plugin moved to enforcer as a rule.
Added typo enforcer rule.

(cherry picked from commit 694e9cda0e42a6a5e49b819c61bf583b9951f5a1)