### PR TITLE
Fix shutdown hooks in native-image

### DIFF
--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -25,6 +25,9 @@
     <suppress checks="FileLength"
             files="helidon-cli/codegen/src/main/java/io/helidon/build/cli/codegen/AST.java"
             lines="1"/>
+    <suppress checks="IllegalImport"
+              files="helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/Helidon.java"
+              lines="22"/>
     <suppress checks="LineLength"
             files="helidon-archetype/engine/src/test/resources/META-INF/test.properties" />
     <suppress checks="LineLength"

--- a/helidon-cli/CHANGELOG.md
+++ b/helidon-cli/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - dev-loop incremental recompilation fails with maven 3.8.2 [499](https://github.com/oracle/helidon-build-tools/issues/499) [500](https://github.com/oracle/helidon-build-tools/pull/500)
 - dev-loop does not re-build for resource files on Windows [357](https://github.com/oracle/helidon-build-tools/issues/357) [483](https://github.com/oracle/helidon-build-tools/issues/483) [498](https://github.com/oracle/helidon-build-tools/pull/498)
 - dev-loop ctrl+c on Windows [511](https://github.com/oracle/helidon-build-tools/pull/511)
+- fix shutdown hooks with native image [520](https://github.com/oracle/helidon-build-tools/pull/520)
 
 ### Changes
 

--- a/helidon-cli/impl/pom.xml
+++ b/helidon-cli/impl/pom.xml
@@ -231,6 +231,7 @@
                                         <argument>-H:Path=${build.dir}</argument>
                                         <argument>-H:Name=${finalName}</argument>
                                         <argument>-H:+PrintAnalysisCallTree</argument>
+                                        <argument>--install-exit-handlers</argument>
                                         <argument>--no-fallback</argument>
                                         <argument>-cp</argument>
                                         <argument>${build.dir}${file.separator}${finalName}.jar${path.separator}${build.dir}${file.separator}libs${file.separator}*${path.separator}${build.dir}${file.separator}native</argument>

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
@@ -435,7 +435,7 @@ public final class DevCommand extends BaseCommand {
                             STDOUT.println();
                             insertLineIfError = false;
                         }
-                        STDOUT.println(errorMessage);
+                        STDOUT.print(errorMessage);
                     }
                 } else {
                     STDOUT.print(line);

--- a/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/Helidon.java
+++ b/helidon-cli/impl/src/main/java/io/helidon/build/cli/impl/Helidon.java
@@ -18,6 +18,9 @@ package io.helidon.build.cli.impl;
 import io.helidon.build.cli.harness.CommandLineInterface;
 import io.helidon.build.cli.harness.CommandRunner;
 
+import org.graalvm.nativeimage.ImageInfo;
+import sun.misc.Signal;
+
 /**
  * Helidon CLI definition and entry-point.
  */
@@ -42,6 +45,13 @@ public final class Helidon {
      * @param args raw command line arguments
      */
     public static void main(String[] args) {
+
+        if (ImageInfo.inImageRuntimeCode()) {
+            // Register a signal handler for Ctrl-C that calls System.exit in order to trigger
+            // the shutdown hooks
+            Signal.handle(new Signal("INT"), sig -> System.exit(0));
+        }
+
         CommandRunner.builder()
                      .args(args)
                      .optionLookup(Config.userConfig()::property)

--- a/helidon-cli/impl/src/main/java/module-info.java
+++ b/helidon-cli/impl/src/main/java/module-info.java
@@ -24,6 +24,7 @@ module io.helidon.build.cli.impl {
     requires io.helidon.build.util;
     requires maven.model;
     requires org.graalvm.sdk;
+    requires jdk.unsupported;
     provides io.helidon.build.cli.harness.CommandRegistry
             with io.helidon.build.cli.impl.HelidonRegistry;
 }


### PR DESCRIPTION
Fix shutdown hooks in native-image

Also fixed:
 - Fixed doubled newlines when printing error output in the dev command
 - Ignore exit code when process exited because of a shutdown
