### PR TITLE
Remove --archetype cli option

### DIFF
--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/MergedModel.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/MergedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public final class MergedModel {
          * Sort the nested values.
          */
         protected void sort() {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("model node does not support 'sort'");
         }
 
         /**
@@ -124,7 +124,7 @@ public final class MergedModel {
          * @return the merged node
          */
         protected Node add(Node node) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("model node does not support 'add'");
         }
     }
 

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeBrowser.java
@@ -82,7 +82,7 @@ class ArchetypeBrowser {
      */
     Path archetypeJar(ArchetypeCatalog.ArchetypeEntry archetype) {
         try {
-            return metadata.archetypeOf(archetype);
+            return metadata.archetypeV1Of(archetype);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/InitOptions.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/InitOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ public final class InitOptions {
     private final BuildSystem buildOption;
     private String archetypeName;
     private final String archetypeNameOption;
-    private final String archetypePath;
     private final EngineVersion engineVersion;
     private final Flavor flavorOption;
     private final String projectNameOption;
@@ -105,7 +104,6 @@ public final class InitOptions {
             @KeyValue(name = "artifactid", description = "Project's artifact ID") String artifactId,
             @KeyValue(name = "package", description = "Project's package name") String packageName,
             @KeyValue(name = "name", description = "Project's name") String projectName,
-            @KeyValue(name = "archetype-path", description = "Archetype path", visible = false) String archetypePath,
             @KeyValue(name = "engine-version", description = "Archetype engine version", visible = false) String engineVersion) {
 
         this.buildOption = build;
@@ -113,7 +111,6 @@ public final class InitOptions {
         this.helidonVersion = version;
         this.archetypeNameOption = archetypeName;
         this.archetypeName = archetypeName == null ? DEFAULT_ARCHETYPE_NAME : archetypeName;
-        this.archetypePath = archetypePath;
         this.engineVersion = getEngineVersion(engineVersion);
         this.flavorOption = flavor;
         this.flavor = flavor == null ? Flavor.valueOf(DEFAULT_FLAVOR) : flavor;
@@ -299,15 +296,6 @@ public final class InitOptions {
      */
     String packageNameOption() {
         return packageNameOption;
-    }
-
-    /**
-     * Get the archetype path.
-     *
-     * @return archetype path
-     */
-    String archetypePath() {
-        return archetypePath;
     }
 
     /**

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/Metadata.java
@@ -348,29 +348,28 @@ public class Metadata {
     }
 
     /**
-     * Get the cache directory for the given helidon version.
-     *
-     * @param helidonVersion The version.
-     * @return The directory.
-     * @throws UpdateFailed if the metadata update failed
-     */
-    public Path directoryOf(MavenVersion helidonVersion) throws UpdateFailed {
-        final Path versionDir = rootDir.resolve(requireNonNull(helidonVersion).toString());
-        final Path checkFile = versionDir.resolve(LAST_UPDATE_FILE_NAME);
-        checkForUpdates(helidonVersion, checkFile, false);
-        return requireHelidonVersionDir(versionDir);
-    }
-
-    /**
-     * Returns the path to the archetype jar for the given catalog entry.
+     * Returns the path to the archetype V1 jar for the given catalog entry.
      *
      * @param catalogEntry The catalog entry.
      * @return The path to the archetype jar.
      * @throws UpdateFailed if the metadata update failed
      */
-    public Path archetypeOf(ArchetypeCatalog.ArchetypeEntry catalogEntry) throws UpdateFailed {
+    public Path archetypeV1Of(ArchetypeCatalog.ArchetypeEntry catalogEntry) throws UpdateFailed {
         final MavenVersion helidonVersion = toMavenVersion(catalogEntry.version());
         final String fileName = catalogEntry.artifactId() + "-" + helidonVersion + JAR_SUFFIX;
+        return versionedFile(helidonVersion, fileName, false);
+    }
+
+    /**
+     * Returns the path to the archetype V2 jar for the given version.
+     *
+     * @param version The version.
+     * @return The path to the archetype jar.
+     * @throws UpdateFailed if the metadata update failed
+     */
+    public Path archetypeV2Of(String version) throws UpdateFailed {
+        final MavenVersion helidonVersion = toMavenVersion(version);
+        final String fileName = "helidon-" + helidonVersion + JAR_SUFFIX;
         return versionedFile(helidonVersion, fileName, false);
     }
 

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
@@ -120,7 +120,7 @@ public class MetadataTest extends MetadataTestBase {
         // Check archetype. Should not perform update.
 
         logged.clear();
-        Path archetypeJar = meta.archetypeOf(entriesById.get("helidon-bare-se"));
+        Path archetypeJar = meta.archetypeV1Of(entriesById.get("helidon-bare-se"));
         assertThat(archetypeJar, is(not(nullValue())));
         assertThat(Files.exists(archetypeJar), is(true));
         assertThat(archetypeJar.getFileName().toString(), is("helidon-bare-se-2.0.0-RC1.jar"));

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTestIT.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTestIT.java
@@ -105,7 +105,7 @@ public class MetadataTestIT extends MetadataTestBase {
         // Check archetype. Should not perform update.
 
         logged.clear();
-        Path archetypeJar = meta.archetypeOf(entriesById.get("helidon-bare-se"));
+        Path archetypeJar = meta.archetypeV1Of(entriesById.get("helidon-bare-se"));
         assertThat(archetypeJar, is(not(nullValue())));
         assertThat(Files.exists(archetypeJar), is(true));
         assertThat(archetypeJar.getFileName().toString(), is("helidon-bare-se-2.0.0-RC2.jar"));

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
@@ -157,6 +157,12 @@ public class IntegrationTestMojo extends AbstractMojo {
             return;
         }
 
+        // support -DskipTests
+        String skipTests = session.getUserProperties().getProperty("skipTests");
+        if (skipTests != null && !"false".equalsIgnoreCase(skipTests)) {
+            return;
+        }
+
         if (!testProjectsDirectory.exists()) {
             getLog().warn("No Archetype IT projects: root 'projects' directory not found.");
             return;


### PR DESCRIPTION
Update ArchetypeInvoker so that V2 uses cli-data (now both V1 and V2 are aligned on this)
Add support for -DskipTests in the integration-test mojo of the helidon-archetype-maven-plugin