### PR TITLE
Archetype Maven plugin improvements

### DIFF
--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,13 +52,21 @@ public class BatchInputResolver extends InputResolver {
         if (result != null) {
             return result;
         }
+        Value defaultValue = defaultValue(input, context);
         if (input.isOptional()) {
-            Value defaultValue = defaultValue(input, context);
             if (defaultValue != null) {
                 context.push(input.name(), defaultValue, input.isGlobal());
                 if (input instanceof Input.Boolean && !defaultValue.asBoolean()) {
                     return VisitResult.SKIP_SUBTREE;
                 }
+                return VisitResult.CONTINUE;
+            }
+        } else if (input instanceof Input.Enum){
+            // skip prompting if there is only one option with a default value
+            Input.Enum enumInput = (Input.Enum) input;
+            int defaultIndex = enumInput.optionIndex(defaultValue.asString());
+            if (enumInput.options().size() == 1 && defaultIndex >= 0) {
+                context.push(input.name(), defaultValue, input.isGlobal());
                 return VisitResult.CONTINUE;
             }
         }

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/BatchInputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/BatchInputResolverTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.archetype.engine.v2;
+
+import io.helidon.build.archetype.engine.v2.ast.Block;
+import io.helidon.build.archetype.engine.v2.ast.Value;
+import io.helidon.build.archetype.engine.v2.ast.ValueTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.build.archetype.engine.v2.TestHelper.inputEnum;
+import static io.helidon.build.archetype.engine.v2.TestHelper.inputOption;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests {@link BatchInputResolver}.
+ */
+public class BatchInputResolverTest {
+
+    @Test
+    void testInputEnumWithSingleOptionAndDefault() {
+        Block block = inputEnum("enum-input1", "value1",
+                inputOption("option1", "value1")).build();
+
+        Context context = Context.create();
+        Controller.walk(new BatchInputResolver(), block, context);
+
+        Value value = context.lookup("enum-input1");
+
+        assertThat(value, is(notNullValue()));
+        assertThat(value.type(), is(ValueTypes.STRING));
+        assertThat(value.asString(), is("value1"));
+    }
+}

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeInvoker.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeInvoker.java
@@ -375,7 +375,6 @@ abstract class ArchetypeInvoker {
         private static final String GROUP_ID_PROPERTY = "groupId";
         private static final String ARTIFACT_ID_PROPERTY = "artifactId";
         private static final String PACKAGE_NAME_PROPERTY = "package";
-        private static final String HELIDON_VERSION_PROPERTY = "helidon-version";
         private static final String BUILD_SYSTEM_PROPERTY = "build-system";
         private static final String ARCHETYPE_BASE_PROPERTY = "base";
 
@@ -391,10 +390,6 @@ abstract class ArchetypeInvoker {
 
             // Initialize params with any properties passed on the command-line; options will take precedence
             Map<String, String> externalValues = new HashMap<>(initProperties());
-
-            // We've already got helidon version, don't prompt again. Note that this will not override
-            // any "helidon.version" command-line property as that is already set in InitOptions
-            externalValues.put(HELIDON_VERSION_PROPERTY, initOptions.helidonVersion());
 
             // Ensure that flavor is lower case if present.
             externalValues.computeIfPresent(FLAVOR_PROPERTY, (key, value) -> value.toLowerCase());
@@ -448,6 +443,7 @@ abstract class ArchetypeInvoker {
                 externalValues.put(PACKAGE_NAME_PROPERTY, initOptions.packageName());
             }
 
+            //noinspection ConstantConditions
             ArchetypeEngineV2 engine = new ArchetypeEngineV2(archetype());
             try {
                 return engine.generate(inputResolver, externalValues, externalDefaults, projectDirSupplier());
@@ -503,8 +499,6 @@ abstract class ArchetypeInvoker {
                     return "--flavor";
                 case BUILD_SYSTEM_PROPERTY:
                     return "--build";
-                case HELIDON_VERSION_PROPERTY:
-                    return "--version";
                 case ARCHETYPE_BASE_PROPERTY:
                     return "--archetype";
                 case GROUP_ID_PROPERTY:

--- a/maven-plugins/build-cache-maven-plugin/README.md
+++ b/maven-plugins/build-cache-maven-plugin/README.md
@@ -44,7 +44,7 @@ A given plugin executions should be excluded when:
 
 Plugin executions may require prior executions in the life-cycle, however the extension does not invalidate cached
  executions based on the life-cycle order. I.e. if an execution has differences and is planned for execution, all
- sub-sequent executions are still eligible for fast-forwarding.
+ subsequent executions are still eligible for fast-forwarding.
 
 The states of modules with inter-project dependencies rely on the dependency graph for indirect state invalidation.
  A module that requires another must declare a dependency, otherwise it will fast-forward even if the required module
@@ -60,18 +60,18 @@ This plugin does not provide any goal at the moment.
 
 ### Configuration
 
-| Property | Type | Default<br/>Value | Description |
-| --- | --- | --- | --- |
-| skip | Boolean | `false` | Disables build cache |
-| projectFilesExcludes | List | `[]` | Project files excludes patterns |
-| buildFilesExcludes | List | `[]` | Build files excludes patterns |
-| enableChecksums | Boolean | `false` | Enables combined checksums for the project files |
-| includeAllChecksums | Boolean | `false` | Enables individual checksums for all project files |
-| archiveFile | File | `null` | Path a `.tar` file |
-| loadArchive | Boolean | `false` | Loads the cache from the archive file |
-| saveArchive | Boolean | `false` | Saves the cache to the archive file |
-| executionsExcludes | List | `[]` | Execution exclude patterns |
-| executionsIncludes | List | `[*]` | Execution include patterns |
+| Property             | Type    | Default<br/>Value | Description                                        |
+|----------------------|---------|-------------------|----------------------------------------------------|
+| skip                 | Boolean | `false`           | Disables build cache                               |
+| projectFilesExcludes | List    | `[]`              | Project files excludes patterns                    |
+| buildFilesExcludes   | List    | `[]`              | Build files excludes patterns                      |
+| enableChecksums      | Boolean | `false`           | Enables combined checksums for the project files   |
+| includeAllChecksums  | Boolean | `false`           | Enables individual checksums for all project files |
+| archiveFile          | File    | `null`            | Path a `.tar` file                                 |
+| loadArchive          | Boolean | `false`           | Loads the cache from the archive file              |
+| saveArchive          | Boolean | `false`           | Saves the cache to the archive file                |
+| executionsExcludes   | List    | `[]`              | Execution exclude patterns                         |
+| executionsIncludes   | List    | `[*]`             | Execution include patterns                         |
 
 All parameters  are mapped to user properties of the form `cache.PROPERTY`. List parameters are passed as comma
  separated values.

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test1/src/test/resources/projects/it1/archetype.properties
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test1/src/test/resources/projects/it1/archetype.properties
@@ -15,6 +15,6 @@
 #
 package=io.helidon.build.maven.archetype.tests
 groupId=io.helidon.build.maven.archetype.tests
-artifactId=project
+artifactId=${shape}-project
 version=0.1-SNAPSHOT
 shape=circle

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test2/src/test/resources/projects/it1/archetype.properties
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test2/src/test/resources/projects/it1/archetype.properties
@@ -15,6 +15,6 @@
 #
 package=io.helidon.build.maven.archetype.tests
 groupId=io.helidon.build.maven.archetype.tests
-artifactId=project
+artifactId=${shape}-project
 version=0.1-SNAPSHOT
 shape=triangle

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test3/src/test/resources/projects/it1/archetype.properties
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test3/src/test/resources/projects/it1/archetype.properties
@@ -15,6 +15,6 @@
 #
 package=io.helidon.build.maven.archetype.tests
 groupId=io.helidon.build.maven.archetype.tests
-artifactId=project
+artifactId=${shape}-project
 version=0.1-SNAPSHOT
 shape=square

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module1/src/test/resources/projects/it1/archetype.properties
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module1/src/test/resources/projects/it1/archetype.properties
@@ -15,6 +15,6 @@
 #
 package=io.helidon.build.maven.archetype.tests
 groupId=io.helidon.build.maven.archetype.tests
-artifactId=project
+artifactId=${shape}-project
 version=0.1-SNAPSHOT
 shape=square

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module2/src/test/resources/projects/it1/archetype.properties
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module2/src/test/resources/projects/it1/archetype.properties
@@ -15,6 +15,6 @@
 #
 package=io.helidon.build.maven.archetype.tests
 groupId=io.helidon.build.maven.archetype.tests
-artifactId=project
+artifactId=${shape}-project
 version=0.1-SNAPSHOT
 shape=rectangle

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module3/src/test/resources/projects/it1/archetype.properties
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module3/src/test/resources/projects/it1/archetype.properties
@@ -15,6 +15,6 @@
 #
 package=io.helidon.build.maven.archetype.tests
 groupId=io.helidon.build.maven.archetype.tests
-artifactId=project
+artifactId=${shape}-project
 version=0.1-SNAPSHOT
 shape=triangle

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -37,6 +38,7 @@ import io.helidon.build.archetype.engine.v2.ArchetypeEngineV2;
 import io.helidon.build.archetype.engine.v2.BatchInputResolver;
 import io.helidon.build.common.FileUtils;
 import io.helidon.build.common.Maps;
+import io.helidon.build.common.SubstitutionVariables;
 
 import org.apache.maven.archetype.ArchetypeGenerationRequest;
 import org.apache.maven.archetype.ArchetypeGenerationResult;
@@ -202,6 +204,13 @@ public class IntegrationTestMojo extends AbstractMojo {
         }
         props.put("name", "test project");
 
+        // substitute all variable references
+        Map<String, String> propsMap = Maps.fromProperties(props);
+        SubstitutionVariables propsVariables = SubstitutionVariables.of(propsMap);
+        for (Entry<String, String> entry : propsMap.entrySet()) {
+            props.setProperty(entry.getKey(), propsVariables.resolve(entry.getValue()));
+        }
+
         Path outputDir = projectGoal.getParent().resolve(props.getProperty("artifactId"));
         FileUtils.deleteDirectory(outputDir);
 
@@ -298,7 +307,7 @@ public class IntegrationTestMojo extends AbstractMojo {
 
             if (!properties.isEmpty()) {
                 Properties props = new Properties();
-                for (Map.Entry<String, String> entry : properties.entrySet()) {
+                for (Entry<String, String> entry : properties.entrySet()) {
                     if (entry.getValue() != null) {
                         props.setProperty(entry.getKey(), entry.getValue());
                     }

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/resources/archetype-metadata.xml.mustache
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/resources/archetype-metadata.xml.mustache
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor name="{{name}}">
-    <requiredProperties/>
-</archetype-descriptor>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/MustacheHelperTest.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/MustacheHelperTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.archetype;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.helidon.build.common.FileUtils.unique;
+import static io.helidon.build.common.test.utils.TestFiles.targetDir;
+import static io.helidon.build.maven.archetype.MustacheHelper.renderMustacheTemplate;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests {@link MustacheHelper}.
+ */
+public class MustacheHelperTest {
+
+    private static final Path OUTPUT_DIR = targetDir(MustacheHelperTest.class).resolve("mustache-helper-ut");
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        Files.createDirectories(OUTPUT_DIR);
+    }
+
+    @Test
+    void testRender() throws IOException {
+        Path target = unique(OUTPUT_DIR, "test", ".txt");
+        InputStream tpl = new ByteArrayInputStream((""
+                + "{{#set}}color:{{.}},{{/set}}"
+                + "{{#map}}{{key}}:{{value}}{{/map}},"
+                + "{{#list}}color:{{.}},{{/list}}").getBytes(UTF_8));
+        Map<String, Object> scope = new HashMap<>();
+        Set<String> set1 = Set.of("blue", "red");
+        scope.put("set", Set.of("blue", "red"));
+        scope.put("map", Map.of("color", "green"));
+        scope.put("list", List.of("yellow", "orange"));
+        renderMustacheTemplate(tpl, "testRender", target, scope);
+        String setStr = set1.stream().map(s -> "color:" + s).collect(joining(","));
+        assertThat(Files.readString(target), is(setStr + ",color:green,color:yellow,color:orange,"));
+    }
+}

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/ProjectsTestIT.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/ProjectsTestIT.java
@@ -63,19 +63,19 @@ final class ProjectsTestIT {
         runTest(basedir, null, expected);
     }
 
-    private static void runTest(String basedir, String prefix, String expected) throws IOException {
+    private static void runTest(String basedir, String prefix, String shape) throws IOException {
         Path outputDir = Path.of(basedir);
         if (prefix != null) {
             outputDir = outputDir.resolve(prefix);
         }
-        outputDir = outputDir.resolve("target/test-classes/projects/it1/project");
+        outputDir = outputDir.resolve("target/test-classes/projects/it1/" + shape + "-project");
         assertThat(Files.exists(outputDir), is(true));
-        Path shape = outputDir.resolve("src/main/java")
+        Path shapeClass = outputDir.resolve("src/main/java")
                               .resolve(TEST_PKG_DIR)
                               .resolve("Shape.java");
-        assertThat(Files.exists(shape), is(true));
-        assertThat(Files.lines(shape)
-                        .filter(line -> line.contains("System.out.println(\"" + expected + "\");"))
+        assertThat(Files.exists(shapeClass), is(true));
+        assertThat(Files.lines(shapeClass)
+                        .filter(line -> line.contains("System.out.println(\"" + shape + "\");"))
                         .count(), is(1L));
     }
 }

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/SchemaTest.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/SchemaTest.java
@@ -40,7 +40,7 @@ class SchemaTest {
 
     @Test
     void testValidateNegative() {
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        RuntimeException ex = assertThrows(Schema.ValidationException.class,
                 () -> VALIDATOR.validate(() -> resource("shapes.xml")));
         assertThat(ex.getCause(), is(instanceOf(SAXParseException.class)));
     }


### PR DESCRIPTION
- Use a custom Mustache object handler to avoid reflection issues with built-in handler when using Java 17.
- Improve schema validation error handling
- Remove unused archetype-metadata.xml.mustache
- Improve integration test error handling
- Support enum with a single option in the batch input resolver.
- Add support for variables in archetype.properties in the integration-test mojo
- Remove `helidon-version` handling in the archetype-invoker.

Also  Reformat build-cache-maven-plugin/README.md