### PR TITLE
Clear last failed time and flag when starting a build.

### DIFF
--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
@@ -301,6 +301,7 @@ public final class DevCommand extends BaseCommand {
                         buildFailed = false;
                     } else if (line.contains(DEV_LOOP_BUILD_COMPLETED)) {
                         building = false;
+                        buildFailed = false;
                     } else if (line.contains(DEV_LOOP_APPLICATION_STARTING)) {
                         appendLine = true;
                         building = false;

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/DevCommand.java
@@ -298,6 +298,7 @@ public final class DevCommand extends BaseCommand {
                     if (line.contains(DEV_LOOP_BUILD_STARTING)) {
                         insertLineIfError = true;
                         building = true;
+                        buildFailed = false;
                     } else if (line.contains(DEV_LOOP_BUILD_COMPLETED)) {
                         building = false;
                     } else if (line.contains(DEV_LOOP_APPLICATION_STARTING)) {
@@ -326,6 +327,7 @@ public final class DevCommand extends BaseCommand {
                            || line.contains(HELP_TAG)) {
                     suspendOutput();
                     building = false;
+                    buildFailed = false;
                     return false;
                 } else {
                     return !line.equals(AT_TAG);

--- a/dev-loop/dev-loop/src/main/java/io/helidon/build/devloop/BuildLoop.java
+++ b/dev-loop/dev-loop/src/main/java/io/helidon/build/devloop/BuildLoop.java
@@ -278,6 +278,7 @@ public class BuildLoop {
         delay.set(0);
         if (type != ChangeType.SourceFile) {
             project.set(null);
+            lastFailedTime.set(0);
         }
     }
 

--- a/dev-loop/dev-loop/src/main/java/io/helidon/build/devloop/BuildLoop.java
+++ b/dev-loop/dev-loop/src/main/java/io/helidon/build/devloop/BuildLoop.java
@@ -287,6 +287,7 @@ public class BuildLoop {
     }
 
     private void buildSucceeded(BuildType type) {
+        lastFailedTime.set(0);
         monitor.onBuildSuccess(cycleNumber.get(), type);
     }
 


### PR DESCRIPTION
Partial fix for 429 that resolves the output "stall" issue.