### PR TITLE
Changes to helidon-services plugin to check source folder instead of target

### DIFF
--- a/common/ansi/src/main/java/io/helidon/build/common/ansi/AnsiTextProvider.java
+++ b/common/ansi/src/main/java/io/helidon/build/common/ansi/AnsiTextProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.build.common.ansi;
 
+import io.helidon.build.common.Instance;
 import io.helidon.build.common.RichText;
 import io.helidon.build.common.RichTextProvider;
 import io.helidon.build.common.RichTextStyle;
@@ -26,13 +27,13 @@ import io.helidon.build.common.RichTextStyle.StyleList;
 public class AnsiTextProvider implements RichTextProvider {
 
     /**
-     * Get the enabled flag if {@link Holder#INSTANCE} is {@link AnsiTextProvider}.
-     *
-     * @return {@code true} if ansi console is enabled, {@code false} otherwise
+     * Enabled flag if {@link Holder#INSTANCE} is {@link AnsiTextProvider}.
+     * Set to {@code true} if ansi console is enabled, {@code false} otherwise
      */
-    public static final boolean ANSI_ENABLED = Holder.INSTANCE.as(AnsiTextProvider.class)
-                                                       .map(AnsiTextProvider::isEnabled)
-                                                       .orElse(false);
+    public static final Instance<Boolean> ANSI_ENABLED =
+            new Instance<>(() -> Holder.INSTANCE.as(AnsiTextProvider.class)
+                                                .map(AnsiTextProvider::isEnabled)
+                                                .orElse(false));
 
     private final boolean enabled;
 

--- a/common/ansi/src/main/java/io/helidon/build/common/ansi/AnsiTextStyle.java
+++ b/common/ansi/src/main/java/io/helidon/build/common/ansi/AnsiTextStyle.java
@@ -198,7 +198,7 @@ public class AnsiTextStyle implements RichTextStyle {
                 return NONE;
             }
         }
-        return ANSI_ENABLED ? style : NONE;
+        return ANSI_ENABLED.instance() ? style : NONE;
     }
 
     /**

--- a/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextRendererTest.java
+++ b/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextRendererTest.java
@@ -39,7 +39,7 @@ class AnsiTextRendererTest {
 
     @BeforeEach
     void checkAnsi() {
-        Assumptions.assumeTrue(AnsiTextProvider.ANSI_ENABLED);
+        Assumptions.assumeTrue(AnsiTextProvider.ANSI_ENABLED.instance());
     }
 
     @Test

--- a/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextStyleTest.java
+++ b/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextStyleTest.java
@@ -281,7 +281,7 @@ class AnsiTextStyleTest {
 
     @Test
     void testStrip() {
-        Assumptions.assumeTrue(AnsiTextProvider.ANSI_ENABLED);
+        Assumptions.assumeTrue(AnsiTextProvider.ANSI_ENABLED.instance());
         String sample = "sample";
         RichTextStyle style = RichTextStyle.of("RED!");
         String styled = style.apply(sample);

--- a/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextStylesTest.java
+++ b/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextStylesTest.java
@@ -30,7 +30,7 @@ class AnsiTextStylesTest {
 
     @Test
     void testAll() {
-        boolean enabled = AnsiTextProvider.ANSI_ENABLED;
+        boolean enabled = AnsiTextProvider.ANSI_ENABLED.instance();
         Ansi.setEnabled(enabled);
         for (AnsiTextStyles function : AnsiTextStyles.values()) {
             String example = function.apply("example");


### PR DESCRIPTION
Changes to helidon-services plugin to check source folder instead of target for services files. Default mode is still "fail" but will now fail if files are in source. This commit also fixes a static initialization problem (NPE) related to AnsiTextProviders.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>