### PR TITLE
Improve Metadata update error handling:

### DIFF
--- a/cli/codegen/pom.xml
+++ b/cli/codegen/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,6 +31,11 @@
         <dependency>
             <groupId>io.helidon.build-tools.cli</groupId>
             <artifactId>helidon-cli-harness</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.build-tools.common</groupId>
+            <artifactId>helidon-build-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/cli/codegen/src/main/java/io/helidon/build/cli/codegen/ASTWriter.java
+++ b/cli/codegen/src/main/java/io/helidon/build/cli/codegen/ASTWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ import io.helidon.build.cli.codegen.AST.TypeDeclaration;
 import io.helidon.build.cli.codegen.AST.Value;
 import io.helidon.build.cli.codegen.AST.ValueCast;
 import io.helidon.build.cli.codegen.AST.ValueRef;
-import io.helidon.build.cli.codegen.Unchecked.CheckedConsumer;
+import io.helidon.build.common.Unchecked.CheckedConsumer;
 
-import static io.helidon.build.cli.codegen.Unchecked.unchecked;
+import static io.helidon.build.common.Unchecked.unchecked;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;

--- a/cli/codegen/src/main/java/io/helidon/build/cli/codegen/FileHeaderJavacPlugin.java
+++ b/cli/codegen/src/main/java/io/helidon/build/cli/codegen/FileHeaderJavacPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.Map.Entry;
 
 import javax.tools.JavaFileObject;
 
-import io.helidon.build.cli.codegen.Unchecked.CheckedSupplier;
+import io.helidon.build.common.Unchecked.CheckedSupplier;
 
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;

