### PR TITLE
Fix LineReader.drain

### DIFF
--- a/utils/src/main/java/io/helidon/build/util/LineReader.java
+++ b/utils/src/main/java/io/helidon/build/util/LineReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ class LineReader {
     void drain() {
         try {
             try {
-                if (reader.ready()) {
+                while (reader.ready()) {
                     readLines(false);
                     if (!remaining.isEmpty()) {
                         String line = remaining;


### PR DESCRIPTION
Use a loop to fully drain the buffered reader in LineReader.drain()