### PR TITLE
Initialize AST eagerly #539

### DIFF
--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Flow.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Flow.java
@@ -159,14 +159,15 @@ public class Flow {
          String startDescriptorPath,
          boolean skipOptional,
          List<Visitor<ASTNode>> additionalVisitors,
+         Map<String, String> externalValues,
          Map<String, String> externalDefaults,
          boolean eagerRun
     ) {
         this.archetype = archetype;
         this.additionalVisitors = additionalVisitors;
         entryPoint = archetype.getDescriptor(startDescriptorPath);
-        interpreter = new Interpreter(archetype, startDescriptorPath, skipOptional, additionalVisitors, externalDefaults,
-                eagerRun);
+        interpreter = new Interpreter(archetype, startDescriptorPath, skipOptional, additionalVisitors, externalValues,
+                externalDefaults, eagerRun);
         this.skipOptional = skipOptional;
         state = new InitialFlowState(this);
     }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Flow.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Flow.java
@@ -153,6 +153,22 @@ public class Flow {
         state = new InitialFlowState(this);
     }
 
+    Flow(Archetype archetype,
+         String startDescriptorPath,
+         boolean skipOptional,
+         List<Visitor<ASTNode>> additionalVisitors,
+         Map<String, String> externalDefaults,
+         boolean eagerRun
+    ) {
+        this.archetype = archetype;
+        this.additionalVisitors = additionalVisitors;
+        entryPoint = archetype.getDescriptor(startDescriptorPath);
+        interpreter = new Interpreter(archetype, startDescriptorPath, skipOptional, additionalVisitors, externalDefaults,
+                eagerRun);
+        this.skipOptional = skipOptional;
+        state = new InitialFlowState(this);
+    }
+
     LinkedList<StepAST> tree() {
         return tree;
     }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Interpreter.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Interpreter.java