--- a/cli/codegen/src/main/java/module-info.java
+++ b/cli/codegen/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.helidon.build.cli.codegen.FileHeaderJavacPlugin;
  */
 module io.helidon.build.cli.codegen {
     requires io.helidon.build.cli.harness;
+    requires io.helidon.build.common;
     requires java.compiler;
     provides javax.annotation.processing.Processor with CommandAP;
     provides com.sun.source.util.Plugin with FileHeaderJavacPlugin;

--- a/cli/codegen/src/test/java/io/helidon/build/cli/codegen/ASTWriterTest.java
+++ b/cli/codegen/src/test/java/io/helidon/build/cli/codegen/ASTWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import io.helidon.build.cli.codegen.AST.MethodBody;
 import io.helidon.build.cli.codegen.AST.MethodDeclaration;
 import io.helidon.build.cli.codegen.AST.MethodInvocation;
 import io.helidon.build.cli.codegen.TypeInfo.CompositeTypeInfo;
-import io.helidon.build.cli.codegen.Unchecked.CheckedConsumer;
+import io.helidon.build.common.Unchecked.CheckedConsumer;
 
 import com.acme.TestClass1;
 import org.junit.jupiter.api.Test;

--- a/cli/codegen/src/test/java/io/helidon/build/cli/codegen/CommandAPTest.java
+++ b/cli/codegen/src/test/java/io/helidon/build/cli/codegen/CommandAPTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import io.helidon.build.cli.codegen.CompilerHelper.JavaSourceFromString;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.build.cli.codegen.Unchecked.unchecked;
+import static io.helidon.build.common.Unchecked.unchecked;
 import static io.helidon.build.common.Strings.normalizeNewLines;
 import static io.helidon.build.common.Strings.read;
 import static java.nio.file.Files.list;

--- a/cli/codegen/src/test/java/io/helidon/build/cli/codegen/CompilerHelper.java
+++ b/cli/codegen/src/test/java/io/helidon/build/cli/codegen/CompilerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static io.helidon.build.cli.codegen.Unchecked.unchecked;
+import static io.helidon.build.common.Unchecked.unchecked;
 import static io.helidon.build.common.Strings.normalizeNewLines;
 import static io.helidon.build.common.Strings.read;
 import static java.util.stream.Collectors.toList;

--- a/cli/common/src/main/java/module-info.java
+++ b/cli/common/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 /**
  * Helidon Build Cli Common
  */
-module io.helidon.cli.common {
+module io.helidon.build.cli.common {
     exports io.helidon.build.cli.common;
     requires io.helidon.build.common;
 }

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class ArchetypeBrowser {
         ArchetypeCatalog catalog = null;
         try {
             catalog = metadata.catalogOf(requireSupportedHelidonVersion(helidonVersion));
-        } catch (PluginFailed e) {
+        } catch (Metadata.UpdateFailed | PluginFailed e) {
             Requirements.failed(HELIDON_VERSION_NOT_FOUND, helidonVersion);
         }
         this.catalog = catalog;

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/BaseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,7 +141,7 @@ public abstract class BaseCommand implements CommandExecution {
             // that if this file was deleted and no build has occurred, a minimal project config is
             // generated in our preconditions, which will attempt to find and store the Helidon
             // version by reading the pom and checking for a Helidon parent pom. Though a Helidon
-            // parent pom will normally be present, it is not required so we may not find it in the
+            // parent pom will normally be present, it is not required, so we may not find it in the
             // config; in that case, fallback to the latest version. If we fail to get that, use our
             // build version.
 
@@ -176,10 +176,12 @@ public abstract class BaseCommand implements CommandExecution {
             try {
                 Log.debug("using Helidon version %s to find CLI plugin version", helidonVersion);
                 return meta.cliPluginVersion(helidonVersion, true).toString();
-            } catch (Plugins.PluginFailed e) {
+            } catch (Metadata.UpdateFailed e) {
                 Log.debug("unable to lookup CLI plugin version for Helidon version %s: %s", helidonVersion, e.getMessage());
             } catch (RequirementFailure e) {
                 Log.debug("CLI plugin version not specified for Helidon version %s: %s", helidonVersion);
+            }  catch (Plugins.PluginFailedUnchecked e) {
+                // already logged
             } catch (Exception e) {
                 Log.debug("unable to lookup CLI plugin version for Helidon version %s: %s", helidonVersion, e.toString());
             }

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/InfoCommand.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/InfoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,7 +160,11 @@ public final class InfoCommand extends BaseCommand {
         log("User Config", userConfigProps, maxWidth);
         log("Project Config", projectProps, maxWidth);
         log("General", buildProps, maxWidth);
-        Plugins.execute("GetInfo", pluginArgs(maxWidth), 5, Log::info);
+        try {
+            Plugins.execute("GetInfo", pluginArgs(maxWidth), 5, Log::info);
+        } catch (Plugins.PluginFailed e) {
+            Log.error(e, "Unable to get system info");
+        }
         log("Metadata", metaProps, maxWidth);
         log("System Properties", systemProps, maxWidth);
         log("Environment Variables", envVars, maxWidth);

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,8 +153,10 @@ public final class InitCommand extends BaseCommand {
             try {
                 version = metadata.latestVersion(true).toString();
                 Log.debug("Latest Helidon version found: %s", version);
-            } catch (Plugins.PluginFailed e) {
+            } catch (Metadata.UpdateFailed e) {
                 Log.info(e.getMessage());
+                Requirements.failed("$(italic Cannot lookup version, please specify with --version option.)");
+            } catch (Plugins.PluginFailedUnchecked e) {
                 Requirements.failed("$(italic Cannot lookup version, please specify with --version option.)");
             } catch (Exception e) {
                 Log.info("$(italic,red %s)", e.getMessage());

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import io.helidon.build.archetype.engine.v1.ArchetypeCatalog;
@@ -524,21 +523,15 @@ public class Metadata {
         args.add(Config.buildVersion());
         args.add("--maxAttempts");
         args.add(Integer.toString(maxAttempts));
-        Consumer<String> stdOut = null;
         if (debugPlugin) {
             // Force debug even if log is not at debug level
             args.add("--debug");
-            stdOut = Log::info;
         }
         try {
-            Plugins.execute(PLUGIN_NAME, args, PLUGIN_MAX_WAIT_SECONDS, stdOut);
+            Plugins.execute(PLUGIN_NAME, args, PLUGIN_MAX_WAIT_SECONDS, Log::info);
         } catch (Plugins.PluginFailed e) {
             throw new UpdateFailed(e);
         }
-    }
-
-    private static void info(String line) {
-        Log.info(line);
     }
 
     private MavenVersion readLatestVersion() {

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import io.helidon.build.archetype.engine.v1.ArchetypeCatalog;
@@ -90,7 +91,7 @@ public class Metadata {
     private final long updateFrequencyMillis;
     private final boolean debugPlugin;
     private final Map<Path, Long> lastChecked;
-    private final AtomicReference<RuntimeException> latestVersionFailure;
+    private final AtomicReference<Throwable> latestVersionFailure;
     private final AtomicReference<MavenVersion> latestVersion;
 
     private Metadata(Builder builder) {
@@ -109,6 +110,7 @@ public class Metadata {
      *
      * @return The url.
      */
+    @SuppressWarnings("unused")
     public String url() {
         return url;
     }
@@ -139,8 +141,9 @@ public class Metadata {
      * Returns the latest Helidon version.
      *
      * @return The version.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public MavenVersion latestVersion() {
+    public MavenVersion latestVersion() throws UpdateFailed {
         return latestVersion(false);
     }
 
@@ -149,10 +152,11 @@ public class Metadata {
      *
      * @param quiet If info messages should be suppressed.
      * @return The version.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public MavenVersion latestVersion(boolean quiet) {
+    public MavenVersion latestVersion(boolean quiet) throws UpdateFailed {
         // If we fail, we only want to do so once per command, so we cache any failure
-        RuntimeException initialFailure = latestVersionFailure.get();
+        Throwable initialFailure = latestVersionFailure.get();
         if (initialFailure == null) {
             try {
                 if (checkForUpdates(null, latestVersionFile, quiet)) {
@@ -161,12 +165,15 @@ public class Metadata {
                     latestVersion.set(readLatestVersion());
                 }
                 return latestVersion.get();
-            } catch (RuntimeException e) {
+            } catch (UpdateFailed | RuntimeException e) {
                 latestVersionFailure.set(e);
                 throw e;
             }
         } else {
-            throw initialFailure;
+            if (initialFailure instanceof UpdateFailed) {
+                throw (UpdateFailed) initialFailure;
+            }
+            throw (RuntimeException) initialFailure;
         }
     }
 
@@ -176,8 +183,9 @@ public class Metadata {
      * @param helidonVersion The version.
      * @param quiet          If info messages should be suppressed.
      * @return The version.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public MavenVersion cliPluginVersion(MavenVersion helidonVersion, boolean quiet) {
+    public MavenVersion cliPluginVersion(MavenVersion helidonVersion, boolean quiet) throws UpdateFailed {
         return cliPluginVersion(helidonVersion, toMavenVersion(Config.buildVersion()), quiet);
     }
 
@@ -188,8 +196,11 @@ public class Metadata {
      * @param thisCliVersion This CLI version.
      * @param quiet          If info messages should be suppressed.
      * @return The version.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public MavenVersion cliPluginVersion(MavenVersion helidonVersion, MavenVersion thisCliVersion, boolean quiet) {
+    public MavenVersion cliPluginVersion(MavenVersion helidonVersion,
+                                         MavenVersion thisCliVersion,
+                                         boolean quiet) throws UpdateFailed {
 
         // Create a map from CLI version to CLI plugin versions, including latest
 
@@ -226,19 +237,21 @@ public class Metadata {
      * @param helidonVersion The version.
      * @param quiet          If info messages should be suppressed.
      * @return The properties.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public MavenVersion cliVersionOf(MavenVersion helidonVersion, boolean quiet) {
+    public MavenVersion cliVersionOf(MavenVersion helidonVersion, boolean quiet) throws UpdateFailed {
         return toMavenVersion(requiredProperty(helidonVersion, CLI_VERSION_PROPERTY, quiet));
     }
 
     /**
-     * Checks whether or not there is a more recent CLI version available and returns the version if so.
+     * Checks if there is a more recent CLI version available and returns the version if so.
      *
      * @param thisCliVersion The version of this CLI.
      * @param quiet          If info messages should be suppressed.
      * @return A valid CLI version if a more recent CLI is available.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public Optional<MavenVersion> checkForCliUpdate(MavenVersion thisCliVersion, boolean quiet) {
+    public Optional<MavenVersion> checkForCliUpdate(MavenVersion thisCliVersion, boolean quiet) throws UpdateFailed {
         final MavenVersion latestHelidonVersion = latestVersion(quiet);
         final MavenVersion latestCliVersion = cliVersionOf(latestHelidonVersion, quiet);
         if (latestCliVersion.isGreaterThan(thisCliVersion)) {
@@ -254,9 +267,11 @@ public class Metadata {
      * @param latestHelidonVersion The latest Helidon version.
      * @param sinceCliVersion      The CLI version to start with.
      * @return The notes, in sorted order.
+     * @throws UpdateFailed if the metadata update failed
      */
     public Map<MavenVersion, String> cliReleaseNotesOf(MavenVersion latestHelidonVersion,
-                                                       MavenVersion sinceCliVersion) {
+                                                       MavenVersion sinceCliVersion) throws UpdateFailed {
+
         requireNonNull(latestHelidonVersion, "latestHelidonVersion must not be null");
         requireNonNull(sinceCliVersion, "sinceCliVersion must not be null");
         final ConfigProperties props = propertiesOf(latestHelidonVersion, true);
@@ -278,8 +293,9 @@ public class Metadata {
      *
      * @param helidonVersion The version.
      * @return The properties.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public ConfigProperties propertiesOf(String helidonVersion) {
+    public ConfigProperties propertiesOf(String helidonVersion) throws UpdateFailed {
         return propertiesOf(toMavenVersion(helidonVersion));
     }
 
@@ -288,8 +304,9 @@ public class Metadata {
      *
      * @param helidonVersion The version.
      * @return The properties.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public ConfigProperties propertiesOf(MavenVersion helidonVersion) {
+    public ConfigProperties propertiesOf(MavenVersion helidonVersion) throws UpdateFailed {
         return propertiesOf(helidonVersion, false);
     }
 
@@ -299,8 +316,9 @@ public class Metadata {
      * @param helidonVersion The version.
      * @param quiet          If info messages should be suppressed.
      * @return The properties.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public ConfigProperties propertiesOf(MavenVersion helidonVersion, boolean quiet) {
+    public ConfigProperties propertiesOf(MavenVersion helidonVersion, boolean quiet) throws UpdateFailed {
         return new ConfigProperties(versionedFile(helidonVersion, METADATA_FILE_NAME, quiet));
     }
 
@@ -309,8 +327,9 @@ public class Metadata {
      *
      * @param helidonVersion The version.
      * @return The catalog.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public ArchetypeCatalog catalogOf(String helidonVersion) {
+    public ArchetypeCatalog catalogOf(String helidonVersion) throws UpdateFailed  {
         return catalogOf(toMavenVersion(helidonVersion));
     }
 
@@ -319,8 +338,9 @@ public class Metadata {
      *
      * @param helidonVersion The version.
      * @return The catalog.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public ArchetypeCatalog catalogOf(MavenVersion helidonVersion) {
+    public ArchetypeCatalog catalogOf(MavenVersion helidonVersion) throws UpdateFailed {
         try {
             return ArchetypeCatalog.read(versionedFile(helidonVersion, CATALOG_FILE_NAME, false));
         } catch (IOException ex) {
@@ -333,8 +353,9 @@ public class Metadata {
      *
      * @param helidonVersion The version.
      * @return The directory.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public Path directoryOf(MavenVersion helidonVersion) {
+    public Path directoryOf(MavenVersion helidonVersion) throws UpdateFailed {
         final Path versionDir = rootDir.resolve(requireNonNull(helidonVersion).toString());
         final Path checkFile = versionDir.resolve(LAST_UPDATE_FILE_NAME);
         checkForUpdates(helidonVersion, checkFile, false);
@@ -346,14 +367,19 @@ public class Metadata {
      *
      * @param catalogEntry The catalog entry.
      * @return The path to the archetype jar.
+     * @throws UpdateFailed if the metadata update failed
      */
-    public Path archetypeOf(ArchetypeCatalog.ArchetypeEntry catalogEntry) {
+    public Path archetypeOf(ArchetypeCatalog.ArchetypeEntry catalogEntry) throws UpdateFailed {
         final MavenVersion helidonVersion = toMavenVersion(catalogEntry.version());
         final String fileName = catalogEntry.artifactId() + "-" + helidonVersion + JAR_SUFFIX;
         return versionedFile(helidonVersion, fileName, false);
     }
 
-    private String requiredProperty(MavenVersion helidonVersion, String propertyName, boolean quiet) {
+    @SuppressWarnings("SameParameterValue")
+    private String requiredProperty(MavenVersion helidonVersion,
+                                    String propertyName,
+                                    boolean quiet) throws UpdateFailed {
+
         ConfigProperties properties = propertiesOf(helidonVersion, quiet);
         return Requirements.requireNonNull(properties.property(propertyName), "missing " + propertyName);
     }
@@ -396,18 +422,22 @@ public class Metadata {
     }
 
     @SuppressWarnings("ConstantConditions")
-    private Path versionedFile(MavenVersion helidonVersion, String fileName, boolean quiet) {
+    private Path versionedFile(MavenVersion helidonVersion, String fileName, boolean quiet) throws UpdateFailed {
         final Path versionDir = rootDir.resolve(requireNonNull(helidonVersion).toString());
         final Path checkFile = versionDir.resolve(LAST_UPDATE_FILE_NAME);
         checkForUpdates(helidonVersion, checkFile, quiet);
         return requireFile(requireHelidonVersionDir(versionDir).resolve(fileName));
     }
 
-    private boolean checkForUpdates(MavenVersion helidonVersion, Path checkFile, boolean quiet) {
+    private boolean checkForUpdates(MavenVersion helidonVersion, Path checkFile, boolean quiet) throws UpdateFailed  {
         return checkForUpdates(helidonVersion, checkFile, System.currentTimeMillis(), quiet);
     }
 
-    boolean checkForUpdates(MavenVersion helidonVersion, Path checkFile, long currentTimeMillis, boolean quiet) {
+    boolean checkForUpdates(MavenVersion helidonVersion,
+                            Path checkFile,
+                            long currentTimeMillis,
+                            boolean quiet) throws UpdateFailed {
+
         if (isStale(checkFile, currentTimeMillis)) {
             update(helidonVersion, quiet);
             return true;
@@ -471,7 +501,7 @@ public class Metadata {
         }
     }
 
-    private void update(MavenVersion helidonVersion, boolean quiet) {
+    private void update(MavenVersion helidonVersion, boolean quiet) throws UpdateFailed {
         final boolean logInfo = Log.isDebug() || !quiet;
         final int maxAttempts = quiet ? 1 : PLUGIN_MAX_ATTEMPTS;
         final List<String> args = new ArrayList<>();
@@ -494,11 +524,17 @@ public class Metadata {
         args.add(Config.buildVersion());
         args.add("--maxAttempts");
         args.add(Integer.toString(maxAttempts));
+        Consumer<String> stdOut = null;
         if (debugPlugin) {
             // Force debug even if log is not at debug level
             args.add("--debug");
+            stdOut = Log::info;
         }
-        Plugins.execute(PLUGIN_NAME, args, PLUGIN_MAX_WAIT_SECONDS, Metadata::info);
+        try {
+            Plugins.execute(PLUGIN_NAME, args, PLUGIN_MAX_WAIT_SECONDS, stdOut);
+        } catch (Plugins.PluginFailed e) {
+            throw new UpdateFailed(e);
+        }
     }
 
     private static void info(String line) {
@@ -516,6 +552,17 @@ public class Metadata {
             throw new IllegalStateException("No version in " + latestVersionFile);
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
+        }
+    }
+
+    /**
+     * Update failed checked exception.
+     * This is a checked exception by design to ensure a proper error handling.
+     */
+    public static class UpdateFailed extends Exception {
+
+        private UpdateFailed(Plugins.PluginFailed ex) {
+            super(ex.getMessage(), ex);
         }
     }
 

--- a/cli/impl/src/main/java/module-info.java
+++ b/cli/impl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ module io.helidon.build.cli.impl {
     requires io.helidon.build.common.ansi;
     requires io.helidon.build.common;
     requires io.helidon.build.common.maven;
-    requires io.helidon.cli.common;
+    requires io.helidon.build.cli.common;
     requires io.helidon.build.devloop.common;
     provides io.helidon.build.cli.harness.CommandRegistry
             with io.helidon.build.cli.impl.HelidonRegistry;

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/ArchetypeBrowserTest.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/ArchetypeBrowserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ public class ArchetypeBrowserTest extends MetadataAccessTestBase {
         return new ArchetypeBrowser(metadata(), flavor, helidonTestVersion());
     }
 
+    @SuppressWarnings("SameParameterValue")
     private static ArchetypeEntry findEntry(String name, ArchetypeBrowser browser) {
         return browser.archetypes()
                       .stream()

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import static io.helidon.build.cli.impl.TestMetadata.TestVersion.RC1;
 import static io.helidon.build.cli.impl.TestMetadata.TestVersion.RC2;
 import static io.helidon.build.cli.impl.TestMetadata.VERSION_RC1;
 import static io.helidon.build.cli.impl.TestMetadata.VERSION_RC2;
+import static io.helidon.build.common.Unchecked.unchecked;
 import static io.helidon.build.common.maven.MavenVersion.toMavenVersion;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -81,7 +82,7 @@ public class MetadataTest extends MetadataTestBase {
     }
 
     @Test
-    void smokeTest() {
+    void smokeTest() throws Exception {
         assertInitialLatestVersionRequestPerformsUpdate(DEFAULT_UPDATE_FREQUENCY, HOURS, VERSION_RC1, NO_ETAG, false);
 
         // Check properties. Should not perform update.
@@ -147,7 +148,7 @@ public class MetadataTest extends MetadataTestBase {
     }
 
     @Test
-    void testCheckForCliUpdate() {
+    void testCheckForCliUpdate() throws Exception {
 
         // Setup with RC2 as latest
 
@@ -183,7 +184,7 @@ public class MetadataTest extends MetadataTestBase {
     }
 
     @Test
-    void testCliPluginVersion() {
+    void testCliPluginVersion() throws Exception {
 
         // Setup with RC2 as latest
 
@@ -249,7 +250,7 @@ public class MetadataTest extends MetadataTestBase {
 
 
     @Test
-    void testReleaseNotes() {
+    void testReleaseNotes() throws Exception {
         meta = newDefaultInstance();
         MavenVersion helidonVersion = MAVEN_VERSION_RC2;
 
@@ -268,7 +269,7 @@ public class MetadataTest extends MetadataTestBase {
         assertThat(notes.get(keys.get(2)), containsString("Performance"));
         assertThat(notes.get(keys.get(3)), containsString("DB archetype"));
 
-        // Check from latest version (RC1)
+        // Check from the latest version (RC1)
 
         notes = meta.cliReleaseNotesOf(helidonVersion, meta.latestVersion());
         assertThat(notes, is(not(nullValue())));
@@ -345,7 +346,7 @@ public class MetadataTest extends MetadataTestBase {
     }
 
     @Test
-    void testZipIsNotDownloadedWhenEtagMatches() {
+    void testZipIsNotDownloadedWhenEtagMatches() throws Exception {
         startMetadataTestServer(TestVersion.RC1);
 
         // Make the initial latestVersion call and validate the result
@@ -365,9 +366,9 @@ public class MetadataTest extends MetadataTestBase {
     }
 
     @Test
-    void testUpdateWhenLatestChanges() {
+    void testUpdateWhenLatestChanges() throws Exception {
 
-        // Setup test server with latest set to RC2
+        // Setup test server with the latest set to RC2
 
         startMetadataTestServer(RC2);
 
@@ -395,12 +396,12 @@ public class MetadataTest extends MetadataTestBase {
     }
 
     @Test
-    void testCatalogUpdatesWhenUnseenVersionRequested() {
+    void testCatalogUpdatesWhenUnseenVersionRequested() throws Exception {
         startMetadataTestServer(RC2);
 
         // Make the initial catalog request and validate the result
 
-        final Runnable request = () -> catalogRequest(VERSION_RC2, true);
+        final Runnable request = unchecked(() -> catalogRequest(VERSION_RC2, true));
         assertInitialRequestPerformsUpdate(request, DEFAULT_UPDATE_FREQUENCY, HOURS, VERSION_RC2, RC2_ETAG, false);
 
         // Now request the catalog again and make sure we do no updates

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTestIT.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import static io.helidon.build.cli.impl.TestMetadata.HELIDON_BARE_SE;
 import static io.helidon.build.cli.impl.TestMetadata.LAST_UPDATE_FILE_NAME;
 import static io.helidon.build.cli.impl.TestMetadata.LATEST_FILE_NAME;
 import static io.helidon.build.cli.impl.TestMetadata.VERSION_RC2;
+import static io.helidon.build.common.Unchecked.unchecked;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -45,7 +46,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * Integration test for class {@link Metadata} using {@code helidon.io} default url.
  */
-public class MetadataIT extends MetadataTestBase {
+public class MetadataTestIT extends MetadataTestBase {
 
     static final String RC2_LAST_UPDATE = VERSION_RC2 + File.separator + LAST_UPDATE_FILE_NAME;
 
@@ -60,11 +61,11 @@ public class MetadataIT extends MetadataTestBase {
     }
 
     @Test
-    void smokeTestRc2() {
+    void smokeTestRc2() throws Exception {
 
         // Do the initial catalog request for RC2
 
-        final Runnable request = () -> catalogRequest(VERSION_RC2, true);
+        final Runnable request = unchecked(() -> catalogRequest(VERSION_RC2, true));
         assertInitialRequestPerformsUpdate(request, 24, HOURS, VERSION_RC2, "", false);
 
         // Check latest version. Should not perform update.

--- a/cli/plugin/src/main/java/io/helidon/build/cli/plugin/Log.java
+++ b/cli/plugin/src/main/java/io/helidon/build/cli/plugin/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,15 @@ class Log {
     }
 
     /**
+     * Get the output.
+     *
+     * @return consumer of string
+     */
+    static Consumer<String> output() {
+        return OUT.get();
+    }
+
+    /**
      * Sets the output consumer.
      *
      * @param outputConsumer The output consumer.
@@ -106,7 +115,7 @@ class Log {
     }
 
     /**
-     * Returns whether or not debug messages will be written.
+     * Returns whether debug messages will be written.
      *
      * @return {@code true} if enabled.
      */
@@ -115,7 +124,7 @@ class Log {
     }
 
     /**
-     * Returns whether or not verbose messages will be written.
+     * Returns whether verbose messages will be written.
      *
      * @return {@code true} if enabled.
      */
@@ -127,7 +136,7 @@ class Log {
      * Log a message if debug is enabled.
      *
      * @param message The message.
-     * @param args The message args.
+     * @param args    The message args.
      */
     static void debug(String message, Object... args) {
         if (isDebug()) {
@@ -139,8 +148,9 @@ class Log {
      * Log a message if verbose is enabled.
      *
      * @param message The message.
-     * @param args The message args.
+     * @param args    The message args.
      */
+    @SuppressWarnings("unused")
     static void verbose(String message, Object... args) {
         if (isVerbose()) {
             log(message, args);
@@ -150,6 +160,7 @@ class Log {
     /**
      * Log an empty message.
      */
+    @SuppressWarnings("unused")
     static void info() {
         log("");
     }
@@ -158,7 +169,7 @@ class Log {
      * Log a message.
      *
      * @param message The message.
-     * @param args The message args.
+     * @param args    The message args.
      */
     static void info(String message, Object... args) {
         log(message, args);
@@ -168,8 +179,9 @@ class Log {
      * Log a warning message.
      *
      * @param message The message.
-     * @param args The message args.
+     * @param args    The message args.
      */
+    @SuppressWarnings("unused")
     static void warn(String message, Object... args) {
         log(style(WARN_STYLE, message, args));
     }
@@ -178,9 +190,10 @@ class Log {
      * Log a warning message with associated throwable.
      *
      * @param thrown The throwable.
-     * @param msg Message to be logged.
-     * @param args Format string arguments.
+     * @param msg    Message to be logged.
+     * @param args   Format string arguments.
      */
+    @SuppressWarnings("unused")
     static void warn(Throwable thrown, String msg, Object... args) {
         log(thrown, style(WARN_STYLE, msg, args));
     }
@@ -189,7 +202,7 @@ class Log {
      * Log an error message.
      *
      * @param message The message.
-     * @param args The message args.
+     * @param args    The message args.
      */
     static void error(String message, Object... args) {
         log(style(ERROR_STYLE, message, args));
@@ -199,26 +212,33 @@ class Log {
      * Log an error message with associated throwable.
      *
      * @param thrown The throwable.
-     * @param msg Message to be logged.
-     * @param args Format string arguments.
+     * @param msg    Message to be logged.
+     * @param args   Format string arguments.
      */
+    @SuppressWarnings("unused")
     static void error(Throwable thrown, String msg, Object... args) {
         log(thrown, style(ERROR_STYLE, msg, args));
     }
 
     private static void log(String message, Object... args) {
         if (message != null) {
-            OUT.get().accept(String.format(message, args));
+            Consumer<String> consumer = OUT.get();
+            if (consumer != null) {
+                consumer.accept(String.format(message, args));
+            }
         }
     }
 
     private static void log(Throwable thrown, String message, Object... args) {
-        final String trace = toStackTrace(thrown);
-        String msg = message == null ? "" : String.format(message, args);
-        if (trace != null) {
-            msg += (msg + EOL + trace);
+        Consumer<String> consumer = OUT.get();
+        if (consumer != null) {
+            final String trace = toStackTrace(thrown);
+            String msg = message == null ? "" : String.format(message, args);
+            if (trace != null) {
+                msg += (msg + EOL + trace);
+            }
+            consumer.accept(msg);
         }
-        OUT.get().accept(msg);
     }
 
     private static String toStackTrace(Throwable thrown) {

--- a/cli/plugin/src/test/java/io/helidon/build/cli/plugin/LogTest.java
+++ b/cli/plugin/src/test/java/io/helidon/build/cli/plugin/LogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module io.helidon.build.devloop {
-    exports io.helidon.build.devloop;
+package io.helidon.build.cli.plugin;
 
-    requires maven.resolver.provider;
-    // requires maven.settings;
-    requires maven.settings.builder;
-    requires org.apache.maven.resolver;
-    requires org.apache.maven.resolver.impl;
-    requires org.apache.maven.resolver.spi;
-    // requires maven.model.builder;
-    requires maven.core;
-    requires maven.model;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests {@link Log}.
+ */
+class LogTest {
+
+    @Test
+    void testNullOutput() {
+        Consumer<String> original = Log.output();
+        try {
+            Log.output(null);
+            Log.info("hello");
+        } catch (Throwable ex) {
+            fail(ex);
+        } finally {
+            Log.output(original);
+        }
+    }
 }

--- a/common/common/src/main/java/io/helidon/build/common/Unchecked.java
+++ b/common/common/src/main/java/io/helidon/build/common/Unchecked.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.helidon.build.cli.codegen;
+package io.helidon.build.common;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 /**
  * Utility to deal with checked exceptions in lambdas.
  */
-interface Unchecked {
+public interface Unchecked {
 
     /**
      * Checked consumer.

--- a/dev-loop/dev-loop/src/main/java/io/helidon/build/devloop/util/ConsumerPrintStream.java
+++ b/dev-loop/dev-loop/src/main/java/io/helidon/build/devloop/util/ConsumerPrintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
-
-import com.google.common.base.Charsets;
 
 /**
  * A {@code PrintStream} that writes lines to a {@code Consumer<String>}.
  */
 public class ConsumerPrintStream extends PrintStream {
-    private static final Charset ENCODING = Charsets.UTF_8;
+    private static final Charset ENCODING = StandardCharsets.UTF_8;
     private static final int LINE_FEED = 10;
     private static final int CARRIAGE_RETURN = 13;
     private static final int NONE = -1;


### PR DESCRIPTION
Make Plugins.PluginFailed a checked exception to force error handling
Wrap Plugins.PluginFailed with Metadata.UpdatedFailed as another checked exception to expose metadata update errors
Metadata.UpdateFailed is explicitly thrown by every public methods of Metadata that performs an update check
Promote io.helidon.build.cli.codegen.Unchecked to io.helidon.build.util.Unchecke

Fixed a bug in Plugin log when Plugin.execute is invoked with a null consumer for output.

Fixes #487
Fixes #507 (forward port of #506)