### PR TITLE
Fix Jansi usage to work with Maven 3.8+ 

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/AnsiConsoleInstaller.java
+++ b/utils/src/main/java/io/helidon/build/util/AnsiConsoleInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,7 +222,7 @@ public class AnsiConsoleInstaller {
             installedType = ConsoleType.DEFAULT;
         }
         if (desiredType != installedType) {
-            switch(installedType){
+            switch (installedType) {
                 case STRIP_ANSI:
                     Log.preInitDebug("Desired = %s, but Ansi escapes will be stripped by system streams.", desiredType);
                     break;
@@ -233,6 +233,8 @@ public class AnsiConsoleInstaller {
                     Log.preInitDebug("Desired = %s, but System.out not a Jansi type (%s) ao Ansi escapes should not be stripped",
                             desiredType, systemOutClassName);
                     break;
+                default:
+                    // do nothing
             }
         }
         return installedType;

--- a/utils/src/main/java/io/helidon/build/util/AnsiConsoleInstaller.java
+++ b/utils/src/main/java/io/helidon/build/util/AnsiConsoleInstaller.java
@@ -202,7 +202,7 @@ public class AnsiConsoleInstaller {
         if (systemOutClassName.startsWith(JANSI_PACKAGE_PREFIX)) {
             if (systemOutClassName.equals(JANSI_STRIP_STREAM_CLASS_NAME)) {
                 try {
-                    // jansi 2.x always use AnsiPrintStream, but have a mode flag
+                    // jansi 2.x always use AnsiPrintStream, but has a mode flag
                     String mode = systemOutclass.getMethod("getMode").invoke(systemOut).toString();
                     if (mode.equalsIgnoreCase("strip")) {
                         installedType = ConsoleType.STRIP_ANSI;

--- a/utils/src/main/java/io/helidon/build/util/AnsiConsoleInstaller.java
+++ b/utils/src/main/java/io/helidon/build/util/AnsiConsoleInstaller.java
@@ -16,6 +16,8 @@
 
 package io.helidon.build.util;
 
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -193,27 +195,47 @@ public class AnsiConsoleInstaller {
     }
 
     private static ConsoleType installedConsoleType(ConsoleType desiredType) {
-        final String systemOutClass = System.out.getClass().getName();
-        if (systemOutClass.startsWith(JANSI_PACKAGE_PREFIX)) {
-            // We have a Jansi type installed, check if it is the type that strips escapes
-            if (systemOutClass.equals(JANSI_STRIP_STREAM_CLASS_NAME)) {
-                if (desiredType != ConsoleType.STRIP_ANSI) {
-                    Log.preInitDebug("Desired = %s, but Ansi escapes will be stripped by system streams.", desiredType);
+        final PrintStream systemOut = System.out;
+        final Class<? extends PrintStream> systemOutclass = systemOut.getClass();
+        final String systemOutClassName = systemOutclass.getName();
+        ConsoleType installedType;
+        if (systemOutClassName.startsWith(JANSI_PACKAGE_PREFIX)) {
+            if (systemOutClassName.equals(JANSI_STRIP_STREAM_CLASS_NAME)) {
+                try {
+                    // jansi 2.x always use AnsiPrintStream, but have a mode flag
+                    String mode = systemOutclass.getMethod("getMode").invoke(systemOut).toString();
+                    if (mode.equalsIgnoreCase("strip")) {
+                        installedType = ConsoleType.STRIP_ANSI;
+                    } else if (mode.equalsIgnoreCase("force")) {
+                        installedType = ConsoleType.ANSI;
+                    } else {
+                        installedType = ConsoleType.DEFAULT;
+                    }
+                } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                    // jansi 1.x uses AnsiPrintStream only for stripping
+                    installedType = ConsoleType.STRIP_ANSI;
                 }
-                return ConsoleType.STRIP_ANSI;
             } else {
-                if (desiredType != ConsoleType.ANSI) {
-                    Log.preInitDebug("Desired = %s, but Ansi escapes should be supported by system streams.", desiredType);
-                }
-                return ConsoleType.ANSI;
+                installedType = ConsoleType.ANSI;
             }
         } else {
-            if (desiredType != ConsoleType.DEFAULT) {
-                Log.preInitDebug("Desired = %s, but System.out not a Jansi type (%s) ao Ansi escapes should not be stripped",
-                                 desiredType, systemOutClass);
-            }
-            return ConsoleType.DEFAULT;
+            installedType = ConsoleType.DEFAULT;
         }
+        if (desiredType != installedType) {
+            switch(installedType){
+                case STRIP_ANSI:
+                    Log.preInitDebug("Desired = %s, but Ansi escapes will be stripped by system streams.", desiredType);
+                    break;
+                case ANSI:
+                    Log.preInitDebug("Desired = %s, but Ansi escapes should be supported by system streams.", desiredType);
+                    break;
+                case DEFAULT:
+                    Log.preInitDebug("Desired = %s, but System.out not a Jansi type (%s) ao Ansi escapes should not be stripped",
+                            desiredType, systemOutClassName);
+                    break;
+            }
+        }
+        return installedType;
     }
 
     private AnsiConsoleInstaller() {


### PR DESCRIPTION
Fixes #458 

Support Jansi 2.x (provided by Maven since 3.8.1) 
- implement ansi escape stripping manually in style instead of relying on AnsiOutputStream
 - update AnsiConsoleInstaller.installedConsoleType(); use reflect to invoke AnsiPrintStream.getMode