### PR TITLE
Use MojoExecutor instead of just BuildPluginManager

### DIFF
--- a/dev-loop/src/main/java/io/helidon/build/dev/maven/MavenEnvironment.java
+++ b/dev-loop/src/main/java/io/helidon/build/dev/maven/MavenEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,33 @@
  */
 package io.helidon.build.dev.maven;
 
+import java.util.List;
 import java.util.Map;
+
+import io.helidon.build.util.Strings;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.lifecycle.LifecycleMappingDelegate;
 import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
+import org.apache.maven.lifecycle.internal.MojoExecutor;
+import org.apache.maven.lifecycle.internal.ProjectIndex;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.Parameter;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * An accessor for various Maven components.
@@ -34,18 +53,21 @@ public class MavenEnvironment {
     private final DefaultLifecycles defaultLifeCycles;
     private final LifecycleMappingDelegate standardLifecycleDelegate;
     private final Map<String, LifecycleMappingDelegate> lifecycleDelegates;
-    private final BuildPluginManager buildPluginManager;
+    private final BuildPluginManager pluginManager;
+    private final MojoExecutor mojoExecutor;
+    private final ProjectIndex projectIndex;
 
     /**
      * Constructor.
      *
-     * @param project The project.
-     * @param session The session.
-     * @param mojoDescriptorCreator The mojo descriptor creator.
-     * @param defaultLifeCycles The default lifecycles.
+     * @param project                   The project.
+     * @param session                   The session.
+     * @param mojoDescriptorCreator     The mojo descriptor creator.
+     * @param defaultLifeCycles         The default lifecycles.
      * @param standardLifecycleDelegate The standard lifecycle mapping delegate.
-     * @param lifecycleDelegates The lifecycle delegates, by phase.
-     * @param buildPluginManager The build plugin manager.
+     * @param lifecycleDelegates        The lifecycle delegates, by phase.
+     * @param buildPluginManager        The build plugin manager.
+     * @param mojoExecutor              The mojo executor
      */
     public MavenEnvironment(MavenProject project,
                             MavenSession session,
@@ -53,14 +75,17 @@ public class MavenEnvironment {
                             DefaultLifecycles defaultLifeCycles,
                             LifecycleMappingDelegate standardLifecycleDelegate,
                             Map<String, LifecycleMappingDelegate> lifecycleDelegates,
-                            BuildPluginManager buildPluginManager) {
+                            BuildPluginManager buildPluginManager,
+                            MojoExecutor mojoExecutor) {
         this.project = project;
         this.session = session;
+        this.projectIndex = new ProjectIndex(session.getProjects());
         this.mojoDescriptorCreator = mojoDescriptorCreator;
         this.defaultLifeCycles = defaultLifeCycles;
         this.standardLifecycleDelegate = standardLifecycleDelegate;
         this.lifecycleDelegates = lifecycleDelegates;
-        this.buildPluginManager = buildPluginManager;
+        this.pluginManager = buildPluginManager;
+        this.mojoExecutor = mojoExecutor;
     }
 
     /**
@@ -118,11 +143,111 @@ public class MavenEnvironment {
     }
 
     /**
-     * Returns the build plugin manager.
+     * Execute a given mojo execution.
      *
-     * @return The manager.
+     * @param execution mojo execution
      */
-    public BuildPluginManager buildPluginManager() {
-        return buildPluginManager;
+    public void execute(MojoExecution execution) {
+        try {
+            mojoExecutor.execute(session, List.of(execution), projectIndex);
+        } catch (LifecycleExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Create a mojo execution.
+     *
+     * @param pluginKey   plugin key (pluginGroupId : pluginArtifactId)
+     * @param goal        plugin goal
+     * @param executionId execution id
+     * @return MojoExecution
+     * @throws Exception if an error occurs while loading the plugin
+     */
+    public MojoExecution execution(String pluginKey, String goal, String executionId) throws Exception {
+        Plugin plugin = plugin(project, pluginKey);
+        MojoDescriptor mojoDescriptor = mojoDescriptor(plugin, goal);
+        Xpp3Dom configuration = configuration(plugin, executionId);
+        return mojoExecution(mojoDescriptor, executionId, configuration);
+    }
+
+    private static Plugin plugin(MavenProject project, String pluginKey) {
+        final Plugin plugin = requireNonNull(project.getPlugin(pluginKey), "plugin " + pluginKey + " not found");
+        if (Strings.isNotValid(plugin.getVersion())) {
+            final PluginManagement pm = project.getPluginManagement();
+            if (pm != null) {
+                for (Plugin p : pm.getPlugins()) {
+                    if (plugin.getGroupId().equals(p.getGroupId()) && plugin.getArtifactId().equals(p.getArtifactId())) {
+                        plugin.setVersion(p.getVersion());
+                        break;
+                    }
+                }
+            }
+        }
+        return plugin;
+    }
+
+    private MojoDescriptor mojoDescriptor(Plugin plugin, String goal) throws Exception {
+        final RepositorySystemSession repositorySession = session.getRepositorySession();
+        final List<RemoteRepository> repositories = project.getRemotePluginRepositories();
+        final PluginDescriptor pluginDescriptor = pluginManager.loadPlugin(plugin, repositories, repositorySession);
+        return pluginDescriptor.getMojo(goal);
+    }
+
+    private static Xpp3Dom configuration(Plugin plugin, String executionId) {
+        final PluginExecution execution = plugin.getExecutionsAsMap().get(executionId);
+        if (execution != null && execution.getConfiguration() != null) {
+            return (Xpp3Dom) execution.getConfiguration();
+        } else if (plugin.getConfiguration() != null) {
+            return (Xpp3Dom) plugin.getConfiguration();
+        } else {
+            return new Xpp3Dom("configuration");
+        }
+    }
+
+    private static MojoExecution mojoExecution(MojoDescriptor mojoDescriptor, String executionId, Xpp3Dom executionConfig) {
+        final MojoExecution result = new MojoExecution(mojoDescriptor, executionId);
+        final Xpp3Dom configuration = mojoConfiguration(mojoDescriptor, executionConfig);
+        result.setConfiguration(configuration);
+        return result;
+    }
+
+    /**
+     * Returns the final mojo configuration, discarding all parameters that are not applicable to the mojo and injecting
+     * the default values for any missing parameters.
+     *
+     * <em>NOTE</em>Copied/modified from {@code org.apache.maven.lifecycle.internal.DefaultLifecycleExecutionPlanCalculator}.
+     *
+     * @param mojoDescriptor         The mojo descriptor. Must not be {@code null}.
+     * @param executionConfiguration The execution configuration. Must not be {@code null}.
+     * @return The final configuration.
+     */
+    private static Xpp3Dom mojoConfiguration(MojoDescriptor mojoDescriptor, Xpp3Dom executionConfiguration) {
+        final Xpp3Dom finalConfiguration = new Xpp3Dom("configuration");
+        final Xpp3Dom defaultConfiguration = MojoDescriptorCreator.convert(mojoDescriptor);
+        if (mojoDescriptor.getParameters() != null) {
+            for (Parameter parameter : mojoDescriptor.getParameters()) {
+                Xpp3Dom parameterConfiguration = executionConfiguration.getChild(parameter.getName());
+                if (parameterConfiguration == null) {
+                    parameterConfiguration = executionConfiguration.getChild(parameter.getAlias());
+                }
+
+                Xpp3Dom parameterDefaults = defaultConfiguration.getChild(parameter.getName());
+
+                parameterConfiguration = Xpp3Dom.mergeXpp3Dom(parameterConfiguration, parameterDefaults, Boolean.TRUE);
+
+                if (parameterConfiguration != null) {
+                    parameterConfiguration = new Xpp3Dom(parameterConfiguration, parameter.getName());
+
+                    if (StringUtils.isEmpty(parameterConfiguration.getAttribute("implementation"))
+                            && StringUtils.isNotEmpty(parameter.getImplementation())) {
+                        parameterConfiguration.setAttribute("implementation", parameter.getImplementation());
+                    }
+
+                    finalConfiguration.addChild(parameterConfiguration);
+                }
+            }
+        }
+        return finalConfiguration;
     }
 }

--- a/dev-loop/src/main/java/io/helidon/build/dev/maven/MavenGoal.java
+++ b/dev-loop/src/main/java/io/helidon/build/dev/maven/MavenGoal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,13 @@
  */
 package io.helidon.build.dev.maven;
 
-import java.util.List;
 import java.util.function.Consumer;
 
 import io.helidon.build.dev.BuildRoot;
 import io.helidon.build.dev.BuildStep;
 import io.helidon.build.util.Log;
-import io.helidon.build.util.Strings;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginExecution;
-import org.apache.maven.model.PluginManagement;
-import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.plugin.descriptor.MojoDescriptor;
-import org.apache.maven.plugin.descriptor.Parameter;
-import org.apache.maven.plugin.descriptor.PluginDescriptor;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringUtils;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.repository.RemoteRepository;
 
 import static java.util.Objects.requireNonNull;
 
@@ -51,8 +35,7 @@ public class MavenGoal implements BuildStep {
     private final String pluginKey;
     private final String executionId;
     private final MojoExecution execution;
-    private final BuildPluginManager pluginManager;
-    private final MavenSession session;
+    private final MavenEnvironment environment;
 
     /**
      * Returns a new instance.
@@ -95,12 +78,8 @@ public class MavenGoal implements BuildStep {
         this.name = goalName;
         this.pluginKey = pluginGroupId + ":" + pluginArtifactId;
         this.executionId = executionId;
-        final Plugin plugin = plugin(environment.project(), pluginKey);
-        final MojoDescriptor mojoDescriptor = mojoDescriptor(environment, plugin, name);
-        final Xpp3Dom configuration = configuration(plugin, executionId);
-        this.execution = mojoExecution(mojoDescriptor, executionId, configuration);
-        this.pluginManager = environment.buildPluginManager();
-        this.session = environment.session();
+        this.execution = environment.execution(pluginKey, goalName, executionId);
+        this.environment = environment;
     }
 
     @Override
@@ -117,7 +96,7 @@ public class MavenGoal implements BuildStep {
      */
     public void execute() throws Exception {
         Log.debug("Executing %s", this);
-        pluginManager.executeMojo(session, execution);
+        environment.execute(execution);
     }
 
     /**
@@ -150,88 +129,5 @@ public class MavenGoal implements BuildStep {
     @Override
     public String toString() {
         return pluginKey() + ":" + name() + "@" + executionId();
-    }
-
-    private static Plugin plugin(MavenProject project, String pluginKey) {
-        final Plugin plugin = requireNonNull(project.getPlugin(pluginKey), "plugin " + pluginKey + " not found");
-        if (Strings.isNotValid(plugin.getVersion())) {
-            final PluginManagement pm = project.getPluginManagement();
-            if (pm != null) {
-                for (Plugin p : pm.getPlugins()) {
-                    if (plugin.getGroupId().equals(p.getGroupId()) && plugin.getArtifactId().equals(p.getArtifactId())) {
-                        plugin.setVersion(p.getVersion());
-                        break;
-                    }
-                }
-            }
-        }
-        return plugin;
-    }
-
-    private static MojoDescriptor mojoDescriptor(MavenEnvironment environment, Plugin plugin, String goal) throws Exception {
-        final MavenProject project = environment.project();
-        final MavenSession session = environment.session();
-        final BuildPluginManager pluginManager = environment.buildPluginManager();
-        final RepositorySystemSession repositorySession = session.getRepositorySession();
-        final List<RemoteRepository> repositories = project.getRemotePluginRepositories();
-        final PluginDescriptor pluginDescriptor = pluginManager.loadPlugin(plugin, repositories, repositorySession);
-        return pluginDescriptor.getMojo(goal);
-    }
-
-    private static Xpp3Dom configuration(Plugin plugin, String executionId) {
-        final PluginExecution execution = plugin.getExecutionsAsMap().get(executionId);
-        if (execution != null && execution.getConfiguration() != null) {
-            return (Xpp3Dom) execution.getConfiguration();
-        } else if (plugin.getConfiguration() != null) {
-            return (Xpp3Dom) plugin.getConfiguration();
-        } else {
-            return new Xpp3Dom("configuration");
-        }
-    }
-
-    private static MojoExecution mojoExecution(MojoDescriptor mojoDescriptor, String executionId, Xpp3Dom executionConfig) {
-        final MojoExecution result = new MojoExecution(mojoDescriptor, executionId);
-        final Xpp3Dom configuration = mojoConfiguration(mojoDescriptor, executionConfig);
-        result.setConfiguration(configuration);
-        return result;
-    }
-
-    /**
-     * Returns the final mojo configuration, discarding all parameters that are not applicable to the mojo and injecting
-     * the default values for any missing parameters.
-     *
-     * <em>NOTE</em>Copied/modified from {@code org.apache.maven.lifecycle.internal.DefaultLifecycleExecutionPlanCalculator}.
-     *
-     * @param mojoDescriptor The mojo descriptor. Must not be {@code null}.
-     * @param executionConfiguration The execution configuration. Must not be {@code null}.
-     * @return The final configuration.
-     */
-    private static Xpp3Dom mojoConfiguration(MojoDescriptor mojoDescriptor, Xpp3Dom executionConfiguration) {
-        final Xpp3Dom finalConfiguration = new Xpp3Dom("configuration");
-        final Xpp3Dom defaultConfiguration = MojoDescriptorCreator.convert(mojoDescriptor);
-        if (mojoDescriptor.getParameters() != null) {
-            for (Parameter parameter : mojoDescriptor.getParameters()) {
-                Xpp3Dom parameterConfiguration = executionConfiguration.getChild(parameter.getName());
-                if (parameterConfiguration == null) {
-                    parameterConfiguration = executionConfiguration.getChild(parameter.getAlias());
-                }
-
-                Xpp3Dom parameterDefaults = defaultConfiguration.getChild(parameter.getName());
-
-                parameterConfiguration = Xpp3Dom.mergeXpp3Dom(parameterConfiguration, parameterDefaults, Boolean.TRUE);
-
-                if (parameterConfiguration != null) {
-                    parameterConfiguration = new Xpp3Dom(parameterConfiguration, parameter.getName());
-
-                    if (StringUtils.isEmpty(parameterConfiguration.getAttribute("implementation"))
-                        && StringUtils.isNotEmpty(parameter.getImplementation())) {
-                        parameterConfiguration.setAttribute("implementation", parameter.getImplementation());
-                    }
-
-                    finalConfiguration.addChild(parameterConfiguration);
-                }
-            }
-        }
-        return finalConfiguration;
     }
 }

--- a/helidon-cli-maven-plugin/src/main/java/io/helidon/build/cli/maven/dev/DevMojo.java
+++ b/helidon-cli-maven-plugin/src/main/java/io/helidon/build/cli/maven/dev/DevMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.LifecycleMappingDelegate;
 import org.apache.maven.lifecycle.internal.DefaultLifecycleMappingDelegate;
 import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
+import org.apache.maven.lifecycle.internal.MojoExecutor;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -125,6 +126,12 @@ public class DevMojo extends AbstractMojo {
     private BuildPluginManager plugins;
 
     /**
+     * The Maven MojoExecutor component.
+     */
+    @Component
+    private MojoExecutor mojoExecutor;
+
+    /**
      * The Maven MojoDescriptorCreated component, used to resolve
      * plugin prefixes.
      */
@@ -182,8 +189,8 @@ public class DevMojo extends AbstractMojo {
         final DevLoopBuildConfig config = devLoop == null ? new DevLoopBuildConfig() : devLoop;
         config.validate();
         if (resolve) {
-            final MavenEnvironment env = new MavenEnvironment(project, session, mojoDescriptorCreator, defaultLifeCycles,
-                                                              standardDelegate, delegates, plugins);
+            final MavenEnvironment env = new MavenEnvironment(project, session, mojoDescriptorCreator,
+                    defaultLifeCycles, standardDelegate, delegates, plugins, mojoExecutor);
             final MavenGoalReferenceResolver resolver = new MavenGoalReferenceResolver(env);
             config.resolve(resolver);
         }


### PR DESCRIPTION
The MavenProject object is stateful and is mutated before plugin executions.
Some of the stateful behavior has changed with newer Maven versions and it breaks the incremental compilation

While our previous implementation worked for simple usescases, there were very likely some plugins that would not
have executed properly since because we aren't mutating the state.

Using MojoExecutor which does seem to take care of all the stateful stuff.
However it is not a supported API of Maven and may change in the future, this is a trade-off.

Fixes #499