### PR TITLE
Fix Maven archetype compatibility layer in interactive mode.

### DIFF
--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/TerminalInputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/TerminalInputResolver.java
@@ -41,7 +41,14 @@ public class TerminalInputResolver extends InputResolver {
     private String lastLabel;
 
     /**
-     * Create a new prompter.
+     * Create an interactive input resolver.
+     */
+    public TerminalInputResolver() {
+        this.in = System.in;
+    }
+
+    /**
+     * Create a new interactive input resolver.
      *
      * @param in input stream to use for reading user input
      */

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/spi/TemplateSupportProvider.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/spi/TemplateSupportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public interface TemplateSupportProvider {
          * Template support providers cache.
          */
         static final Map<String, TemplateSupportProvider> PROVIDERS =
-                ServiceLoader.load(TemplateSupportProvider.class)
+                ServiceLoader.load(TemplateSupportProvider.class, TemplateSupportProvider.class.getClassLoader())
                              .stream()
                              .map(ServiceLoader.Provider::get)
                              .collect(toUnmodifiableMap(TemplateSupportProvider::name, Function.identity()));

--- a/common/common/src/main/java/io/helidon/build/common/RichTextProvider.java
+++ b/common/common/src/main/java/io/helidon/build/common/RichTextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,6 @@ public interface RichTextProvider {
 
             @Override
             public RichText reset() {
-                sb.delete(0, sb.length());
                 return this;
             }
         }

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/postgenerate/EngineFacade.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/postgenerate/EngineFacade.java
@@ -124,6 +124,8 @@ public final class EngineFacade {
         Properties archetypeProps = request.getProperties();
         Map<String, String> props = new HashMap<>();
         archetypeProps.stringPropertyNames().forEach(k -> props.put(k, archetypeProps.getProperty(k)));
+        Properties userProps = request.getProjectBuildingRequest().getUserProperties();
+        userProps.stringPropertyNames().forEach(k -> props.putIfAbsent(k, userProps.getProperty(k)));
 
         // resolve the archetype JAR from the local repository
         File archetypeFile = aether.resolveArtifact(request.getArchetypeGroupId(), request.getArchetypeArtifactId(),
@@ -133,7 +135,8 @@ public final class EngineFacade {
             FileSystem fileSystem = FileSystems.newFileSystem(archetypeFile.toPath(), EngineFacade.class.getClassLoader());
             Path projectDir = Paths.get(request.getOutputDirectory()).resolve(request.getArtifactId());
             Files.delete(projectDir.resolve("pom.xml"));
-            new ReflectedEngine(ecl, fileSystem).generate(request.isInteractiveMode(), props, emptyMap(), n -> projectDir);
+            boolean interactiveMode = !"false".equals(System.getProperty("interactiveMode"));
+            new ReflectedEngine(ecl, fileSystem).generate(interactiveMode, props, emptyMap(), n -> projectDir);
         } catch (IOException ioe) {
             throw new IllegalStateException(ioe);
         }


### PR DESCRIPTION
- ArchetypeGenerationRequest.isInteractiveMode is always false, using system property as a workaround
- Use request.getProjectBuildingRequest().getUserProperties() on top of request.getProperties to get all external values supplied from the command line
- Add a no-args constructor to TerminalInputResolver so that ReflectedEngine can instanciate it
- Lookup template provider using the class-loader of the provider class itself (instead of the tccl)
- Fix the default RichText.reset() implementation, it needs to be a no-op instead of deleting the content (with ansi disabled some text was not printed out)