### PR TITLE
Support Java8 in maven archetype postgenerate bootstrap

### DIFF
--- a/helidon-archetype/maven-plugin/pom.xml
+++ b/helidon-archetype/maven-plugin/pom.xml
@@ -118,6 +118,32 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/postgenerate/*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>postgenerate</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>8</release>
+                            <includes>
+                                <include>**/postgenerate/*</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <executions>
                     <execution>

--- a/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/postgenerate/EngineFacade.java
+++ b/helidon-archetype/maven-plugin/src/main/java/io/helidon/build/archetype/maven/postgenerate/EngineFacade.java
@@ -70,12 +70,13 @@ public final class EngineFacade {
 
     private static void checkJavaVersion() {
         try {
-            if (Runtime.class.getMethod("version") != null
-                    && Runtime.Version.class.getMethod("feature") != null
-                    && Runtime.getRuntime().version().feature() < 11) {
+            Class<?> runtimeClass = Class.forName("java.lang.Runtime");
+            Object runtime = runtimeClass.getMethod("getRuntime").invoke(null);
+            Object version = runtimeClass.getMethod("version").invoke(runtime);
+            if ((int) Class.forName("java.lang.Runtime$Version").getMethod("feature").invoke(version) < 11) {
                 throw new IllegalStateException();
             }
-        } catch (NoSuchMethodException | IllegalStateException ex) {
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalStateException ex) {
             throw new IllegalStateException("Requires Java >= 11");
         } catch (Throwable ex) {
             throw new IllegalStateException("Unable to verify Java version", ex);


### PR DESCRIPTION
- compile io.helidon.build.archetype.maven.postgenerate for Java8 runtime,
- update EngineFacade to compile for Java8:  use reflection to invoke java.lang.Runtime.getRuntime().version().feature()