@@ -60,13 +60,14 @@ public class Interpreter implements Visitor<ASTNode> {
                 List<Visitor<ASTNode>> additionalVisitors,
                 Map<String, String> externalValues,
                 Map<String, String> externalDefaults) {
-        this(archetype, startDescriptorPath, skipOptional, additionalVisitors, externalDefaults, false);
+        this(archetype, startDescriptorPath, skipOptional, additionalVisitors, externalValues, externalDefaults, false);
     }
 
     Interpreter(Archetype archetype,
                 String startDescriptorPath,
                 boolean skipOptional,
                 List<Visitor<ASTNode>> additionalVisitors,
+                Map<String, String> externalValues,
                 Map<String, String> externalDefaults,
                 boolean eagerRun
                 ) {

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Interpreter.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/interpreter/Interpreter.java
@@ -50,19 +50,30 @@ public class Interpreter implements Visitor<ASTNode> {
     private final Map<String, String> externalDefaults;
     private boolean skipOptional;
     private boolean canBeGenerated = false;
-    private final boolean isEagerRun = true;
+    private final boolean eagerRun;
 
     Interpreter(Archetype archetype,
                 String startDescriptorPath,
                 boolean skipOptional,
                 List<Visitor<ASTNode>> additionalVisitors,
                 Map<String, String> externalDefaults) {
+        this(archetype, startDescriptorPath, skipOptional, additionalVisitors, externalDefaults, false);
+    }
+
+    Interpreter(Archetype archetype,
+                String startDescriptorPath,
+                boolean skipOptional,
+                List<Visitor<ASTNode>> additionalVisitors,
+                Map<String, String> externalDefaults,
+                boolean eagerRun
+                ) {
         this.archetype = archetype;
         pathToContextNodeMap = new HashMap<>();
         this.additionalVisitors = additionalVisitors;
         this.startDescriptorPath = startDescriptorPath;
         this.externalDefaults = externalDefaults;
         this.skipOptional = skipOptional;
+        this.eagerRun = eagerRun;
     }
 
     boolean canBeGenerated() {
@@ -119,7 +130,7 @@ public class Interpreter implements Visitor<ASTNode> {
         replaceDefaultValue(input);
         validate(input);
         pushToStack(input);
-        if (!isEagerRun) {
+        if (!eagerRun) {
             boolean result = resolve(input);
             if (!result) {
                 InputNodeAST unresolvedUserInputNode = userInputVisitor.visit(input, parent);
@@ -143,7 +154,7 @@ public class Interpreter implements Visitor<ASTNode> {
         replaceDefaultValue(input);
         validate(input);
         pushToStack(input);
-        if (!isEagerRun) {
+        if (!eagerRun) {
             boolean result = resolve(input);
             if (!result) {
                 InputNodeAST unresolvedUserInputNode = userInputVisitor.visit(input, parent);
@@ -160,7 +171,7 @@ public class Interpreter implements Visitor<ASTNode> {
         replaceDefaultValue(input);
         validate(input);
         pushToStack(input);
-        if (!isEagerRun) {
+        if (!eagerRun) {
             boolean result = resolve(input);
             if (!result) {
                 InputNodeAST unresolvedUserInputNode = userInputVisitor.visit(input, parent);
@@ -177,7 +188,7 @@ public class Interpreter implements Visitor<ASTNode> {
         replaceDefaultValue(input);
         validate(input);
         pushToStack(input);
-        if (!isEagerRun) {
+        if (!eagerRun) {
             boolean result = resolve(input);
             if (!result) {
                 InputNodeAST unresolvedUserInputNode = userInputVisitor.visit(input, parent);
@@ -246,7 +257,7 @@ public class Interpreter implements Visitor<ASTNode> {
             String scriptPath = script.location().scriptPath();
             String scriptType = script.includeType();
             boolean isCycle = isCycle(script, descriptorPath);
-            if (isEagerRun) {
+            if (eagerRun) {
                 if (!isCycle) {
                     return archetype.getDescriptor(descriptorPath);
                 }
@@ -376,7 +387,7 @@ public class Interpreter implements Visitor<ASTNode> {
         applyAdditionalVisitors(input);
         pushToStack(input);
         Map<String, String> contextValuesMap = convertContext();
-        if (!isEagerRun) {
+        if (!eagerRun) {
             if (input.expression().evaluate(contextValuesMap)) {
                 acceptAll(input);
             } else {

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/interpreter/FlowTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/interpreter/FlowTest.java
@@ -38,6 +38,15 @@ public class FlowTest extends ArchetypeBaseTest {
     private Archetype archetype;
 
     @Test
+    public void testEagerMode() {
+        archetype = getArchetype("eager-run");
+
+        Flow flow = new Flow(archetype, "flavor.xml", false, List.of(DebugVisitor.builder().build()), Map.of());
+        flow.build(new ContextAST());
+        assertResult(flow, 2, 6);
+    }
+
+    @Test
     public void testInnerOutputsElements() {
         archetype = getArchetype("interpreter-test-resources");
 

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/interpreter/FlowTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/interpreter/FlowTest.java
@@ -19,6 +19,7 @@ package io.helidon.build.archetype.engine.v2.interpreter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,16 +42,58 @@ public class FlowTest extends ArchetypeBaseTest {
     public void testEagerMode() {
         archetype = getArchetype("eager-run");
 
-        Flow flow = new Flow(archetype, "flavor.xml", false, List.of(DebugVisitor.builder().build()), Map.of());
+        Flow flow = new Flow(archetype, "flavor.xml", false, List.of(DebugVisitor.builder().build()), Map.of(), true);
         flow.build(new ContextAST());
         assertResult(flow, 2, 6);
+        LinkedList<StepAST> tree = flow.tree();
+        InputAST input1 = (InputAST) tree.get(0).children().get(0);
+        InputAST input2 = (InputAST) tree.get(0).children().get(1);
+
+        InputEnumAST input1Enum = (InputEnumAST) input1.children().get(0);
+
+        OptionAST enumOtion1 = (OptionAST) input1Enum.children().get(0);
+        SourceAST enumSource1 = (SourceAST) enumOtion1.children().get(0);
+        ContextAST enumContext1 = (ContextAST) enumSource1.children().get(0);
+        assertThat(enumContext1.children().size(), is(2));
+
+        OptionAST enumOtion2 = (OptionAST) input1Enum.children().get(1);
+        SourceAST enumSource2 = (SourceAST) enumOtion2.children().get(0);
+        IfStatement ifStatement1 = (IfStatement) enumSource2.children().get(0);
+        assertThat(ifStatement1.children().get(0) instanceof OutputAST, is(true));
+
+        OptionAST enumOtion3 = (OptionAST) input1Enum.children().get(2);
+        SourceAST enumSource3 = (SourceAST) enumOtion3.children().get(0);
+        OutputAST outputAST3 = (OutputAST) enumSource3.children().get(0);
+        assertThat(outputAST3.children().get(0) instanceof TemplatesAST, is(true));
+
+        InputListAST input1List = (InputListAST) input1.children().get(1);
+
+        OptionAST listOtion1 = (OptionAST) input1List.children().get(0);
+        SourceAST listSource1 = (SourceAST) listOtion1.children().get(0);
+        ContextAST listContext1 = (ContextAST) listSource1.children().get(0);
+        assertThat(listContext1.children().size(), is(2));
+
+        OptionAST listOtion2 = (OptionAST) input1List.children().get(1);
+        SourceAST listSource2 = (SourceAST) listOtion2.children().get(0);
+        IfStatement ifStatement2 = (IfStatement) listSource2.children().get(0);
+        assertThat(ifStatement2.children().get(0) instanceof OutputAST, is(true));
+
+        InputBooleanAST input2Bool = (InputBooleanAST) input2.children().get(0);
+
+        SourceAST boolSource1 = (SourceAST) input2Bool.children().get(0);
+        OutputAST outputAST4 = (OutputAST) boolSource1.children().get(0);
+        assertThat(outputAST4.children().get(0) instanceof TemplatesAST, is(true));
+
+        InputTextAST input2Text = (InputTextAST) input2.children().get(1);
+        assertThat(input2Text.defaultValue(), is("default text"));
     }
 
     @Test
     public void testInnerOutputsElements() {
         archetype = getArchetype("interpreter-test-resources");
 
-        Flow flow = new Flow(archetype, "inner-output-elements-test.xml", false, List.of(DebugVisitor.builder().build()), Map.of());
+        Flow flow = new Flow(archetype, "inner-output-elements-test.xml", false, List.of(DebugVisitor.builder().build()),
+                Map.of());
         flow.build(new ContextAST());
         assertResult(flow, 6, 3);
 

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/interpreter/FlowTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/interpreter/FlowTest.java
@@ -42,7 +42,7 @@ public class FlowTest extends ArchetypeBaseTest {
     public void testEagerMode() {
         archetype = getArchetype("eager-run");
 
-        Flow flow = new Flow(archetype, "flavor.xml", false, List.of(DebugVisitor.builder().build()), Map.of(), true);
+        Flow flow = new Flow(archetype, "flavor.xml", false, List.of(DebugVisitor.builder().build()), Map.of(), Map.of(), true);
         flow.build(new ContextAST());
         assertResult(flow, 2, 6);
         LinkedList<StepAST> tree = flow.tree();
@@ -92,7 +92,8 @@ public class FlowTest extends ArchetypeBaseTest {
     public void testInnerOutputsElements() {
         archetype = getArchetype("interpreter-test-resources");
 
-        Flow flow = new Flow(archetype, "inner-output-elements-test.xml", false, List.of(DebugVisitor.builder().build()), Map.of(), Map.of());
+        Flow flow = new Flow(archetype, "inner-output-elements-test.xml", false, List.of(DebugVisitor.builder().build()),
+                Map.of(), Map.of());
         flow.build(new ContextAST());
         assertResult(flow, 6, 3);
 
@@ -213,7 +214,8 @@ public class FlowTest extends ArchetypeBaseTest {
     public void testSource() {
         archetype = getArchetype("interpreter-test-resources");
 
-        Flow flow = new Flow(archetype, "source_script_test.xml", false, List.of(DebugVisitor.builder().build()), Map.of(), Map.of());
+        Flow flow = new Flow(archetype, "source_script_test.xml", false, List.of(DebugVisitor.builder().build()), Map.of(),
+                Map.of());
         flow.build(new ContextAST());
 
         flow.build(getUserInput("User boolean input label"));
@@ -232,7 +234,8 @@ public class FlowTest extends ArchetypeBaseTest {
     public void testExec() {
         archetype = getArchetype("interpreter-test-resources");
 
-        Flow flow = new Flow(archetype, "exec_script_test.xml", false, List.of(DebugVisitor.builder().build()), Map.of(), Map.of());
+        Flow flow = new Flow(archetype, "exec_script_test.xml", false, List.of(DebugVisitor.builder().build()), Map.of(),
+                Map.of());
         flow.build(new ContextAST());
 
         flow.build(getUserInput("User boolean input label"));
@@ -296,7 +299,8 @@ public class FlowTest extends ArchetypeBaseTest {
     public void testCanBeGenerated() {
         archetype = getArchetype("interpreter-test-resources");
 
-        Flow flow = new Flow(archetype, "can-be-generated-test.xml", false, List.of(DebugVisitor.builder().build()), Map.of(), Map.of());
+        Flow flow = new Flow(archetype, "can-be-generated-test.xml", false, List.of(DebugVisitor.builder().build()), Map.of(),
+                Map.of());
         FlowState state = flow.build(new ContextAST());
         assertThat(state.canBeGenerated(), is(false));
         state = flow.build(getUserInput("User boolean input label"));

--- a/archetype/engine-v2/src/test/resources/eager-run/e1.xml
+++ b/archetype/engine-v2/src/test/resources/eager-run/e1.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
+
+    <context>
+        <boolean path="foo">true</boolean>
+        <text path="model.var.value">some value e1</text>
+    </context>
+
+</archetype-script>

--- a/archetype/engine-v2/src/test/resources/eager-run/e2.xml
+++ b/archetype/engine-v2/src/test/resources/eager-run/e2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
+
+    <output if="${foo2} == true">
+        <templates>
+            <directory>files2</directory>
+            <includes>
+                <include>file2.yaml.mustache</include>
+            </includes>
+            <model if="${foo} == false">
+                <list key="not-readme-sections">
+                    <value order="7" template="mustache">
+                        the value e2
+                    </value>
+                </list>
+            </model>
+        </templates>
+    </output>
+
+</archetype-script>

--- a/archetype/engine-v2/src/test/resources/eager-run/flavor.xml
+++ b/archetype/engine-v2/src/test/resources/eager-run/flavor.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
+
+    <step label="Helidon Flavor">
+        <input>
+            <enum name="enum1" label="enum1 lebel">
+                <option value="e1" label="enum option 1">
+                    <source src="e1.xml"/>
+                </option>
+                <option value="e2" label="enum option 2">
+                    <source src="e2.xml"/>
+                </option>
+                <option value="e3" label="enum option 3">
+                    <source src="o3.xml"/>
+                </option>
+            </enum>
+
+            <list name="list1" label="Select the list1">
+                <option value="option1" label="List option 1">
+                    <source src="l1.xml"/>
+                    <output>
+                        <templates>
+                            <directory>files1</directory>
+                            <includes>
+                                <include>included1.file</include>
+                            </includes>
+                        </templates>
+                    </output>
+                </option>
+                <option value="option2" label="List option 2">
+                    <source src="l2.xml"/>
+                    <output>
+                        <templates>
+                            <directory>files2</directory>
+                            <includes>
+                                <include>included2.file</include>
+                            </includes>
+                        </templates>
+                    </output>
+                </option>
+            </list>
+        </input>
+
+        <input>
+            <boolean name="b1" label="b1 lebel">
+                <source src="o3.xml"/>
+            </boolean>
+
+            <text name="t1"
+                  label="Project name"
+                  optional="true"
+                  default="default text"
+            />
+        </input>
+    </step>
+</archetype-script>

--- a/archetype/engine-v2/src/test/resources/eager-run/l1.xml
+++ b/archetype/engine-v2/src/test/resources/eager-run/l1.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
+
+    <context>
+        <boolean path="foo">false</boolean>
+        <text path="model.var.value">some value l1</text>
+    </context>
+
+</archetype-script>

--- a/archetype/engine-v2/src/test/resources/eager-run/l2.xml
+++ b/archetype/engine-v2/src/test/resources/eager-run/l2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
+
+    <output if="${foo1} == true">
+        <templates>
+            <directory>files1</directory>
+            <includes>
+                <include>file1.yaml.mustache</include>
+            </includes>
+            <model if="${foo} == false">
+                <list key="not-readme-sections">
+                    <value order="7" template="mustache">
+                        the value l2
+                    </value>
+                </list>
+            </model>
+        </templates>
+    </output>
+
+</archetype-script>

--- a/archetype/engine-v2/src/test/resources/eager-run/o3.xml
+++ b/archetype/engine-v2/src/test/resources/eager-run/o3.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
+
+    <output>
+        <templates engine="mustache" transformations="mustache">
+            <directory>files</directory>
+            <includes>
+                <include>.helidon.mustache</include>
+            </includes>
+        </templates>
+    </output>
+</archetype-script>


### PR DESCRIPTION
Initialize AST eagerly #539

resolves #539 

Few notes for the reviewers:
1) because in the eager mode Interpreter is trying to load all the scripts :
   - Interpreter does not check duplicate include of the scripts. The reason is different type of the Helidon projects can have the same scripts, so the result tree in this mode can have duplicate scripts.
   - Interpreter checks circular dependencies from one script to another
   - different types of the Helidon projects can have the same context nodes but with different values, but because of the fact that every context node is unique by its path in the tree only one context note with the given path can exist in the result tree, so some values may be lost.
2) we do not check and skip all the IF statements because we cannot check all of them
