### PR TITLE
Release updates

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to the Helidon CLI will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changes
+
+- Validate Helidon version input. [628](https://github.com/oracle/helidon-build-tools/pull/628)
+- Handle `latest` file with multiple lines [633](https://github.com/oracle/helidon-build-tools/pull/633)
+
+### Fixes
+
+- Fix prompter when default answer is null [630](https://github.com/oracle/helidon-build-tools/pull/630)
+
 ## [3.0.0-M2]
 
 ### Notable New Features
@@ -162,13 +173,14 @@ This release of helidon-build-tools does not contain changes related to the Heli
 
 Initial release of the Helidon CLI.
 
-[3.0.0-M2]: https://github.com/oracle/helidon-build-tools/tree/3.0.0-M2/cli
-[2.3.0]: https://github.com/oracle/helidon-build-tools/compare/2.2.3...2.3.0
-[2.2.3]:    https://github.com/oracle/helidon-build-tools/compare/2.2.2...2.2.3
-[2.2.2]:    https://github.com/oracle/helidon-build-tools/compare/2.2.0...2.2.2
-[2.2.0]:    https://github.com/oracle/helidon-build-tools/compare/2.1.3...2.2.0
-[2.1.3]:    https://github.com/oracle/helidon-build-tools/compare/2.1.2...2.1.3
-[2.1.2]:    https://github.com/oracle/helidon-build-tools/compare/2.1.1...2.1.2
-[2.1.0]:    https://github.com/oracle/helidon-build-tools/compare/2.0.2...2.1.0
-[2.0.2]:    https://github.com/oracle/helidon-build-tools/compare/2.0.1...2.0.2
-[2.0.0]:    https://github.com/oracle/helidon-build-tools/tree/2.0.0/helidon-cli
+[unreleased]: https://github.com/oracle/helidon-build-tools/compare/3.0.0-M2...master
+[3.0.0-M2]:   https://github.com/oracle/helidon-build-tools/tree/3.0.0-M2/cli
+[2.3.0]:      https://github.com/oracle/helidon-build-tools/compare/2.2.3...2.3.0
+[2.2.3]:      https://github.com/oracle/helidon-build-tools/compare/2.2.2...2.2.3
+[2.2.2]:      https://github.com/oracle/helidon-build-tools/compare/2.2.0...2.2.2
+[2.2.0]:      https://github.com/oracle/helidon-build-tools/compare/2.1.3...2.2.0
+[2.1.3]:      https://github.com/oracle/helidon-build-tools/compare/2.1.2...2.1.3
+[2.1.2]:      https://github.com/oracle/helidon-build-tools/compare/2.1.1...2.1.2
+[2.1.0]:      https://github.com/oracle/helidon-build-tools/compare/2.0.2...2.1.0
+[2.0.2]:      https://github.com/oracle/helidon-build-tools/compare/2.0.1...2.0.2
+[2.0.0]:      https://github.com/oracle/helidon-build-tools/tree/2.0.0/helidon-cli

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -145,7 +145,8 @@ update_version(){
         -DgenerateBackupPoms="false" \
         -DnewVersion="${FULL_VERSION}" \
         -Dproperty="helidon.version" \
-        -DprocessFromLocalAggregationRoot="false"
+        -DprocessFromLocalAggregationRoot="false" \
+        -DupdateMatchingVersions="false"
 
     local osgi_mvn_v
     osgi_mvn_v="$(osgi_mvn_version "${MVN_VERSION}")"


### PR DESCRIPTION
 - update release.sh to use updateMatchingVersions=false with the versions plugin to avoid updating versions under ide-support.
 - prepare changelog for the upcoming release