### PR TITLE
Improve Metadata update error handling

### DIFF
--- a/dev-loop/src/main/java/module-info.javatmp
+++ b/dev-loop/src/main/java/module-info.javatmp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module helidon.build.dev {
+module io.helidon.build.dev {
     exports io.helidon.build.dev;
 
     requires maven.resolver.provider;
@@ -25,5 +25,5 @@ module helidon.build.dev {
     // requires maven.model.builder;
     requires maven.core;
     requires maven.model;
-    requires helidon.build.utils;
+    requires io.helidon.build.util;
 }

--- a/helidon-archetype/engine/src/main/java/module-info.java
+++ b/helidon-archetype/engine/src/main/java/module-info.java
@@ -18,7 +18,7 @@
  * Helidon archetype engine.
  */
 module io.helidon.build.archetype.engine {
-    requires helidon.build.utils;
+    requires io.helidon.build.util;
     requires com.github.mustachejava;
     exports io.helidon.build.archetype.engine;
 }

--- a/helidon-cli/codegen/pom.xml
+++ b/helidon-cli/codegen/pom.xml
@@ -35,6 +35,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.build-tools</groupId>
+            <artifactId>helidon-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/helidon-cli/codegen/src/main/java/io/helidon/build/cli/codegen/ASTWriter.java
+++ b/helidon-cli/codegen/src/main/java/io/helidon/build/cli/codegen/ASTWriter.java
@@ -57,9 +57,9 @@ import io.helidon.build.cli.codegen.AST.TypeDeclaration;
 import io.helidon.build.cli.codegen.AST.Value;
 import io.helidon.build.cli.codegen.AST.ValueCast;
 import io.helidon.build.cli.codegen.AST.ValueRef;
-import io.helidon.build.cli.codegen.Unchecked.CheckedConsumer;
+import io.helidon.build.util.Unchecked.CheckedConsumer;
 
-import static io.helidon.build.cli.codegen.Unchecked.unchecked;
+import static io.helidon.build.util.Unchecked.unchecked;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;

--- a/helidon-cli/codegen/src/main/java/io/helidon/build/cli/codegen/FileHeaderJavacPlugin.java
+++ b/helidon-cli/codegen/src/main/java/io/helidon/build/cli/codegen/FileHeaderJavacPlugin.java
@@ -25,7 +25,7 @@ import java.util.Map.Entry;
 
 import javax.tools.JavaFileObject;
 
-import io.helidon.build.cli.codegen.Unchecked.CheckedSupplier;
+import io.helidon.build.util.Unchecked.CheckedSupplier;
 
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;

--- a/helidon-cli/codegen/src/main/java/module-info.java
+++ b/helidon-cli/codegen/src/main/java/module-info.java
@@ -22,6 +22,7 @@ import io.helidon.build.cli.codegen.FileHeaderJavacPlugin;
  */
 module io.helidon.build.cli.codegen {
     requires io.helidon.build.cli.harness;
+    requires io.helidon.build.util;
     requires java.compiler;
     provides javax.annotation.processing.Processor with CommandAP;
     provides com.sun.source.util.Plugin with FileHeaderJavacPlugin;

--- a/helidon-cli/codegen/src/test/java/io/helidon/build/cli/codegen/ASTWriterTest.java
+++ b/helidon-cli/codegen/src/test/java/io/helidon/build/cli/codegen/ASTWriterTest.java
@@ -34,9 +34,9 @@ import io.helidon.build.cli.codegen.AST.MethodBody;
 import io.helidon.build.cli.codegen.AST.MethodDeclaration;
 import io.helidon.build.cli.codegen.AST.MethodInvocation;
 import io.helidon.build.cli.codegen.TypeInfo.CompositeTypeInfo;
-import io.helidon.build.cli.codegen.Unchecked.CheckedConsumer;
 
 import com.acme.TestClass1;
+import io.helidon.build.util.Unchecked.CheckedConsumer;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.build.cli.codegen.AST.Modifier.*;

--- a/helidon-cli/codegen/src/test/java/io/helidon/build/cli/codegen/CommandAPTest.java
+++ b/helidon-cli/codegen/src/test/java/io/helidon/build/cli/codegen/CommandAPTest.java
@@ -25,9 +25,9 @@ import io.helidon.build.cli.codegen.CompilerHelper.JavaSourceFromString;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.build.cli.codegen.Unchecked.unchecked;
 import static io.helidon.build.util.Strings.normalizeNewLines;
 import static io.helidon.build.util.Strings.read;
+import static io.helidon.build.util.Unchecked.unchecked;
 import static java.nio.file.Files.list;
 import static java.nio.file.Files.readString;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/helidon-cli/codegen/src/test/java/io/helidon/build/cli/codegen/CompilerHelper.java
+++ b/helidon-cli/codegen/src/test/java/io/helidon/build/cli/codegen/CompilerHelper.java
@@ -36,9 +36,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static io.helidon.build.cli.codegen.Unchecked.unchecked;
 import static io.helidon.build.util.Strings.normalizeNewLines;
 import static io.helidon.build.util.Strings.read;
+import static io.helidon.build.util.Unchecked.unchecked;
 import static java.util.stream.Collectors.toList;
 
 /**

--- a/helidon-cli/harness/src/main/java/module-info.java
+++ b/helidon-cli/harness/src/main/java/module-info.java
@@ -20,7 +20,7 @@
 module io.helidon.build.cli.harness {
     requires java.logging;
     requires static com.github.spotbugs.annotations;
-    requires helidon.build.utils;
+    requires io.helidon.build.util;
     requires org.fusesource.jansi;
     requires info.picocli.jansi.graalvm;
     exports io.helidon.build.cli.harness;

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 
 import io.helidon.build.archetype.engine.ArchetypeCatalog;
 import io.helidon.build.cli.impl.InitCommand.Flavor;
-import io.helidon.build.cli.impl.Plugins.PluginFailed;
 import io.helidon.build.util.Requirements;
 
 import static io.helidon.build.cli.impl.CommandRequirements.requireSupportedHelidonVersion;
@@ -53,7 +52,7 @@ class ArchetypeBrowser {
         ArchetypeCatalog catalog = null;
         try {
             catalog = metadata.catalogOf(requireSupportedHelidonVersion(helidonVersion));
-        } catch (PluginFailed e) {
+        } catch (Metadata.UpdateFailed e) {
             Requirements.failed(HELIDON_VERSION_NOT_FOUND, helidonVersion);
         }
         this.catalog = catalog;

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
@@ -52,7 +52,7 @@ class ArchetypeBrowser {
         ArchetypeCatalog catalog = null;
         try {
             catalog = metadata.catalogOf(requireSupportedHelidonVersion(helidonVersion));
-        } catch (Metadata.UpdateFailed e) {
+        } catch (Metadata.UpdateFailed | Plugins.PluginFailedUnchecked e) {
             Requirements.failed(HELIDON_VERSION_NOT_FOUND, helidonVersion);
         }
         this.catalog = catalog;

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
@@ -184,6 +184,8 @@ public abstract class BaseCommand implements CommandExecution {
                 Log.debug("unable to lookup CLI plugin version for Helidon version %s: %s", helidonVersion, e.getMessage());
             } catch (RequirementFailure e) {
                 Log.debug("CLI plugin version not specified for Helidon version %s: %s", helidonVersion);
+            } catch (Plugins.PluginFailedUnchecked e) {
+                // already logged
             } catch (Exception e) {
                 Log.debug("unable to lookup CLI plugin version for Helidon version %s: %s", helidonVersion, e.toString());
             }

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
@@ -145,7 +145,7 @@ public abstract class BaseCommand implements CommandExecution {
             // that if this file was deleted and no build has occurred, a minimal project config is
             // generated in our preconditions, which will attempt to find and store the Helidon
             // version by reading the pom and checking for a Helidon parent pom. Though a Helidon
-            // parent pom will normally be present, it is not required so we may not find it in the
+            // parent pom will normally be present, it is not required, so we may not find it in the
             // config; in that case, fallback to the latest version. If we fail to get that, use our
             // build version.
 
@@ -180,7 +180,7 @@ public abstract class BaseCommand implements CommandExecution {
             try {
                 Log.debug("using Helidon version %s to find CLI plugin version", helidonVersion);
                 return meta.cliPluginVersion(helidonVersion, true).toString();
-            } catch (Plugins.PluginFailed e) {
+            } catch (Metadata.UpdateFailed e) {
                 Log.debug("unable to lookup CLI plugin version for Helidon version %s: %s", helidonVersion, e.getMessage());
             } catch (RequirementFailure e) {
                 Log.debug("CLI plugin version not specified for Helidon version %s: %s", helidonVersion);

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/CommonOptions.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/CommonOptions.java
@@ -124,9 +124,10 @@ final class CommonOptions {
                 Log.debug("using metadata url %s", metadataUrl);
             }
             metadata = Metadata.builder()
-                               .url(metadataUrl)
-                               .updateFrequency(config.checkForUpdatesIntervalHours())
-                               .build();
+                    .url(metadataUrl)
+                    .debugPlugin(debug)
+                    .updateFrequency(config.checkForUpdatesIntervalHours())
+                    .build();
         }
         return metadata;
     }
@@ -152,8 +153,8 @@ final class CommonOptions {
             } else {
                 Log.debug("no update available");
             }
-        } catch (Plugins.PluginFailed ignore) {
-            // message has already been logged
+        } catch (Metadata.UpdateFailed e) {
+            Log.debug("check for updates failed: %s", e.getMessage());
         } catch (Exception e) {
             Log.debug("check for updates failed: %s", e.toString());
         }
@@ -164,7 +165,7 @@ final class CommonOptions {
             Map<Object, Object> notes = new LinkedHashMap<>();
             metadata().cliReleaseNotesOf(latestHelidonVersion, sinceCliVersion).forEach((v, m) -> notes.put("    " + v, m));
             return notes;
-        } catch (Plugins.PluginFailed e) {
+        } catch (Metadata.UpdateFailed e) {
             Log.debug("accessing release notes for %s failed: %s", latestHelidonVersion, e.getMessage());
         } catch (Exception e) {
             Log.debug("accessing release notes for %s failed: %s", latestHelidonVersion, e.toString());

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/CommonOptions.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/CommonOptions.java
@@ -155,6 +155,8 @@ final class CommonOptions {
             }
         } catch (Metadata.UpdateFailed e) {
             Log.debug("check for updates failed: %s", e.getMessage());
+        } catch (Plugins.PluginFailedUnchecked e) {
+            // already logged
         } catch (Exception e) {
             Log.debug("check for updates failed: %s", e.toString());
         }
@@ -167,6 +169,8 @@ final class CommonOptions {
             return notes;
         } catch (Metadata.UpdateFailed e) {
             Log.debug("accessing release notes for %s failed: %s", latestHelidonVersion, e.getMessage());
+        } catch (Plugins.PluginFailedUnchecked e) {
+            Log.debug("accessing release notes for %s failed", latestHelidonVersion);
         } catch (Exception e) {
             Log.debug("accessing release notes for %s failed: %s", latestHelidonVersion, e.toString());
         }

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InfoCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InfoCommand.java
@@ -156,7 +156,11 @@ public final class InfoCommand extends BaseCommand {
         log("User Config", userConfigProps, maxWidth);
         log("Project Config", projectProps, maxWidth);
         log("General", buildProps, maxWidth);
-        Plugins.execute("GetInfo", pluginArgs(maxWidth), 5, Log::info);
+        try {
+            Plugins.execute("GetInfo", pluginArgs(maxWidth), 5, Log::info);
+        } catch (Plugins.PluginFailed e) {
+            Log.error(e, "Unable to get system info");
+        }
         log("Metadata", metaProps, maxWidth);
         log("System Properties", systemProps, maxWidth);
         log("Environment Variables", envVars, maxWidth);

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
@@ -158,6 +158,7 @@ public final class InitCommand extends BaseCommand {
         // Need Helidon version and flavor to proceed
         if (!batch) {
             if (helidonVersion == null) {
+                //noinspection ConstantConditions
                 helidonVersion = prompt("Helidon version", helidonVersion);
             }
             String[] flavorOptions = new String[]{"SE", "MP"};
@@ -304,7 +305,7 @@ public final class InitCommand extends BaseCommand {
             try {
                 version = metadata.latestVersion(true).toString();
                 Log.debug("Latest Helidon version found: %s", version);
-            } catch (Plugins.PluginFailed e) {
+            } catch (Metadata.UpdateFailed e) {
                 Log.info(e.getMessage());
                 failed("$(italic Cannot lookup version, please specify with --version option.)");
             } catch (Exception e) {

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
@@ -308,6 +308,8 @@ public final class InitCommand extends BaseCommand {
             } catch (Metadata.UpdateFailed e) {
                 Log.info(e.getMessage());
                 failed("$(italic Cannot lookup version, please specify with --version option.)");
+            } catch (Plugins.PluginFailedUnchecked e) {
+                failed("$(italic Cannot lookup version, please specify with --version option.)");
             } catch (Exception e) {
                 Log.info("$(italic,red %s)", e.getMessage());
                 failed("$(italic Cannot lookup version, please specify with --version option.)");

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
@@ -532,12 +532,12 @@ public class Metadata {
     }
 
     /**
-     * Update failed exception.
+     * Update failed checked exception.
      * This is a checked exception by design to ensure a proper error handling.
      */
     public static class UpdateFailed extends Exception {
 
-        private UpdateFailed(Throwable ex) {
+        private UpdateFailed(Plugins.PluginFailed ex) {
             super(ex.getMessage(), ex);
         }
     }

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/Plugins.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/Plugins.java
@@ -223,7 +223,7 @@ public class Plugins {
             if (containsUnsupportedClassVersionError(stdErr)) {
                 unsupportedJavaVersion();
             } else {
-                throw new PluginFailed(String.join(EOL, error.monitor().output()));
+                throw new PluginFailedUnchecked(String.join(EOL, error.monitor().output()));
             }
         } catch (ProcessMonitor.ProcessTimeoutException error) {
             throw new PluginFailed(pluginName + TIMED_OUT_SUFFIX);
@@ -237,9 +237,26 @@ public class Plugins {
     }
 
     /**
-     * Plugin failure.
+     * Plugin failure unchecked exception.
+     * This is a runtime exception used when the error has already been logged.
+     *
+     * @see PluginFailed for the checked variant
+     */
+    public static class PluginFailedUnchecked extends RuntimeException {
+
+        private PluginFailedUnchecked(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Plugin failure checked exception.
+     * This is a checked exception by design to ensure a proper error handling.
+     *
+     * @see PluginFailedUnchecked for the unchecked variant
      */
     public static class PluginFailed extends Exception {
+
         private PluginFailed(String message) {
             super(message);
         }

--- a/helidon-cli/impl/src/main/java/module-info.java
+++ b/helidon-cli/impl/src/main/java/module-info.java
@@ -21,7 +21,7 @@ module io.helidon.build.cli.impl {
     requires io.helidon.build.cli.harness;
     requires io.helidon.build.cli.plugin;
     requires io.helidon.build.archetype.engine;
-    requires helidon.build.utils;
+    requires io.helidon.build.util;
     requires maven.model;
     requires org.graalvm.sdk;
     provides io.helidon.build.cli.harness.CommandRegistry

--- a/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataIT.java
+++ b/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import static io.helidon.build.cli.impl.TestMetadata.HELIDON_BARE_SE;
 import static io.helidon.build.cli.impl.TestMetadata.LAST_UPDATE_FILE_NAME;
 import static io.helidon.build.cli.impl.TestMetadata.LATEST_FILE_NAME;
 import static io.helidon.build.cli.impl.TestMetadata.VERSION_RC2;
+import static io.helidon.build.util.Unchecked.unchecked;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -64,7 +65,7 @@ public class MetadataIT extends MetadataTestBase {
 
         // Do the initial catalog request for RC2
 
-        final Runnable request = () -> catalogRequest(VERSION_RC2, true);
+        final Runnable request = unchecked(() -> catalogRequest(VERSION_RC2, true));
         assertInitialRequestPerformsUpdate(request, 24, HOURS, VERSION_RC2, "", false);
 
         // Check latest version. Should not perform update.

--- a/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
+++ b/helidon-cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
@@ -52,6 +52,7 @@ import static io.helidon.build.cli.impl.TestMetadata.TestVersion.RC2;
 import static io.helidon.build.cli.impl.TestMetadata.VERSION_RC1;
 import static io.helidon.build.cli.impl.TestMetadata.VERSION_RC2;
 import static io.helidon.build.util.MavenVersion.toMavenVersion;
+import static io.helidon.build.util.Unchecked.unchecked;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -400,7 +401,7 @@ public class MetadataTest extends MetadataTestBase {
 
         // Make the initial catalog request and validate the result
 
-        final Runnable request = () -> catalogRequest(VERSION_RC2, true);
+        final Runnable request = unchecked(() -> catalogRequest(VERSION_RC2, true));
         assertInitialRequestPerformsUpdate(request, DEFAULT_UPDATE_FREQUENCY, HOURS, VERSION_RC2, RC2_ETAG, false);
 
         // Now request the catalog again and make sure we do no updates

--- a/helidon-linker/src/main/java/module-info.java
+++ b/helidon-linker/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module helidon.linker {
+module io.helidon.linker {
     exports io.helidon.linker;
     exports io.helidon.linker.util;
     opens io.helidon.linker;
@@ -24,5 +24,5 @@ module helidon.linker {
     requires jandex;
     requires org.fusesource.jansi;
     requires org.objectweb.asm;
-    requires helidon.build.utils;
+    requires io.helidon.build.util;
 }

--- a/utils/src/main/java/io/helidon/build/util/ProcessMonitor.java
+++ b/utils/src/main/java/io/helidon/build/util/ProcessMonitor.java
@@ -72,6 +72,7 @@ public final class ProcessMonitor {
      * Builder for a {@link ProcessMonitor}.
      */
     public static final class Builder {
+
         private ProcessBuilder builder;
         private String description;
         private boolean capture;

--- a/utils/src/main/java/io/helidon/build/util/Unchecked.java
+++ b/utils/src/main/java/io/helidon/build/util/Unchecked.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.helidon.build.cli.codegen;
+package io.helidon.build.util;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 /**
  * Utility to deal with checked exceptions in lambdas.
  */
-interface Unchecked {
+public interface Unchecked {
 
     /**
      * Checked consumer.

--- a/utils/src/main/java/module-info.java
+++ b/utils/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module helidon.build.utils {
+module io.helidon.build.util {
     exports io.helidon.build.util;
     opens io.helidon.build.util;
 


### PR DESCRIPTION
Improve Metadata update error handling:
 - Make Plugins.PluginFailed a checked exception to force error handling
 - Wrap Plugins.PluginFailed with Metadata.UpdatedFailed as another checked exception to expose metadata update errors
 - Metadata.UpdateFailed is explicitly thrown by every public methods of Metadata that performs an update check

Promote io.helidon.build.cli.codegen.Unchecked to io.helidon.build.util.Unchecke
Rename util module from helidon.build.utils to io.helidon.build.util (same as the package name)

Fixes #487