### PR TITLE
Archetype updates

### DIFF
--- a/archetype/engine-v1/src/main/java/io/helidon/build/archetype/engine/v1/ArchetypeEngine.java
+++ b/archetype/engine-v1/src/main/java/io/helidon/build/archetype/engine/v1/ArchetypeEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@ package io.helidon.build.archetype.engine.v1;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -214,7 +215,7 @@ public final class ArchetypeEngine implements Closeable {
      *
      * @param outputDirectory output directory
      */
-    public void generate(File outputDirectory) {
+    public void generate(Path outputDirectory) {
         try {
             for (Entry<String, List<Transformation>> entry : templates.entrySet()) {
                 String resourcePath = entry.getKey().substring(1);
@@ -223,9 +224,9 @@ public final class ArchetypeEngine implements Closeable {
                         throw new IllegalStateException(resourcePath + " not found");
                     }
                     Mustache m = mf.compile(new InputStreamReader(is), resourcePath);
-                    File outputFile = new File(outputDirectory, transform(resourcePath, entry.getValue(), properties));
-                    outputFile.getParentFile().mkdirs();
-                    try (FileWriter writer = new FileWriter(outputFile)) {
+                    Path outputFile = outputDirectory.resolve(transform(resourcePath, entry.getValue(), properties));
+                    Files.createDirectories(outputFile.getParent());
+                    try (Writer writer = Files.newBufferedWriter(outputFile)) {
                         m.execute(writer, properties).flush();
                     }
                 }
@@ -236,9 +237,9 @@ public final class ArchetypeEngine implements Closeable {
                     if (is == null) {
                         throw new IllegalStateException(resourcePath + " not found");
                     }
-                    File outputFile = new File(outputDirectory, transform(resourcePath, entry.getValue(), properties));
-                    outputFile.getParentFile().mkdirs();
-                    Files.copy(is, outputFile.toPath());
+                    Path outputFile = outputDirectory.resolve(transform(resourcePath, entry.getValue(), properties));
+                    Files.createDirectories(outputFile.getParent());
+                    Files.copy(is, outputFile);
                 }
             }
         } catch (IOException e) {

--- a/archetype/engine-v1/src/main/java/io/helidon/build/archetype/engine/v1/Main.java
+++ b/archetype/engine-v1/src/main/java/io/helidon/build/archetype/engine/v1/Main.java
@@ -55,6 +55,6 @@ public final class Main {
             System.err.println(outputDir + " exists");
             System.exit(1);
         }
-        new ArchetypeEngine(loader, Maps.fromProperties(System.getProperties())).generate(outputDir);
+        new ArchetypeEngine(loader, Maps.fromProperties(System.getProperties())).generate(outputDir.toPath());
     }
 }

--- a/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeEngineTest.java
+++ b/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import io.helidon.build.common.Strings;
 import io.helidon.build.common.test.utils.TestFiles;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.build.common.Unchecked.unchecked;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -121,16 +122,14 @@ public class ArchetypeEngineTest extends ArchetypeBaseTest {
         properties.put("package", "com.example.myproject");
         properties.put("maven", "true");
         File targetDir = new File(new File("").getAbsolutePath(), "target");
-        File outputDir = new File(targetDir, "test-project");
-        Path outputDirPath = outputDir.toPath();
+        Path outputDirPath = targetDir.toPath().resolve("test-project");
         if (Files.exists(outputDirPath)) {
             Files.walk(outputDirPath)
                     .sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
+                    .forEach(unchecked(Files::delete));
         }
         assertThat(Files.exists(outputDirPath), is(false));
-        new ArchetypeEngine(targetDir(), properties).generate(outputDir);
+        new ArchetypeEngine(targetDir(), properties).generate(outputDirPath);
         assertThat(Files.exists(outputDirPath), is(true));
         assertThat(Files.walk(outputDirPath)
                 .filter(p -> !Files.isDirectory(p))

--- a/archetype/engine-v2-json/src/main/java/io/helidon/build/archetype/v2/json/ScriptSerializer.java
+++ b/archetype/engine-v2-json/src/main/java/io/helidon/build/archetype/v2/json/ScriptSerializer.java
@@ -47,7 +47,13 @@ import io.helidon.build.archetype.engine.v2.ast.Preset;
 import io.helidon.build.archetype.engine.v2.ast.Script;
 import io.helidon.build.archetype.engine.v2.ast.Step;
 import io.helidon.build.archetype.engine.v2.ast.Value;
+import io.helidon.build.archetype.engine.v2.ast.Variable;
 import io.helidon.build.archetype.engine.v2.util.ClientCompiler;
+
+// TODO don't include default attributes (global=false, optional=false etc)
+// TODO don't include input prompt (for cli only)
+// TODO bug with conditional preset
+// TODO bug with variable/preset null value
 
 /**
  * Script serializer.
@@ -264,10 +270,17 @@ public final class ScriptSerializer implements Node.Visitor<Script>,
     }
 
     private VisitResult visitNamed(Input.NamedInput input, JsonObjectBuilder builder) {
-        builder.add("name", input.name())
-               .add("global", input.isGlobal())
-               .add("optional", input.isOptional())
-               .add("default", JsonFactory.createValue(input.defaultValue()));
+        builder.add("name", input.name());
+        if (input.isGlobal()) {
+            builder.add("global", true);
+        }
+        if (input.isOptional()) {
+            builder.add("optional", true);
+        }
+        Value defaultValue = input.defaultValue();
+        if (defaultValue != null && defaultValue != Value.NULL) {
+            builder.add("default", JsonFactory.createValue(defaultValue));
+        }
         return VisitResult.CONTINUE;
     }
 
@@ -291,6 +304,13 @@ public final class ScriptSerializer implements Node.Visitor<Script>,
     public VisitResult visitPreset(Preset preset, JsonObjectBuilder builder) {
         builder.add("path", preset.path())
                .add("value", JsonFactory.createValue(preset.value()));
+        return VisitResult.SKIP_SUBTREE;
+    }
+
+    @Override
+    public VisitResult visitVariable(Variable variable, JsonObjectBuilder builder) {
+        builder.add("path", variable.path())
+               .add("value", JsonFactory.createValue(variable.value()));
         return VisitResult.SKIP_SUBTREE;
     }
 

--- a/archetype/engine-v2-json/src/test/java/io/helidon/build/archetype/v2/json/ScriptDeserializerTest.java
+++ b/archetype/engine-v2-json/src/test/java/io/helidon/build/archetype/v2/json/ScriptDeserializerTest.java
@@ -46,6 +46,7 @@ class ScriptDeserializerTest {
         Script script = ScriptDeserializer.deserialize(Files.newInputStream(jsonFile));
 
         JsonObject archetypeJson = ScriptSerializer.serialize(script);
+        System.out.println(JsonFactory.toPrettyString(archetypeJson));
         assertThat(jsonDiff(archetypeJson, readJson(expected)), is(EMPTY_JSON_ARRAY));
     }
 }

--- a/archetype/engine-v2-json/src/test/java/io/helidon/build/archetype/v2/json/ScriptSerializerTest.java
+++ b/archetype/engine-v2-json/src/test/java/io/helidon/build/archetype/v2/json/ScriptSerializerTest.java
@@ -104,7 +104,6 @@ class ScriptSerializerTest {
         FileSystem fs = VirtualFileSystem.create(sourceDir);
 
         JsonObject archetypeJson = ScriptSerializer.serialize(fs);
-        System.out.println(JsonFactory.toPrettyString(archetypeJson));
         assertThat(jsonDiff(archetypeJson, readJson(expected)), is(EMPTY_JSON_ARRAY));
     }
 

--- a/archetype/engine-v2-json/src/test/resources/deserializer/script.json
+++ b/archetype/engine-v2-json/src/test/resources/deserializer/script.json
@@ -3,7 +3,7 @@
   "methods": {
     "main": [
       {
-        "label": "Cake",
+        "name": "Cake",
         "id": "3",
         "kind": "step",
         "children": [
@@ -27,15 +27,15 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Fruit",
-            "name": "fruit",
+            "name": "Fruit",
+            "id": "fruit",
             "global": false,
             "optional": false,
             "default": "berries",
             "kind": "enum",
             "children": [
               {
-                "label": "Berries",
+                "name": "Berries",
                 "value": "berries",
                 "kind": "option",
                 "children": [
@@ -46,7 +46,7 @@
                 ]
               },
               {
-                "label": "Tropical",
+                "name": "Tropical",
                 "value": "tropical",
                 "kind": "option",
                 "children": [
@@ -66,15 +66,15 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Berry type",
-            "name": "berry-type",
+            "name": "Berry type",
+            "id": "berry-type",
             "global": false,
             "optional": false,
             "default": "raspberry",
             "kind": "enum",
             "children": [
               {
-                "label": "Raspberry",
+                "name": "Raspberry",
                 "value": "raspberry",
                 "kind": "option",
                 "children": [
@@ -85,7 +85,7 @@
                 ]
               },
               {
-                "label": "Strawberry",
+                "name": "Strawberry",
                 "value": "strawberry",
                 "kind": "option",
                 "children": [
@@ -105,15 +105,15 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Tropical type",
-            "name": "tropical-type",
+            "name": "Tropical type",
+            "id": "tropical-type",
             "global": false,
             "optional": false,
             "default": "mango",
             "kind": "enum",
             "children": [
               {
-                "label": "Mango",
+                "name": "Mango",
                 "value": "mango",
                 "kind": "option",
                 "children": [
@@ -124,7 +124,7 @@
                 ]
               },
               {
-                "label": "Banana",
+                "name": "Banana",
                 "value": "banana",
                 "kind": "option",
                 "children": [
@@ -144,8 +144,8 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Organic",
-            "name": "organic",
+            "name": "Organic",
+            "id": "organic",
             "global": false,
             "optional": false,
             "default": true,
@@ -159,8 +159,8 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Frozen",
-            "name": "frozen",
+            "name": "Frozen",
+            "id": "frozen",
             "global": false,
             "optional": false,
             "default": true,
@@ -174,8 +174,8 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Fare trade",
-            "name": "fare-trade",
+            "name": "Fare trade",
+            "id": "fare-trade",
             "global": false,
             "optional": false,
             "default": true,
@@ -195,8 +195,8 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Plantain",
-            "name": "plantain",
+            "name": "Plantain",
+            "id": "plantain",
             "global": false,
             "optional": false,
             "default": true,
@@ -210,8 +210,8 @@
         "kind": "inputs",
         "children": [
           {
-            "label": "Comment",
-            "name": "comment",
+            "name": "Comment",
+            "id": "comment",
             "global": false,
             "optional": true,
             "default": null,
@@ -222,7 +222,7 @@
     ],
     "customize": [
       {
-        "label": "Customize cake",
+        "name": "Customize cake",
         "id": "4",
         "kind": "step",
         "children": [
@@ -230,8 +230,8 @@
             "kind": "inputs",
             "children": [
               {
-                "label": "Frosting",
-                "name": "frosting",
+                "name": "Frosting",
+                "id": "frosting",
                 "global": false,
                 "optional": false,
                 "default": true,

--- a/archetype/engine-v2-json/src/test/resources/empty-script/main.xml
+++ b/archetype/engine-v2-json/src/test/resources/empty-script/main.xml
@@ -20,13 +20,13 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <enum name="enum1" label="Enum1">
-                <option value="enum1-value1" label="Enum1Value1">
+            <enum id="enum1" name="Enum1">
+                <option value="enum1-value1" name="Enum1Value1">
                     <exec src="script1.xml"/>
                 </option>
-                <option value="enum1-value2" label="Enum1Value2"/>
+                <option value="enum1-value2" name="Enum1Value2"/>
             </enum>
         </inputs>
     </step>

--- a/archetype/engine-v2-json/src/test/resources/expected/deserializer.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/deserializer.json
@@ -10,9 +10,7 @@
             "kind": "text",
             "label": "Comment",
             "name": "comment",
-            "global": false,
-            "optional": true,
-            "default": null
+            "optional": true
           }
         ]
       }
@@ -31,8 +29,6 @@
               "kind": "enum",
               "label": "Fruit",
               "name": "fruit",
-              "global": false,
-              "optional": false,
               "default": "berries",
               "children": [
                 {
@@ -47,8 +43,6 @@
                           "kind": "enum",
                           "label": "Berry type",
                           "name": "berry-type",
-                          "global": false,
-                          "optional": false,
                           "default": "raspberry",
                           "children": [
                             {
@@ -63,8 +57,6 @@
                                       "kind": "boolean",
                                       "label": "Organic",
                                       "name": "organic",
-                                      "global": false,
-                                      "optional": false,
                                       "default": true
                                     }
                                   ]
@@ -83,8 +75,6 @@
                                       "kind": "boolean",
                                       "label": "Frozen",
                                       "name": "frozen",
-                                      "global": false,
-                                      "optional": false,
                                       "default": true
                                     }
                                   ]
@@ -109,8 +99,6 @@
                           "kind": "enum",
                           "label": "Tropical type",
                           "name": "tropical-type",
-                          "global": false,
-                          "optional": false,
                           "default": "mango",
                           "children": [
                             {
@@ -125,8 +113,6 @@
                                       "kind": "boolean",
                                       "label": "Fare trade",
                                       "name": "fare-trade",
-                                      "global": false,
-                                      "optional": false,
                                       "default": true,
                                       "children": [
                                         {
@@ -151,8 +137,6 @@
                                       "kind": "boolean",
                                       "label": "Plantain",
                                       "name": "plantain",
-                                      "global": false,
-                                      "optional": false,
                                       "default": true
                                     }
                                   ]
@@ -185,8 +169,6 @@
                   "kind": "boolean",
                   "label": "Frosting",
                   "name": "frosting",
-                  "global": false,
-                  "optional": false,
                   "default": true
                 }
               ]

--- a/archetype/engine-v2-json/src/test/resources/expected/deserializer.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/deserializer.json
@@ -8,8 +8,8 @@
         "children": [
           {
             "kind": "text",
-            "label": "Comment",
-            "name": "comment",
+            "name": "Comment",
+            "id": "comment",
             "optional": true
           }
         ]
@@ -19,7 +19,7 @@
   "children": [
     {
       "kind": "step",
-      "label": "Cake",
+      "name": "Cake",
       "id": "1",
       "children": [
         {
@@ -27,13 +27,13 @@
           "children": [
             {
               "kind": "enum",
-              "label": "Fruit",
-              "name": "fruit",
+              "name": "Fruit",
+              "id": "fruit",
               "default": "berries",
               "children": [
                 {
                   "kind": "option",
-                  "label": "Berries",
+                  "name": "Berries",
                   "value": "berries",
                   "children": [
                     {
@@ -41,13 +41,13 @@
                       "children": [
                         {
                           "kind": "enum",
-                          "label": "Berry type",
-                          "name": "berry-type",
+                          "name": "Berry type",
+                          "id": "berry-type",
                           "default": "raspberry",
                           "children": [
                             {
                               "kind": "option",
-                              "label": "Raspberry",
+                              "name": "Raspberry",
                               "value": "raspberry",
                               "children": [
                                 {
@@ -55,8 +55,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Organic",
-                                      "name": "organic",
+                                      "name": "Organic",
+                                      "id": "organic",
                                       "default": true
                                     }
                                   ]
@@ -65,7 +65,7 @@
                             },
                             {
                               "kind": "option",
-                              "label": "Strawberry",
+                              "name": "Strawberry",
                               "value": "strawberry",
                               "children": [
                                 {
@@ -73,8 +73,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Frozen",
-                                      "name": "frozen",
+                                      "name": "Frozen",
+                                      "id": "frozen",
                                       "default": true
                                     }
                                   ]
@@ -89,7 +89,7 @@
                 },
                 {
                   "kind": "option",
-                  "label": "Tropical",
+                  "name": "Tropical",
                   "value": "tropical",
                   "children": [
                     {
@@ -97,13 +97,13 @@
                       "children": [
                         {
                           "kind": "enum",
-                          "label": "Tropical type",
-                          "name": "tropical-type",
+                          "name": "Tropical type",
+                          "id": "tropical-type",
                           "default": "mango",
                           "children": [
                             {
                               "kind": "option",
-                              "label": "Mango",
+                              "name": "Mango",
                               "value": "mango",
                               "children": [
                                 {
@@ -111,8 +111,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Fare trade",
-                                      "name": "fare-trade",
+                                      "name": "Fare trade",
+                                      "id": "fare-trade",
                                       "default": true,
                                       "children": [
                                         {
@@ -127,7 +127,7 @@
                             },
                             {
                               "kind": "option",
-                              "label": "Banana",
+                              "name": "Banana",
                               "value": "banana",
                               "children": [
                                 {
@@ -135,8 +135,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Plantain",
-                                      "name": "plantain",
+                                      "name": "Plantain",
+                                      "id": "plantain",
                                       "default": true
                                     }
                                   ]
@@ -159,7 +159,7 @@
         },
         {
           "kind": "step",
-          "label": "Customize cake",
+          "name": "Customize cake",
           "id": "2",
           "children": [
             {
@@ -167,8 +167,8 @@
               "children": [
                 {
                   "kind": "boolean",
-                  "label": "Frosting",
-                  "name": "frosting",
+                  "name": "Frosting",
+                  "id": "frosting",
                   "default": true
                 }
               ]

--- a/archetype/engine-v2-json/src/test/resources/expected/empty-script.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/empty-script.json
@@ -13,9 +13,6 @@
             {
               "label": "Enum1",
               "name": "enum1",
-              "global": false,
-              "optional": false,
-              "default": null,
               "kind": "enum",
               "children": [
                 {

--- a/archetype/engine-v2-json/src/test/resources/expected/empty-script.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/empty-script.json
@@ -3,7 +3,7 @@
   "methods": {},
   "children": [
     {
-      "label": "Step1",
+      "name": "Step1",
       "id": "1",
       "kind": "step",
       "children": [
@@ -11,17 +11,17 @@
           "kind": "inputs",
           "children": [
             {
-              "label": "Enum1",
-              "name": "enum1",
+              "name": "Enum1",
+              "id": "enum1",
               "kind": "enum",
               "children": [
                 {
-                  "label": "Enum1Value1",
+                  "name": "Enum1Value1",
                   "value": "enum1-value1",
                   "kind": "option"
                 },
                 {
-                  "label": "Enum1Value2",
+                  "name": "Enum1Value2",
                   "value": "enum1-value2",
                   "kind": "option"
                 }

--- a/archetype/engine-v2-json/src/test/resources/expected/filtering.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/filtering.json
@@ -3,7 +3,7 @@
   "methods": {},
   "children": [
     {
-      "label": "Step1",
+      "name": "Step1",
       "id": "1",
       "kind": "step",
       "children": [
@@ -11,8 +11,8 @@
           "kind": "inputs",
           "children": [
             {
-              "label": "Boolean1",
-              "name": "boolean1",
+              "name": "Boolean1",
+              "id": "boolean1",
               "kind": "boolean",
               "default": false
             }

--- a/archetype/engine-v2-json/src/test/resources/expected/filtering.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/filtering.json
@@ -13,10 +13,8 @@
             {
               "label": "Boolean1",
               "name": "boolean1",
-              "global": false,
-              "optional": false,
-              "default": false,
-              "kind": "boolean"
+              "kind": "boolean",
+              "default": false
             }
           ]
         }

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined1.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined1.json
@@ -14,8 +14,6 @@
               "kind": "boolean",
               "label": "Boolean1",
               "name": "boolean1",
-              "global": false,
-              "optional": false,
               "default": false
             }
           ]

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined1.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined1.json
@@ -4,7 +4,7 @@
   "children": [
     {
       "kind": "step",
-      "label": "Step1",
+      "name": "Step1",
       "id": "1",
       "children": [
         {
@@ -12,8 +12,8 @@
           "children": [
             {
               "kind": "boolean",
-              "label": "Boolean1",
-              "name": "boolean1",
+              "name": "Boolean1",
+              "id": "boolean1",
               "default": false
             }
           ]

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined2.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined2.json
@@ -14,8 +14,6 @@
               "kind": "boolean",
               "label": "Boolean1",
               "name": "boolean1",
-              "global": false,
-              "optional": false,
               "default": false,
               "children": [
                 {
@@ -25,8 +23,6 @@
                       "kind": "boolean",
                       "label": "Boolean2",
                       "name": "boolean2",
-                      "global": false,
-                      "optional": false,
                       "default": false
                     }
                   ]

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined2.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined2.json
@@ -4,7 +4,7 @@
   "children": [
     {
       "kind": "step",
-      "label": "Step1",
+      "name": "Step1",
       "id": "1",
       "children": [
         {
@@ -12,8 +12,8 @@
           "children": [
             {
               "kind": "boolean",
-              "label": "Boolean1",
-              "name": "boolean1",
+              "name": "Boolean1",
+              "id": "boolean1",
               "default": false,
               "children": [
                 {
@@ -21,8 +21,8 @@
                   "children": [
                     {
                       "kind": "boolean",
-                      "label": "Boolean2",
-                      "name": "boolean2",
+                      "name": "Boolean2",
+                      "id": "boolean2",
                       "default": false
                     }
                   ]

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined3.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined3.json
@@ -6,7 +6,7 @@
   "children": [
     {
       "kind": "step",
-      "label": "Step1",
+      "name": "Step1",
       "id": "1",
       "children": [
         {
@@ -14,8 +14,8 @@
           "children": [
             {
               "kind": "boolean",
-              "label": "Boolean1",
-              "name": "boolean1",
+              "name": "Boolean1",
+              "id": "boolean1",
               "default": false,
               "children": [
                 {
@@ -23,8 +23,8 @@
                   "children": [
                     {
                       "kind": "boolean",
-                      "label": "Boolean2",
-                      "name": "boolean2",
+                      "name": "Boolean2",
+                      "id": "boolean2",
                       "default": false
                     }
                   ]

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined3.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined3.json
@@ -16,8 +16,6 @@
               "kind": "boolean",
               "label": "Boolean1",
               "name": "boolean1",
-              "global": false,
-              "optional": false,
               "default": false,
               "children": [
                 {
@@ -27,8 +25,6 @@
                       "kind": "boolean",
                       "label": "Boolean2",
                       "name": "boolean2",
-                      "global": false,
-                      "optional": false,
                       "default": false
                     }
                   ]

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined4.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined4.json
@@ -9,10 +9,7 @@
           {
             "kind": "text",
             "label": "Comment",
-            "name": "comment",
-            "global": false,
-            "optional": false,
-            "default": null
+            "name": "comment"
           }
         ]
       }
@@ -31,8 +28,6 @@
               "kind": "enum",
               "label": "Fruit",
               "name": "fruit",
-              "global": false,
-              "optional": false,
               "default": "berries",
               "children": [
                 {
@@ -47,8 +42,6 @@
                           "kind": "enum",
                           "label": "Berry type",
                           "name": "berry-type",
-                          "global": false,
-                          "optional": false,
                           "default": "raspberry",
                           "children": [
                             {
@@ -63,8 +56,6 @@
                                       "kind": "boolean",
                                       "label": "Organic",
                                       "name": "organic",
-                                      "global": false,
-                                      "optional": false,
                                       "default": false
                                     }
                                   ]
@@ -83,8 +74,6 @@
                                       "kind": "boolean",
                                       "label": "Frozen",
                                       "name": "frozen",
-                                      "global": false,
-                                      "optional": false,
                                       "default": false
                                     }
                                   ]
@@ -109,8 +98,6 @@
                           "kind": "enum",
                           "label": "Tropical type",
                           "name": "tropical-type",
-                          "global": false,
-                          "optional": false,
                           "default": "mango",
                           "children": [
                             {
@@ -125,8 +112,6 @@
                                       "kind": "boolean",
                                       "label": "Fare trade",
                                       "name": "fare-trade",
-                                      "global": false,
-                                      "optional": false,
                                       "default": false,
                                       "children": [
                                         {
@@ -151,8 +136,6 @@
                                       "kind": "boolean",
                                       "label": "Plantain",
                                       "name": "plantain",
-                                      "global": false,
-                                      "optional": false,
                                       "default": false
                                     }
                                   ]
@@ -180,8 +163,6 @@
               "kind": "boolean",
               "label": "Frosting",
               "name": "frosting",
-              "global": false,
-              "optional": false,
               "default": false
             }
           ]

--- a/archetype/engine-v2-json/src/test/resources/expected/inlined4.json
+++ b/archetype/engine-v2-json/src/test/resources/expected/inlined4.json
@@ -8,8 +8,8 @@
         "children": [
           {
             "kind": "text",
-            "label": "Comment",
-            "name": "comment"
+            "name": "Comment",
+            "id": "comment"
           }
         ]
       }
@@ -18,7 +18,7 @@
   "children": [
     {
       "kind": "step",
-      "label": "Cake",
+      "name": "Cake",
       "id": "1",
       "children": [
         {
@@ -26,13 +26,13 @@
           "children": [
             {
               "kind": "enum",
-              "label": "Fruit",
-              "name": "fruit",
+              "name": "Fruit",
+              "id": "fruit",
               "default": "berries",
               "children": [
                 {
                   "kind": "option",
-                  "label": "Berries",
+                  "name": "Berries",
                   "value": "berries",
                   "children": [
                     {
@@ -40,13 +40,13 @@
                       "children": [
                         {
                           "kind": "enum",
-                          "label": "Berry type",
-                          "name": "berry-type",
+                          "name": "Berry type",
+                          "id": "berry-type",
                           "default": "raspberry",
                           "children": [
                             {
                               "kind": "option",
-                              "label": "Raspberry",
+                              "name": "Raspberry",
                               "value": "raspberry",
                               "children": [
                                 {
@@ -54,8 +54,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Organic",
-                                      "name": "organic",
+                                      "name": "Organic",
+                                      "id": "organic",
                                       "default": false
                                     }
                                   ]
@@ -64,7 +64,7 @@
                             },
                             {
                               "kind": "option",
-                              "label": "Strawberry",
+                              "name": "Strawberry",
                               "value": "strawberry",
                               "children": [
                                 {
@@ -72,8 +72,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Frozen",
-                                      "name": "frozen",
+                                      "name": "Frozen",
+                                      "id": "frozen",
                                       "default": false
                                     }
                                   ]
@@ -88,7 +88,7 @@
                 },
                 {
                   "kind": "option",
-                  "label": "Tropical",
+                  "name": "Tropical",
                   "value": "tropical",
                   "children": [
                     {
@@ -96,13 +96,13 @@
                       "children": [
                         {
                           "kind": "enum",
-                          "label": "Tropical type",
-                          "name": "tropical-type",
+                          "name": "Tropical type",
+                          "id": "tropical-type",
                           "default": "mango",
                           "children": [
                             {
                               "kind": "option",
-                              "label": "Mango",
+                              "name": "Mango",
                               "value": "mango",
                               "children": [
                                 {
@@ -110,8 +110,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Fare trade",
-                                      "name": "fare-trade",
+                                      "name": "Fare trade",
+                                      "id": "fare-trade",
                                       "default": false,
                                       "children": [
                                         {
@@ -126,7 +126,7 @@
                             },
                             {
                               "kind": "option",
-                              "label": "Banana",
+                              "name": "Banana",
                               "value": "banana",
                               "children": [
                                 {
@@ -134,8 +134,8 @@
                                   "children": [
                                     {
                                       "kind": "boolean",
-                                      "label": "Plantain",
-                                      "name": "plantain",
+                                      "name": "Plantain",
+                                      "id": "plantain",
                                       "default": false
                                     }
                                   ]
@@ -161,8 +161,8 @@
           "children": [
             {
               "kind": "boolean",
-              "label": "Frosting",
-              "name": "frosting",
+              "name": "Frosting",
+              "id": "frosting",
               "default": false
             }
           ]

--- a/archetype/engine-v2-json/src/test/resources/filtering/main.xml
+++ b/archetype/engine-v2-json/src/test/resources/filtering/main.xml
@@ -23,16 +23,16 @@
     <variables>
         <boolean path="foo" transient="true">true</boolean>
     </variables>
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <boolean name="boolean1" label="Boolean1">
+            <boolean id="boolean1" name="Boolean1">
                 <output>
                     <file source="foo.txt" target="foo.txt"/>
                 </output>
             </boolean>
         </inputs>
     </step>
-    <step label="Step2">
+    <step name="Step2">
         <inputs></inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2-json/src/test/resources/filtering/main.xml
+++ b/archetype/engine-v2-json/src/test/resources/filtering/main.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <presets>
+    <variables>
         <boolean path="foo" transient="true">true</boolean>
-    </presets>
+    </variables>
     <step label="Step1">
         <inputs>
             <boolean name="boolean1" label="Boolean1">

--- a/archetype/engine-v2-json/src/test/resources/inlined1/main.xml
+++ b/archetype/engine-v2-json/src/test/resources/inlined1/main.xml
@@ -20,7 +20,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <exec src="script1.xml"/>
     </step>
 </archetype-script>

--- a/archetype/engine-v2-json/src/test/resources/inlined1/script3.xml
+++ b/archetype/engine-v2-json/src/test/resources/inlined1/script3.xml
@@ -20,6 +20,6 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
     <inputs>
-        <boolean name="boolean1" label="Boolean1" />
+        <boolean id="boolean1" name="Boolean1" />
     </inputs>
 </archetype-script>

--- a/archetype/engine-v2-json/src/test/resources/inlined2/script2.xml
+++ b/archetype/engine-v2-json/src/test/resources/inlined2/script2.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <boolean name="boolean1" label="Boolean1">
+            <boolean id="boolean1" name="Boolean1">
                 <exec src="script3.xml"/>
             </boolean>
         </inputs>

--- a/archetype/engine-v2-json/src/test/resources/inlined2/script3.xml
+++ b/archetype/engine-v2-json/src/test/resources/inlined2/script3.xml
@@ -20,6 +20,6 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
     <inputs>
-        <boolean name="boolean2" label="Boolean2"/>
+        <boolean id="boolean2" name="Boolean2"/>
     </inputs>
 </archetype-script>

--- a/archetype/engine-v2-json/src/test/resources/inlined3/script2.xml
+++ b/archetype/engine-v2-json/src/test/resources/inlined3/script2.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <boolean name="boolean1" label="Boolean1">
+            <boolean id="boolean1" name="Boolean1">
                 <exec src="script3.xml"/>
             </boolean>
         </inputs>

--- a/archetype/engine-v2-json/src/test/resources/inlined3/script3.xml
+++ b/archetype/engine-v2-json/src/test/resources/inlined3/script3.xml
@@ -23,7 +23,7 @@
     <methods>
         <method name="method3">
             <inputs>
-                <boolean name="boolean2" label="Boolean2"/>
+                <boolean id="boolean2" name="Boolean2"/>
             </inputs>
         </method>
     </methods>

--- a/archetype/engine-v2-json/src/test/resources/inlined4/main.xml
+++ b/archetype/engine-v2-json/src/test/resources/inlined4/main.xml
@@ -22,7 +22,7 @@
 
     <methods>
         <method name="main">
-            <step label="Cake">
+            <step name="Cake">
                 <call method="fruit"/>
                 <call method="common"/>
                 <call method="customize"/>
@@ -30,11 +30,11 @@
         </method>
         <method name="fruit">
             <inputs>
-                <enum name="fruit" label="Fruit" default="berries">
-                    <option value="berries" label="Berries">
+                <enum id="fruit" name="Fruit" default="berries">
+                    <option value="berries" name="Berries">
                         <call method="berries"/>
                     </option>
-                    <option value="tropical" label="Tropical">
+                    <option value="tropical" name="Tropical">
                         <call method="tropical"/>
                     </option>
                 </enum>
@@ -42,11 +42,11 @@
         </method>
         <method name="berries">
             <inputs>
-                <enum name="berry-type" label="Berry type" default="raspberry">
-                    <option value="raspberry" label="Raspberry">
+                <enum id="berry-type" name="Berry type" default="raspberry">
+                    <option value="raspberry" name="Raspberry">
                         <call method="raspberry"/>
                     </option>
-                    <option value="strawberry" label="Strawberry">
+                    <option value="strawberry" name="Strawberry">
                         <call method="strawberry"/>
                     </option>
                 </enum>
@@ -54,11 +54,11 @@
         </method>
         <method name="tropical">
             <inputs>
-                <enum name="tropical-type" label="Tropical type" default="mango">
-                    <option value="mango" label="Mango">
+                <enum id="tropical-type" name="Tropical type" default="mango">
+                    <option value="mango" name="Mango">
                         <call method="mango"/>
                     </option>
-                    <option value="banana" label="Banana">
+                    <option value="banana" name="Banana">
                         <call method="banana"/>
                     </option>
                 </enum>
@@ -66,34 +66,34 @@
         </method>
         <method name="raspberry">
             <inputs>
-                <boolean name="organic" label="Organic"/>
+                <boolean id="organic" name="Organic"/>
             </inputs>
         </method>
         <method name="strawberry">
             <inputs>
-                <boolean name="frozen" label="Frozen"/>
+                <boolean id="frozen" name="Frozen"/>
             </inputs>
         </method>
         <method name="mango">
             <inputs>
-                <boolean name="fare-trade" label="Fare trade">
+                <boolean id="fare-trade" name="Fare trade">
                     <call method="common"/>
                 </boolean>
             </inputs>
         </method>
         <method name="banana">
             <inputs>
-                <boolean name="plantain" label="Plantain"/>
+                <boolean id="plantain" name="Plantain"/>
             </inputs>
         </method>
         <method name="common">
             <inputs>
-                <text name="comment" label="Comment"/>
+                <text id="comment" name="Comment"/>
             </inputs>
         </method>
         <method name="customize">
             <inputs>
-                <boolean name="frosting" label="Frosting"/>
+                <boolean id="frosting" name="Frosting"/>
             </inputs>
         </method>
     </methods>

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
@@ -82,7 +82,7 @@ public class ArchetypeEngineV2 {
 
         // resolve inputs (full traversal)
         Controller.walk(inputResolver, script, context);
-        context.ensureEmptyInputs();
+        context.ensureRootScope();
         onResolved.run();
 
         // resolve output directory
@@ -95,7 +95,7 @@ public class ArchetypeEngineV2 {
         //  generate output  (full traversal)
         OutputGenerator outputGenerator = new OutputGenerator(model, directory);
         Controller.walk(outputGenerator, script, context);
-        context.ensureEmptyInputs();
+        context.ensureRootScope();
 
         return directory;
     }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
@@ -58,7 +58,8 @@ public class ArchetypeEngineV2 {
                          Map<String, String> externalDefaults,
                          Function<String, Path> directorySupplier) {
 
-        return generate(inputResolver, externalValues, externalDefaults, () -> {}, directorySupplier);
+        return generate(inputResolver, externalValues, externalDefaults, () -> {
+        }, directorySupplier);
     }
 
     /**
@@ -82,6 +83,9 @@ public class ArchetypeEngineV2 {
 
         // resolve inputs (full traversal)
         Controller.walk(inputResolver, script, context);
+        if (context.peekScope() != Context.Scope.ROOT) {
+            throw new IllegalStateException("Invalid scope");
+        }
         context.ensureRootScope();
         onResolved.run();
 
@@ -95,7 +99,9 @@ public class ArchetypeEngineV2 {
         //  generate output  (full traversal)
         OutputGenerator outputGenerator = new OutputGenerator(model, directory);
         Controller.walk(outputGenerator, script, context);
-        context.ensureRootScope();
+        if (context.peekScope() != Context.Scope.ROOT) {
+            throw new IllegalStateException("Invalid scope");
+        }
 
         return directory;
     }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
@@ -86,7 +86,6 @@ public class ArchetypeEngineV2 {
         if (context.peekScope() != Context.Scope.ROOT) {
             throw new IllegalStateException("Invalid scope");
         }
-        context.ensureRootScope();
         onResolved.run();
 
         // resolve output directory

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
@@ -58,12 +58,32 @@ public class ArchetypeEngineV2 {
                          Map<String, String> externalDefaults,
                          Function<String, Path> directorySupplier) {
 
+        return generate(inputResolver, externalValues, externalDefaults, () -> {}, directorySupplier);
+    }
+
+    /**
+     * Generate a project.
+     *
+     * @param inputResolver     input resolver
+     * @param externalValues    external values
+     * @param externalDefaults  external defaults
+     * @param onResolved        callback executed when inputs are fully resolved
+     * @param directorySupplier output directory supplier
+     * @return output directory
+     */
+    public Path generate(InputResolver inputResolver,
+                         Map<String, String> externalValues,
+                         Map<String, String> externalDefaults,
+                         Runnable onResolved,
+                         Function<String, Path> directorySupplier) {
+
         Context context = Context.create(cwd, externalValues, externalDefaults);
         Script script = ScriptLoader.load(cwd.resolve(ENTRYPOINT));
 
         // resolve inputs (full traversal)
         Controller.walk(inputResolver, script, context);
         context.ensureEmptyInputs();
+        onResolved.run();
 
         // resolve output directory
         String artifactId = requireNonNull(context.lookup(ARTIFACT_ID), ARTIFACT_ID + " is null").asString();

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
@@ -21,6 +21,8 @@ import io.helidon.build.archetype.engine.v2.ast.Input.NamedInput;
 import io.helidon.build.archetype.engine.v2.ast.Node.VisitResult;
 import io.helidon.build.archetype.engine.v2.ast.Value;
 
+import java.util.List;
+
 /**
  * Batch input resolver.
  * Only fails if a non-optional input is unresolved, or an optional input cannot be resolved with a default value.
@@ -55,18 +57,18 @@ public class BatchInputResolver extends InputResolver {
         Value defaultValue = defaultValue(input, context);
         if (input.isOptional()) {
             if (defaultValue != null) {
-                context.push(input.name(), defaultValue, input.isGlobal());
+                context.push(input.name(), defaultValue, input.isGlobal(), true);
                 if (input instanceof Input.Boolean && !defaultValue.asBoolean()) {
                     return VisitResult.SKIP_SUBTREE;
                 }
                 return VisitResult.CONTINUE;
             }
         } else if (input instanceof Input.Enum){
+            List<Input.Option> options = ((Input.Enum) input).options(context::filterNode);
+            int defaultIndex = ((Input.Enum) input).optionIndex(defaultValue.asString(), options);
             // skip prompting if there is only one option with a default value
-            Input.Enum enumInput = (Input.Enum) input;
-            int defaultIndex = enumInput.optionIndex(defaultValue.asString());
-            if (enumInput.options().size() == 1 && defaultIndex >= 0) {
-                context.push(input.name(), defaultValue, input.isGlobal());
+            if (options.size() == 1 && defaultIndex >= 0) {
+                context.push(input.name(), defaultValue, input.isGlobal(), true);
                 return VisitResult.CONTINUE;
             }
         }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
@@ -16,12 +16,14 @@
 
 package io.helidon.build.archetype.engine.v2;
 
+import java.util.List;
+
 import io.helidon.build.archetype.engine.v2.ast.Input;
-import io.helidon.build.archetype.engine.v2.ast.Input.NamedInput;
+import io.helidon.build.archetype.engine.v2.ast.Input.DeclaredInput;
 import io.helidon.build.archetype.engine.v2.ast.Node.VisitResult;
 import io.helidon.build.archetype.engine.v2.ast.Value;
 
-import java.util.List;
+import static io.helidon.build.archetype.engine.v2.ast.Input.Enum.optionIndex;
 
 /**
  * Batch input resolver.
@@ -49,29 +51,35 @@ public class BatchInputResolver extends InputResolver {
         return visit(input, context);
     }
 
-    private VisitResult visit(NamedInput input, Context context) {
-        VisitResult result = onVisitInput(input, context);
-        if (result != null) {
-            return result;
-        }
-        Value defaultValue = defaultValue(input, context);
-        if (input.isOptional()) {
-            if (defaultValue != null) {
-                context.push(input.name(), defaultValue, input.isGlobal(), true);
-                if (input instanceof Input.Boolean && !defaultValue.asBoolean()) {
-                    return VisitResult.SKIP_SUBTREE;
+    private VisitResult visit(DeclaredInput input, Context context) {
+        Context.Scope scope = context.newScope(input.id(), input.isGlobal());
+        VisitResult result = onVisitInput(input, scope, context);
+        if (result == null) {
+            Value defaultValue = defaultValue(input, context);
+            if (input.isOptional()) {
+                if (defaultValue != null) {
+                    context.setValue(scope.id(), defaultValue, ContextValue.ValueKind.DEFAULT);
+                    if (input instanceof Input.Boolean && !defaultValue.asBoolean()) {
+                        result = VisitResult.SKIP_SUBTREE;
+                    } else {
+                        result = VisitResult.CONTINUE;
+                    }
+                } else {
+                    throw new UnresolvedInputException(scope.id());
                 }
-                return VisitResult.CONTINUE;
-            }
-        } else if (input instanceof Input.Enum){
-            List<Input.Option> options = ((Input.Enum) input).options(context::filterNode);
-            int defaultIndex = ((Input.Enum) input).optionIndex(defaultValue.asString(), options);
-            // skip prompting if there is only one option with a default value
-            if (options.size() == 1 && defaultIndex >= 0) {
-                context.push(input.name(), defaultValue, input.isGlobal(), true);
-                return VisitResult.CONTINUE;
+            } else if (input instanceof Input.Enum) {
+                List<Input.Option> options = ((Input.Enum) input).options(context::filterNode);
+                int defaultIndex = optionIndex(defaultValue.asString(), options);
+                // skip prompting if there is only one option with a default value
+                if (options.size() == 1 && defaultIndex >= 0) {
+                    context.setValue(scope.id(), defaultValue, ContextValue.ValueKind.DEFAULT);
+                    result = VisitResult.CONTINUE;
+                } else {
+                    throw new UnresolvedInputException(scope.id());
+                }
             }
         }
-        throw new UnresolvedInputException(context.path(input.name()));
+        context.pushScope(scope);
+        return result;
     }
 }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ContextValue.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ContextValue.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.archetype.engine.v2;
+
+import java.util.List;
+
+import io.helidon.build.archetype.engine.v2.ast.DynamicValue;
+import io.helidon.build.archetype.engine.v2.ast.Value;
+import io.helidon.build.common.GenericType;
+
+/**
+ * Context value.
+ */
+public final class ContextValue implements Value {
+
+    private final Value value;
+    private final ValueKind kind;
+
+    /**
+     * Create a new context value.
+     *
+     * @param value wrapped value
+     * @param kind  value kind
+     */
+    ContextValue(Value value, ValueKind kind) {
+        this.value = value;
+        this.kind = kind;
+    }
+
+    /**
+     * Test if this context value is read-only.
+     *
+     * @return {@code true} if read-only, {@code false} otherwise
+     */
+    public boolean isReadOnly() {
+        switch (kind) {
+            case EXTERNAL:
+            case PRESET:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Create a new external value.
+     *
+     * @param value raw value
+     * @return ContextValue
+     */
+    public static ContextValue external(String value) {
+        return new ContextValue(DynamicValue.create(value), ValueKind.EXTERNAL);
+    }
+
+    @Override
+    public Boolean asBoolean() {
+        return value.asBoolean();
+    }
+
+    @Override
+    public String asString() {
+        return value.asString();
+    }
+
+    @Override
+    public Integer asInt() {
+        return value.asInt();
+    }
+
+    @Override
+    public List<String> asList() {
+        return value.asList();
+    }
+
+    @Override
+    public Object unwrap() {
+        return value.unwrap();
+    }
+
+    @Override
+    public GenericType<?> type() {
+        return value.type();
+    }
+
+    @Override
+    public <U> U as(GenericType<U> type) {
+        return value.as(type);
+    }
+
+    @Override
+    public String toString() {
+        return "ContextValue{"
+                + "kind=" + kind
+                + ", value=" + value
+                + '}';
+    }
+
+    /**
+     * Context value kind.
+     */
+    public enum ValueKind {
+        /**
+         * Preset value.
+         */
+        PRESET,
+
+        /**
+         * Default value.
+         */
+        DEFAULT,
+
+        /**
+         * External value.
+         */
+        EXTERNAL,
+
+        /**
+         * User value.
+         */
+        USER
+    }
+}

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/Controller.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/Controller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,13 +59,13 @@ final class Controller extends VisitorAdapter<Context> {
 
     @Override
     public VisitResult visitPreset(Preset preset, Context ctx) {
-        ctx.put(preset.path(), preset.value(), true);
+        ctx.setValue(preset.path(), preset.value(), ContextValue.ValueKind.PRESET);
         return VisitResult.CONTINUE;
     }
 
     @Override
     public VisitResult visitVariable(Variable variable, Context ctx) {
-        ctx.put(variable.path(), variable.value(), false);
+        ctx.setVariable(variable.path(), variable.value());
         return VisitResult.CONTINUE;
     }
 

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/MergedModel.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/MergedModel.java
@@ -72,7 +72,9 @@ public final class MergedModel {
     public static MergedModel resolveModel(Block block, Context context) {
         ModelResolver modelResolver = new ModelResolver(block);
         Controller.walk(modelResolver, block, context);
-        context.ensureRootScope();
+        if (context.peekScope() != Context.Scope.ROOT) {
+            throw new IllegalStateException("Invalid scope");
+        }
         return modelResolver.model();
     }
 

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/MergedModel.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/MergedModel.java
@@ -72,7 +72,7 @@ public final class MergedModel {
     public static MergedModel resolveModel(Block block, Context context) {
         ModelResolver modelResolver = new ModelResolver(block);
         Controller.walk(modelResolver, block, context);
-        context.ensureEmptyInputs();
+        context.ensureRootScope();
         return modelResolver.model();
     }
 

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ScriptLoader.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ScriptLoader.java
@@ -21,11 +21,11 @@ import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.WeakHashMap;
 
 import io.helidon.build.archetype.engine.v2.ast.Block;
@@ -37,15 +37,19 @@ import io.helidon.build.archetype.engine.v2.ast.Location;
 import io.helidon.build.archetype.engine.v2.ast.Method;
 import io.helidon.build.archetype.engine.v2.ast.Model;
 import io.helidon.build.archetype.engine.v2.ast.Node;
+import io.helidon.build.archetype.engine.v2.ast.Node.BuilderInfo;
 import io.helidon.build.archetype.engine.v2.ast.Output;
 import io.helidon.build.archetype.engine.v2.ast.Preset;
 import io.helidon.build.archetype.engine.v2.ast.Script;
 import io.helidon.build.archetype.engine.v2.ast.Step;
 import io.helidon.build.archetype.engine.v2.ast.Value;
+import io.helidon.build.archetype.engine.v2.ast.Variable;
 import io.helidon.build.common.Maps;
 import io.helidon.build.common.VirtualFileSystem;
 import io.helidon.build.common.xml.SimpleXMLParser;
 import io.helidon.build.common.xml.SimpleXMLParser.XMLReaderException;
+
+import static io.helidon.build.common.xml.SimpleXMLParser.processXmlEscapes;
 
 /**
  * Script loader.
@@ -54,7 +58,7 @@ import io.helidon.build.common.xml.SimpleXMLParser.XMLReaderException;
 public class ScriptLoader {
 
     private static final Map<FileSystem, ScriptLoader> LOADERS = new WeakHashMap<>();
-    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final Random RANDOM = new Random();
 
     private final Map<Path, Script> scripts = new HashMap<>();
 
@@ -141,6 +145,7 @@ public class ScriptLoader {
     }
 
     private enum State {
+        VARIABLE,
         PRESET,
         INPUT,
         METHOD,
@@ -165,7 +170,7 @@ public class ScriptLoader {
 
         private final ScriptLoader loader;
         private Path path;
-        private Location location;
+        private BuilderInfo info;
         private SimpleXMLParser parser;
         private String qName;
         private Map<String, Value> attrs;
@@ -192,15 +197,16 @@ public class ScriptLoader {
         public void startElement(String qName, Map<String, String> attrs) {
             this.qName = qName;
             this.attrs = Maps.mapValue(attrs, DynamicValue::create);
-            location = Location.of(path, parser.lineNumber(), parser.charNumber());
+            Location location = Location.of(path, parser.lineNumber(), parser.charNumber());
+            info = BuilderInfo.of(loader, path, location);
             ctx = stack.peek();
             if (ctx == null) {
                 if (!"archetype-script".equals(qName)) {
                     throw new XMLReaderException(String.format(
                             "Invalid root element '%s'. {file=%s, location=%s}",
-                            qName, path, path));
+                            qName, path, location));
                 }
-                scriptBuilder = Script.builder(loader, path);
+                scriptBuilder = Script.builder(info);
                 stack.push(new Context(State.EXECUTABLE, scriptBuilder));
             } else {
                 try {
@@ -208,11 +214,11 @@ public class ScriptLoader {
                 } catch (IllegalArgumentException ex) {
                     throw new XMLReaderException(String.format(
                             "Invalid element '%s'. { file=%s, location=%s }",
-                            qName, path, path), ex);
+                            qName, path, location), ex);
                 } catch (Throwable ex) {
                     throw new XMLReaderException(String.format(
                             "An unexpected error occurred. { file=%s, location=%s }",
-                            path, path), ex);
+                            path, location), ex);
                 }
             }
         }
@@ -253,6 +259,9 @@ public class ScriptLoader {
                 case PRESET:
                     processPreset();
                     break;
+                case VARIABLE:
+                    processVariable();
+                    break;
                 case INPUT:
                     processInput();
                     break;
@@ -269,7 +278,7 @@ public class ScriptLoader {
         }
 
         void processMethod() {
-            addChild(State.EXECUTABLE, Method.builder(loader, path, location));
+            addChild(State.EXECUTABLE, Method.builder(info));
         }
 
         boolean processExec() {
@@ -277,7 +286,7 @@ public class ScriptLoader {
                 case "exec":
                 case "source":
                 case "call":
-                    addChild(ctx.state, Invocation.builder(loader, path, location, invocationKind()));
+                    addChild(ctx.state, Invocation.builder(info, invocationKind()));
                     return true;
                 default:
                     return false;
@@ -307,7 +316,7 @@ public class ScriptLoader {
                     throw new XMLReaderException(String.format(
                             "Invalid input block: %s. { element=%s }", kind, qName));
             }
-            addChild(nextState, Input.builder(loader, path, location, kind));
+            addChild(nextState, Input.builder(info, kind));
         }
 
         void processPreset() {
@@ -318,14 +327,35 @@ public class ScriptLoader {
                 case TEXT:
                 case ENUM:
                 case LIST:
-                    builder = Preset.builder(loader, path, location, blockKind());
+                    builder = Preset.builder(info, blockKind());
                     break;
                 case VALUE:
-                    builder = Block.builder(loader, path, location, blockKind());
+                    builder = Block.builder(info, blockKind());
                     break;
                 default:
                     throw new XMLReaderException(String.format(
                             "Invalid preset block: %s. { element=%s }", kind, qName));
+
+            }
+            addChild(ctx.state, builder);
+        }
+
+        void processVariable() {
+            Block.Builder builder;
+            Block.Kind kind = blockKind();
+            switch (kind) {
+                case BOOLEAN:
+                case TEXT:
+                case ENUM:
+                case LIST:
+                    builder = Variable.builder(info, blockKind());
+                    break;
+                case VALUE:
+                    builder = Block.builder(info, blockKind());
+                    break;
+                default:
+                    throw new XMLReaderException(String.format(
+                            "Invalid variable block: %s. { element=%s }", kind, qName));
 
             }
             addChild(ctx.state, builder);
@@ -338,7 +368,7 @@ public class ScriptLoader {
             switch (kind) {
                 case INCLUDES:
                 case EXCLUDES:
-                    builder = Block.builder(loader, path, location, kind);
+                    builder = Block.builder(info, kind);
                     break;
                 case INCLUDE:
                 case EXCLUDE:
@@ -348,11 +378,11 @@ public class ScriptLoader {
                 case TEMPLATES:
                 case FILE:
                 case TEMPLATE:
-                    builder = Output.builder(loader, path, location, kind);
+                    builder = Output.builder(info, kind);
                     break;
                 case MODEL:
                     nextState = State.MODEL;
-                    builder = Block.builder(loader, path, location, kind);
+                    builder = Block.builder(info, kind);
                     break;
                 default:
                     throw new XMLReaderException(String.format(
@@ -369,7 +399,7 @@ public class ScriptLoader {
                 case MAP:
                 case VALUE:
                 case LIST:
-                    builder = Model.builder(loader, path, location, kind);
+                    builder = Model.builder(info, kind);
                     break;
                 default:
                     throw new XMLReaderException(String.format(
@@ -392,14 +422,17 @@ public class ScriptLoader {
                     break;
                 case METHOD:
                     nextState = State.EXECUTABLE;
-                    builder = Method.builder(loader, path, location);
+                    builder = Method.builder(info);
                     break;
                 case STEP:
                     nextState = State.EXECUTABLE;
-                    builder = Step.builder(loader, path, location);
+                    builder = Step.builder(info);
                     break;
                 case INPUTS:
                     nextState = State.INPUT;
+                    break;
+                case VARIABLES:
+                    nextState = State.VARIABLE;
                     break;
                 case PRESETS:
                     nextState = State.PRESET;
@@ -410,7 +443,7 @@ public class ScriptLoader {
                 default:
             }
             if (builder == null) {
-                builder = Block.builder(loader, path, location, kind);
+                builder = Block.builder(info, kind);
             }
             addChild(nextState, builder);
         }
@@ -419,9 +452,8 @@ public class ScriptLoader {
             builder.attributes(attrs);
             Value ifExpr = attrs.get("if");
             if (ifExpr != null) {
-                ctx.builder.addChild(Condition.builder(loader, path, location)
-                                              .expression(ifExpr.asString())
-                                              .then(builder));
+                String expr = processXmlEscapes(ifExpr.asString());
+                ctx.builder.addChild(Condition.builder(info).expression(expr).then(builder));
             } else {
                 ctx.builder.addChild(builder);
             }
@@ -443,7 +475,7 @@ public class ScriptLoader {
         private final String qName;
 
         ValueBuilder(Node.Builder<?, ?> parent, String qName) {
-            super(parent.loader(), parent.scriptPath(), null);
+            super(parent.info());
             this.parent = parent;
             this.qName = qName;
         }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/Walker.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/Walker.java
@@ -122,15 +122,15 @@ public final class Walker<A> {
             traversing = false;
             Node node = stack.peek();
             Node parent = parents.peek();
-            int parentId = parent != null ? parent.nodeId() : 0;
-            int nodeId = node.nodeId();
+            int parentId = parent != null ? parent.uid() : 0;
+            int nodeId = node.uid();
             if (nodeId != parentId) {
                 result = accept(node, arg, true);
             } else {
                 if (node instanceof Block) {
                     result = accept(node, arg, false);
                 }
-                parentId = parents.pop().nodeId();
+                parentId = parents.pop().uid();
             }
             if (!traversing) {
                 stack.pop();
@@ -148,7 +148,7 @@ public final class Walker<A> {
         while (!stack.isEmpty()) {
             Node n = stack.peek();
             if (n instanceof Block) {
-                if (n.nodeId() == parentId) {
+                if (n.uid() == parentId) {
                     break;
                 }
                 stack.pop();

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/Walker.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/Walker.java
@@ -135,21 +135,25 @@ public final class Walker<A> {
             if (!traversing) {
                 stack.pop();
                 if (result == VisitResult.SKIP_SIBLINGS) {
-                    while (!stack.isEmpty()) {
-                        Node n = stack.peek();
-                        if (!(n instanceof Block)) {
-                            continue;
-                        } else if (n.nodeId() == parentId) {
-                            break;
-                        }
-                        stack.pop();
-                    }
+                    skipSiblings(parentId);
                 } else if (result == VisitResult.TERMINATE) {
                     return;
                 }
             }
         }
         accept(block, arg, false);
+    }
+
+    private void skipSiblings(int parentId) {
+        while (!stack.isEmpty()) {
+            Node n = stack.peek();
+            if (n instanceof Block) {
+                if (n.nodeId() == parentId) {
+                    break;
+                }
+                stack.pop();
+            }
+        }
     }
 
     private Script resolveScript(ScriptInvocation invocation) {

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Block.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Block.java
@@ -16,12 +16,9 @@
 
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
 
 /**
  * Block.
@@ -45,20 +42,13 @@ public class Block extends Node {
     /**
      * Create a new block.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
+     * @param info       builder info
      * @param attributes attributes map
      * @param kind       kind
      * @param children   children
      */
-    protected Block(ScriptLoader loader,
-                    Path scriptPath,
-                    Location location,
-                    Map<String, Value> attributes,
-                    Kind kind,
-                    List<Node> children) {
-        super(loader, scriptPath, location, attributes);
+    protected Block(BuilderInfo info, Map<String, Value> attributes, Kind kind, List<Node> children) {
+        super(info, attributes);
         this.kind = Objects.requireNonNull(kind, "kind is null");
         this.children = Objects.requireNonNull(children, "children is null");
     }
@@ -79,7 +69,7 @@ public class Block extends Node {
      * @return block
      */
     public Block wrap(Block.Kind kind) {
-        return new Block(loader(), scriptPath(), location(), attributes(), kind, List.of(this));
+        return new Block(BuilderInfo.of(this), attributes(), kind, List.of(this));
     }
 
     @Override
@@ -105,6 +95,17 @@ public class Block extends Node {
          */
         default VisitResult visitPreset(Preset preset, A arg) {
             return visitAny(preset, arg);
+        }
+
+        /**
+         * Visit a variable block.
+         *
+         * @param variable variable
+         * @param arg      visitor argument
+         * @return visit result
+         */
+        default VisitResult visitVariable(Variable variable, A arg) {
+            return visitAny(variable, arg);
         }
 
         /**
@@ -324,6 +325,11 @@ public class Block extends Node {
         PRESETS,
 
         /**
+         * Variables.
+         */
+        VARIABLES,
+
+        /**
          * Output.
          */
         OUTPUT,
@@ -407,14 +413,12 @@ public class Block extends Node {
     /**
      * Create a new builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
-     * @param kind       kind
+     * @param info builder info
+     * @param kind kind
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-        return new Builder(loader, scriptPath, location, kind);
+    public static Builder builder(BuilderInfo info, Kind kind) {
+        return new Builder(info, kind);
     }
 
     /**
@@ -427,13 +431,11 @@ public class Block extends Node {
         /**
          * Create a new builder.
          *
-         * @param loader     script loader
-         * @param scriptPath script path
-         * @param location   location
-         * @param kind       kind
+         * @param info builder info
+         * @param kind kind
          */
-        protected Builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-            super(loader, scriptPath, location);
+        protected Builder(BuilderInfo info, Kind kind) {
+            super(info);
             this.kind = kind;
         }
 

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Condition.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Condition.java
@@ -16,9 +16,7 @@
 
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
+import java.util.function.Function;
 
 /**
  * Condition.
@@ -68,15 +66,40 @@ public final class Condition extends Node {
     }
 
     /**
+     * If the given node is an instance of {@link Condition}, evaluate the expression.
+     *
+     * @param node     node
+     * @param resolver variable resolver
+     * @return {@code true} if the node is not an instance of {@link Condition} or the expression result
+     */
+    public static boolean filter(Node node, Function<String, Value> resolver) {
+        if (node instanceof Condition) {
+            return ((Condition) node).expression().eval(resolver);
+        }
+        return true;
+    }
+
+    /**
+     * If the given node is an instance of {@link Condition}, unwrap the nested node or return the input node.
+     *
+     * @param node node
+     * @return Node
+     */
+    public static Node unwrap(Node node) {
+        if (node instanceof Condition) {
+            return ((Condition) node).then();
+        }
+        return node;
+    }
+
+    /**
      * Create a new builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
+     * @param info builder info
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location) {
-        return new Builder(loader, scriptPath, location);
+    public static Builder builder(BuilderInfo info) {
+        return new Builder(info);
     }
 
     /**
@@ -88,8 +111,8 @@ public final class Condition extends Node {
         private Expression expression;
         private Node.Builder<? extends Node, ?> then;
 
-        private Builder(ScriptLoader loader, Path scriptPath, Location location) {
-            super(loader, scriptPath, location);
+        private Builder(BuilderInfo info) {
+            super(info);
         }
 
         /**

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Condition.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Condition.java
@@ -44,6 +44,15 @@ public final class Condition extends Node {
     }
 
     /**
+     * Get the raw expression.
+     *
+     * @return raw expression
+     */
+    public String rawExpression() {
+        return rawExpression;
+    }
+
+    /**
      * Get the "then" node.
      *
      * @return node

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DeclaredValue.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DeclaredValue.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.archetype.engine.v2.ast;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+/**
+ * Declared value.
+ */
+public abstract class DeclaredValue extends Block {
+
+    private final Value value;
+    private final String path;
+
+    protected DeclaredValue(Builder builder, List<String> values) {
+        super(builder);
+        this.path = builder.attribute("path", true).asString();
+        Kind kind = builder.kind();
+        switch (kind) {
+            case BOOLEAN:
+                value = Value.create(Boolean.parseBoolean(builder.value()));
+                break;
+            case TEXT:
+            case ENUM:
+                value = Value.create(builder.value());
+                break;
+            case LIST:
+                value = Value.create(values);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown preset kind: " + kind);
+        }
+    }
+
+    /**
+     * Get the input path.
+     *
+     * @return path
+     */
+    public String path() {
+        return path;
+    }
+
+    /**
+     * Get the value.
+     *
+     * @return value
+     */
+    public Value value() {
+        return value;
+    }
+
+    /**
+     * Declared value builder.
+     */
+    public static abstract class Builder extends Block.Builder {
+
+        /**
+         * Create a new builder.
+         *
+         * @param info builder info
+         * @param kind kind
+         */
+        protected Builder(BuilderInfo info, Kind kind) {
+            super(info, kind);
+        }
+
+        /**
+         * Create the declared value instance.
+         *
+         * @param builder builder
+         * @param values  values
+         * @return DeclaredValue
+         */
+        protected abstract DeclaredValue doBuild(Builder builder, List<String> values);
+
+        @Override
+        protected DeclaredValue doBuild() {
+            if (kind() == Kind.LIST) {
+                // collapse the nested values and clear the nested builders
+                List<Node.Builder<? extends Node, ?>> nestedBuilders = nestedBuilders();
+                List<String> values = nestedBuilders.stream().map(Node.Builder::value).collect(toUnmodifiableList());
+                nestedBuilders.clear();
+                return doBuild(this, values);
+            }
+            return doBuild(this, null);
+        }
+    }
+}

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DeclaredValue.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DeclaredValue.java
@@ -69,7 +69,7 @@ public abstract class DeclaredValue extends Block {
     /**
      * Declared value builder.
      */
-    public static abstract class Builder extends Block.Builder {
+    public abstract static class Builder extends Block.Builder {
 
         /**
          * Create a new builder.

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DynamicValue.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DynamicValue.java
@@ -72,6 +72,13 @@ public final class DynamicValue implements Value {
         throw new DynamicValueTypeException(type);
     }
 
+    @Override
+    public String toString() {
+        return "DynamicValue{"
+                + "rawValue='" + rawValue + '\''
+                + '}';
+    }
+
     private static final class DynamicValueTypeException extends ValueTypeException {
 
         DynamicValueTypeException(GenericType<?> type) {

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DynamicValue.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DynamicValue.java
@@ -63,8 +63,9 @@ public final class DynamicValue implements Value {
         } else if (type.equals(ValueTypes.INT)) {
             return (U) Integer.valueOf(rawValue);
         } else if (type.equals(ValueTypes.STRING_LIST)) {
-            return (U) Arrays.stream((rawValue).split(","))
+            return (U) Arrays.stream(rawValue.split(","))
                              .map(String::trim)
+                             .filter(s -> !s.isEmpty())
                              .collect(toList());
         } else if (type.equals(ValueTypes.STRING)) {
             return (U) rawValue;

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Input.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Input.java
@@ -30,24 +30,35 @@ import static java.util.Collections.emptyList;
  */
 public abstract class Input extends Block {
 
-    private final String label;
+    private final String name;
+    private final String description;
     private final String help;
     private final String prompt;
 
     private Input(Input.Builder builder) {
         super(builder);
-        label = builder.attribute("label", false).asString();
+        name = builder.attribute("name", false).asString();
+        description = builder.attribute("description", false).asString();
         prompt = builder.attribute("prompt", false).asString();
         help = builder.attribute("help", false).asString();
     }
 
     /**
-     * Get the input label.
+     * Get the input name.
      *
-     * @return label
+     * @return name
      */
-    public String label() {
-        return label;
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Get the input description.
+     *
+     * @return description
+     */
+    public String description() {
+        return description;
     }
 
     /**
@@ -241,28 +252,28 @@ public abstract class Input extends Block {
     }
 
     /**
-     * Named input.
+     * Declared input.
      */
-    public abstract static class NamedInput extends Input {
+    public abstract static class DeclaredInput extends Input {
 
-        private final String name;
+        private final String id;
         private final boolean optional;
         private final boolean global;
 
-        private NamedInput(Input.Builder builder) {
+        private DeclaredInput(Input.Builder builder) {
             super(builder);
-            this.name = builder.attribute("name", true).asString();
+            this.id = builder.attribute("id", true).asString();
             this.optional = builder.attribute("optional", false).asBoolean();
             this.global = builder.attribute("global", false).asBoolean();
         }
 
         /**
-         * Get the input name.
+         * Get the input id.
          *
-         * @return name
+         * @return id
          */
-        public String name() {
-            return name;
+        public String id() {
+            return id;
         }
 
         /**
@@ -334,8 +345,8 @@ public abstract class Input extends Block {
 
         @Override
         public String toString() {
-            return "NamedInput{"
-                    + "name='" + name + '\''
+            return "DeclaredInput{"
+                    + "id='" + id + '\''
                     + ", optional=" + optional
                     + ", global=" + global
                     + '}';
@@ -384,7 +395,7 @@ public abstract class Input extends Block {
     /**
      * Text input.
      */
-    public static final class Text extends NamedInput {
+    public static final class Text extends DeclaredInput {
 
         private final String defaultValue;
 
@@ -412,8 +423,8 @@ public abstract class Input extends Block {
         @Override
         public String toString() {
             return "InputText{"
-                    + "name='" + name() + '\''
-                    + ", label='" + label() + '\''
+                    + "id='" + id() + '\''
+                    + ", name='" + name() + '\''
                     + ", optional=" + isOptional()
                     + ", global=" + isGlobal()
                     + ", defaultValue='" + defaultValue + '\''
@@ -424,7 +435,7 @@ public abstract class Input extends Block {
     /**
      * Boolean input.
      */
-    public static final class Boolean extends NamedInput {
+    public static final class Boolean extends DeclaredInput {
 
         private final boolean defaultValue;
 
@@ -503,8 +514,8 @@ public abstract class Input extends Block {
         @Override
         public String toString() {
             return "InputBoolean{"
-                    + "name='" + name() + '\''
-                    + ", label='" + label() + '\''
+                    + "id='" + id() + '\''
+                    + ", name='" + name() + '\''
                     + ", optional=" + isOptional()
                     + ", global=" + isGlobal()
                     + ", defaultValue='" + defaultValue + '\''
@@ -515,7 +526,7 @@ public abstract class Input extends Block {
     /**
      * Selection based input.
      */
-    public abstract static class Options extends NamedInput {
+    public abstract static class Options extends DeclaredInput {
 
         private Options(Input.Builder builder) {
             super(builder);
@@ -590,8 +601,8 @@ public abstract class Input extends Block {
         @Override
         public String toString() {
             return "InputList{"
-                    + "name='" + name() + '\''
-                    + ", label='" + label() + '\''
+                    + "id='" + id() + '\''
+                    + ", name='" + name() + '\''
                     + ", optional=" + isOptional()
                     + ", global=" + isGlobal()
                     + ", defaultValue='" + Arrays.toString(defaultValue) + '\''
@@ -624,9 +635,10 @@ public abstract class Input extends Block {
          * Get the index.
          *
          * @param optionName option name
+         * @param options    the options to process
          * @return index
          */
-        public int optionIndex(String optionName, java.util.List<Option> options) {
+        public static int optionIndex(String optionName, java.util.List<Option> options) {
             if (optionName == null) {
                 return -1;
             }
@@ -671,8 +683,8 @@ public abstract class Input extends Block {
         @Override
         public String toString() {
             return "InputEnum{"
-                    + "name='" + name() + '\''
-                    + ", label='" + label() + '\''
+                    + "id='" + id() + '\''
+                    + ", name='" + name() + '\''
                     + ", optional=" + isOptional()
                     + ", global=" + isGlobal()
                     + ", defaultValue='" + defaultValue + '\''

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Input.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Input.java
@@ -15,13 +15,13 @@
  */
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import io.helidon.build.archetype.engine.v2.InvalidInputException;
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
 
 import static java.util.Collections.emptyList;
 
@@ -490,6 +490,16 @@ public abstract class Input extends Block {
             }
         }
 
+        /**
+         * Return a string representation of the given boolean value.
+         *
+         * @param value value
+         * @return string representation or {@code null} if the given value is {@code null}
+         */
+        public static String asString(Value value) {
+            return value != null ? value.asBoolean() ? "yes" : "no" : null;
+        }
+
         @Override
         public String toString() {
             return "InputBoolean{"
@@ -507,11 +517,8 @@ public abstract class Input extends Block {
      */
     public abstract static class Options extends NamedInput {
 
-        private final java.util.List<Option> options;
-
         private Options(Input.Builder builder) {
             super(builder);
-            options = builder.children(Option.class);
         }
 
         /**
@@ -520,7 +527,22 @@ public abstract class Input extends Block {
          * @return options
          */
         public java.util.List<Option> options() {
-            return options;
+            return options(n -> true);
+        }
+
+        /**
+         * Get the options.
+         *
+         * @param predicate node predicate
+         * @return options
+         */
+        public java.util.List<Option> options(Predicate<Node> predicate) {
+            return children().stream()
+                             .filter(predicate)
+                             .map(Condition::unwrap)
+                             .filter(Option.class::isInstance)
+                             .map(Option.class::cast)
+                             .collect(Collectors.toList());
         }
 
         @Override
@@ -534,50 +556,17 @@ public abstract class Input extends Block {
      */
     public static final class List extends Options {
 
-        private final java.util.List<String> defaultValue;
+        private final String[] defaultValue;
 
         private List(Input.Builder builder) {
             super(builder);
-            defaultValue = builder.attribute("default", ValueTypes.STRING_LIST, emptyList());
-        }
-
-        /**
-         * Get the index.
-         *
-         * @param optionNames option names convert to indexes
-         * @return default indexes
-         */
-        public java.util.List<Integer> optionIndexes(java.util.List<String> optionNames) {
-            if (optionNames == null) {
-                return java.util.List.of();
-            }
-            java.util.List<Option> options = options();
-            return IntStream.range(0, options.size())
-                            .boxed()
-                            .filter(i -> containsIgnoreCase(optionNames, options.get(0).value))
-                            .collect(Collectors.toList());
-        }
-
-        /**
-         * Parse a response text.
-         *
-         * @param response response text
-         * @return response values
-         */
-        public java.util.List<String> parseResponse(String response) {
-            java.util.List<Option> options = options();
-            return Arrays.stream(response.trim().split("\\s+"))
-                         .map(Integer::parseInt)
-                         .distinct()
-                         .map(i -> options.get(i - 1))
-                         .map(Input.Option::value)
-                         .map(this::normalizeOptionValue)
-                         .collect(Collectors.toList());
+            defaultValue = builder.attribute("default", ValueTypes.STRING_LIST, emptyList())
+                                  .toArray(new String[0]);
         }
 
         @Override
         public Value defaultValue() {
-            return Value.create(defaultValue);
+            return Value.create(Arrays.asList(defaultValue));
         }
 
         @Override
@@ -605,11 +594,11 @@ public abstract class Input extends Block {
                     + ", label='" + label() + '\''
                     + ", optional=" + isOptional()
                     + ", global=" + isGlobal()
-                    + ", defaultValue='" + defaultValue + '\''
+                    + ", defaultValue='" + Arrays.toString(defaultValue) + '\''
                     + '}';
         }
 
-        private static boolean containsIgnoreCase(java.util.List<String> values, String expected) {
+        private static boolean containsIgnoreCase(Collection<String> values, String expected) {
             for (String optionName : values) {
                 if (optionName.equalsIgnoreCase(expected)) {
                     return true;
@@ -637,11 +626,10 @@ public abstract class Input extends Block {
          * @param optionName option name
          * @return index
          */
-        public int optionIndex(String optionName) {
+        public int optionIndex(String optionName, java.util.List<Option> options) {
             if (optionName == null) {
                 return -1;
             }
-            java.util.List<Option> options = options();
             return IntStream.range(0, options.size())
                             .boxed()
                             .filter(i -> optionName.equalsIgnoreCase(options.get(i).value))
@@ -657,7 +645,7 @@ public abstract class Input extends Block {
         @Override
         public void validate(Value value, String path) throws InvalidInputException {
             String option = value.asString();
-            if (optionIndex(option) == -1) {
+            if (optionIndex(option, options(n -> true)) == -1) {
                 throw new InvalidInputException(option, path);
             }
         }
@@ -695,14 +683,12 @@ public abstract class Input extends Block {
     /**
      * Create a new input block builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
-     * @param blockKind  block kind
+     * @param info      builder info
+     * @param blockKind block kind
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location, Kind blockKind) {
-        return new Builder(loader, scriptPath, location, blockKind);
+    public static Builder builder(BuilderInfo info, Kind blockKind) {
+        return new Builder(info, blockKind);
     }
 
     /**
@@ -710,8 +696,8 @@ public abstract class Input extends Block {
      */
     public static class Builder extends Block.Builder {
 
-        private Builder(ScriptLoader loader, Path scriptPath, Location location, Kind blockKind) {
-            super(loader, scriptPath, location, blockKind);
+        private Builder(BuilderInfo info, Kind blockKind) {
+            super(info, blockKind);
         }
 
         @Override

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Invocation.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Invocation.java
@@ -16,10 +16,7 @@
 
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
 import java.util.Objects;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
 
 /**
  * Invocation.
@@ -208,14 +205,12 @@ public abstract class Invocation extends Node {
     /**
      * Create a new builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
-     * @param kind       kind
+     * @param info builder info
+     * @param kind kind
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-        return new Builder(loader, scriptPath, location, kind);
+    public static Builder builder(BuilderInfo info, Kind kind) {
+        return new Builder(info, kind);
     }
 
     /**
@@ -225,8 +220,8 @@ public abstract class Invocation extends Node {
 
         private final Kind kind;
 
-        private Builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-            super(loader, scriptPath, location);
+        private Builder(BuilderInfo info, Kind kind) {
+            super(info);
             this.kind = kind;
         }
 

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Method.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Method.java
@@ -16,10 +16,6 @@
 
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
-
 /**
  * Method.
  */
@@ -56,13 +52,11 @@ public final class Method extends DeclaredBlock {
     /**
      * Create a new builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
+     * @param info builder info
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location) {
-        return new Builder(loader, scriptPath, location);
+    public static Builder builder(BuilderInfo info) {
+        return new Builder(info);
     }
 
     /**
@@ -70,8 +64,8 @@ public final class Method extends DeclaredBlock {
      */
     public static final class Builder extends Block.Builder {
 
-        private Builder(ScriptLoader loader, Path scriptPath, Location location) {
-            super(loader, scriptPath, location, Kind.METHOD);
+        private Builder(BuilderInfo info) {
+            super(info, Kind.METHOD);
         }
 
         @Override

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Model.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Model.java
@@ -15,10 +15,6 @@
  */
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
-
 /**
  * Model block.
  */
@@ -277,14 +273,12 @@ public abstract class Model extends Block {
     /**
      * Create a new model block builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
-     * @param kind       block kind
+     * @param info builder info
+     * @param kind block kind
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-        return new Builder(loader, scriptPath, location, kind);
+    public static Builder builder(BuilderInfo info, Kind kind) {
+        return new Builder(info, kind);
     }
 
     /**
@@ -294,8 +288,8 @@ public abstract class Model extends Block {
 
         private String value;
 
-        private Builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-            super(loader, scriptPath, location, kind);
+        private Builder(BuilderInfo info, Kind kind) {
+            super(info, kind);
         }
 
         @Override

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Node.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Node.java
@@ -36,15 +36,12 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class Node {
 
+    // TODO get the id from the script loader
     private static final AtomicInteger NEXT_ID = new AtomicInteger();
 
     private final int id;
     private final ScriptLoader loader;
     private final Path scriptPath;
-    // TODO use a "Location" that captures lineNo + charNo + original scriptPath
-    //  this will provide good stack traces even for compiled scripts
-    //  use workDir instead of scriptPath
-    //  use node.id() as the key in ScriptLoader
     private final Location location;
     private final Map<String, Value> attributes;
 
@@ -54,21 +51,19 @@ public abstract class Node {
      * @param builder builder
      */
     protected Node(Builder<?, ?> builder) {
-        this(builder.loader, builder.scriptPath, builder.location, builder.attributes);
+        this(builder.info, builder.attributes);
     }
 
     /**
      * Create a new node.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
+     * @param info       builder info
      * @param attributes attributes map
      */
-    protected Node(ScriptLoader loader, Path scriptPath, Location location, Map<String, Value> attributes) {
-        this.loader = requireNonNull(loader, "loader is null");
-        this.scriptPath = requireNonNull(scriptPath, "scriptPath is null");
-        this.location = requireNonNull(location, "location is null");
+    protected Node(BuilderInfo info, Map<String, Value> attributes) {
+        this.loader = info.loader;
+        this.scriptPath = info.scriptPath;
+        this.location = info.location;
         this.attributes = requireNonNull(attributes, "attributes is null");
         this.id = NEXT_ID.updateAndGet(i -> i == Integer.MAX_VALUE ? 1 : i + 1);
     }
@@ -132,6 +127,7 @@ public abstract class Node {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Node node = (Node) o;
+        //  TODO use both id and loader
         return id == node.id;
     }
 
@@ -265,6 +261,55 @@ public abstract class Node {
     }
 
     /**
+     * Builder info.
+     */
+    public static final class BuilderInfo {
+
+        private final ScriptLoader loader;
+        private final Path scriptPath;
+        private final Location location;
+
+        private BuilderInfo(ScriptLoader loader, Path scriptPath, Location location) {
+            this.loader = requireNonNull(loader, "loader is null");
+            this.scriptPath = requireNonNull(scriptPath, "scriptPath is null").toAbsolutePath().normalize();
+            this.location = location == null ? Location.of(scriptPath, 0, 0) : location;
+        }
+
+        /**
+         * Create a new builder info instance.
+         *
+         * @param loader     script loader
+         * @param scriptPath script path
+         * @return builder info
+         */
+        public static BuilderInfo of(ScriptLoader loader, Path scriptPath) {
+            return new BuilderInfo(loader, scriptPath, null);
+        }
+
+        /**
+         * Create a new builder info instance.
+         *
+         * @param loader     script loader
+         * @param scriptPath script path
+         * @param location   location
+         * @return builder info
+         */
+        public static BuilderInfo of(ScriptLoader loader, Path scriptPath, Location location) {
+            return new BuilderInfo(loader, scriptPath, location);
+        }
+
+        /**
+         * Create a new builder info instance.
+         *
+         * @param node node
+         * @return builder info
+         */
+        public static BuilderInfo of(Node node) {
+            return new BuilderInfo(node.loader, node.scriptPath, node.location);
+        }
+    }
+
+    /**
      * Node builder.
      *
      * @param <T> node sub-type
@@ -275,41 +320,26 @@ public abstract class Node {
 
         private final List<Node.Builder<? extends Node, ?>> children = new LinkedList<>();
         private final Map<String, Value> attributes = new HashMap<>();
-        private final ScriptLoader loader;
-        private final Path scriptPath;
-        private final Location location;
+        private final BuilderInfo info;
         private String value;
         private T instance;
 
         /**
          * Create a new node builder.
          *
-         * @param loader     script loader
-         * @param scriptPath script path
-         * @param location   location
+         * @param info builder info
          */
-        protected Builder(ScriptLoader loader, Path scriptPath, Location location) {
-            this.loader = requireNonNull(loader, "loader is null");
-            this.scriptPath = requireNonNull(scriptPath, "scriptPath is null").toAbsolutePath().normalize();
-            this.location = location == null ? Location.of(scriptPath, 0, 0) : location;
+        protected Builder(BuilderInfo info) {
+            this.info = requireNonNull(info, "info is null");
         }
 
         /**
-         * Get the script loader.
+         * Get the builder info.
          *
-         * @return ScriptLoader
+         * @return builder info
          */
-        public ScriptLoader loader() {
-            return loader;
-        }
-
-        /**
-         * Get the script path.
-         *
-         * @return Path
-         */
-        public Path scriptPath() {
-            return scriptPath;
+        public BuilderInfo info() {
+            return info;
         }
 
         /**
@@ -351,7 +381,8 @@ public abstract class Node {
          * @return children
          */
         public <V> Stream<V> childrenStream(Class<V> clazz) {
-            return children.stream().map(Node.Builder::build)
+            return children.stream()
+                           .map(Node.Builder::build)
                            .filter(clazz::isInstance)
                            .map(clazz::cast);
         }
@@ -423,8 +454,8 @@ public abstract class Node {
             if (value == null) {
                 if (required) {
                     throw new IllegalStateException(String.format(
-                            "Unable to get attribute '%s', file=%s, location=%s",
-                            key, scriptPath, location));
+                            "Unable to get attribute '%s', location=%s",
+                            key, info.location));
                 }
                 return Value.NULL;
             }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Node.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Node.java
@@ -39,7 +39,7 @@ public abstract class Node {
     // TODO get the id from the script loader
     private static final AtomicInteger NEXT_ID = new AtomicInteger();
 
-    private final int id;
+    private final int uid;
     private final ScriptLoader loader;
     private final Path scriptPath;
     private final Location location;
@@ -65,7 +65,7 @@ public abstract class Node {
         this.scriptPath = info.scriptPath;
         this.location = info.location;
         this.attributes = requireNonNull(attributes, "attributes is null");
-        this.id = NEXT_ID.updateAndGet(i -> i == Integer.MAX_VALUE ? 1 : i + 1);
+        this.uid = NEXT_ID.updateAndGet(i -> i == Integer.MAX_VALUE ? 1 : i + 1);
     }
 
     /**
@@ -114,12 +114,12 @@ public abstract class Node {
     }
 
     /**
-     * Get the node id.
+     * Get the unique id.
      *
      * @return id
      */
-    public int nodeId() {
-        return id;
+    public int uid() {
+        return uid;
     }
 
     @Override
@@ -128,12 +128,12 @@ public abstract class Node {
         if (o == null || getClass() != o.getClass()) return false;
         Node node = (Node) o;
         //  TODO use both id and loader
-        return id == node.id;
+        return uid == node.uid;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(uid);
     }
 
     /**

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Output.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Output.java
@@ -15,10 +15,7 @@
  */
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
 import java.util.List;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
 
 import static java.util.Collections.emptyList;
 
@@ -517,14 +514,12 @@ public abstract class Output extends Block {
     /**
      * Create a new Output block builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
-     * @param kind       block kind
+     * @param info builder info
+     * @param kind block kind
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-        return new Builder(loader, scriptPath, location, kind);
+    public static Builder builder(BuilderInfo info, Kind kind) {
+        return new Builder(info, kind);
     }
 
     /**
@@ -532,16 +527,8 @@ public abstract class Output extends Block {
      */
     public static class Builder extends Block.Builder {
 
-        /**
-         * Create a new output builder.
-         *
-         * @param loader     script loader
-         * @param scriptPath script path
-         * @param location   location
-         * @param kind       kind
-         */
-        Builder(ScriptLoader loader, Path scriptPath, Location location, Kind kind) {
-            super(loader, scriptPath, location, kind);
+        private Builder(BuilderInfo info, Kind kind) {
+            super(info, kind);
         }
 
         @Override

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Script.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Script.java
@@ -16,11 +16,8 @@
 
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
 
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toUnmodifiableMap;
@@ -61,12 +58,11 @@ public final class Script extends DeclaredBlock {
     /**
      * Create a new builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
+     * @param info builder info
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath) {
-        return new Builder(loader, scriptPath);
+    public static Builder builder(BuilderInfo info) {
+        return new Builder(info);
     }
 
     /**
@@ -74,8 +70,8 @@ public final class Script extends DeclaredBlock {
      */
     public static final class Builder extends Block.Builder {
 
-        private Builder(ScriptLoader loader, Path scriptPath) {
-            super(loader, scriptPath, null, Kind.SCRIPT);
+        private Builder(BuilderInfo info) {
+            super(info, Kind.SCRIPT);
         }
 
         @Override

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Step.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Step.java
@@ -16,10 +16,6 @@
 
 package io.helidon.build.archetype.engine.v2.ast;
 
-import java.nio.file.Path;
-
-import io.helidon.build.archetype.engine.v2.ScriptLoader;
-
 /**
  * Step.
  */
@@ -84,13 +80,11 @@ public class Step extends Block {
     /**
      * Create a new Step block builder.
      *
-     * @param loader     script loader
-     * @param scriptPath script path
-     * @param location   location
+     * @param info builder info
      * @return builder
      */
-    public static Builder builder(ScriptLoader loader, Path scriptPath, Location location) {
-        return new Builder(loader, scriptPath, location);
+    public static Builder builder(BuilderInfo info) {
+        return new Builder(info);
     }
 
     /**
@@ -98,8 +92,8 @@ public class Step extends Block {
      */
     public static final class Builder extends Block.Builder {
 
-        private Builder(ScriptLoader loader, Path scriptPath, Location location) {
-            super(loader, scriptPath, location, Kind.STEP);
+        private Builder(BuilderInfo info) {
+            super(info, Kind.STEP);
         }
 
         @Override

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Step.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Step.java
@@ -21,24 +21,24 @@ package io.helidon.build.archetype.engine.v2.ast;
  */
 public class Step extends Block {
 
-    private final String label;
+    private final String name;
     private final String help;
     private final boolean optional;
 
     private Step(Builder builder) {
         super(builder);
-        label = builder.attribute("label", false).asString();
+        name = builder.attribute("name", false).asString();
         help = builder.attribute("help", false).asString();
         optional = builder.attribute("optional", false).asBoolean();
     }
 
     /**
-     * Get the step label.
+     * Get the step name.
      *
      * @return name
      */
-    public String label() {
-        return label;
+    public String name() {
+        return name;
     }
 
     /**
@@ -72,7 +72,7 @@ public class Step extends Block {
     @Override
     public String toString() {
         return "Step{"
-                + "label='" + label() + '\''
+                + "name='" + name() + '\''
                 + ", optional=" + isOptional()
                 + '}';
     }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Variable.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Variable.java
@@ -19,25 +19,38 @@ package io.helidon.build.archetype.engine.v2.ast;
 import java.util.List;
 
 /**
- * Preset.
+ * Variable.
  */
-public final class Preset extends DeclaredValue {
+public final class Variable extends DeclaredValue {
 
-    private Preset(DeclaredValue.Builder builder, List<String> values) {
+    private final boolean isTransient;
+
+    private Variable(DeclaredValue.Builder builder, List<String> values) {
         super(builder, values);
+        this.isTransient = builder.attribute("transient", false).asBoolean();
+    }
+
+    /**
+     * Test if this preset is transient.
+     *
+     * @return {@code true} if transient, {@code false} otherwise
+     */
+    public boolean isTransient() {
+        return isTransient;
     }
 
     @Override
     public String toString() {
-        return "Preset{"
+        return "Variable{"
                 + "path='" + path() + '\''
+                + ", transient=" + isTransient + '\''
                 + ", value=" + value() + '\''
                 + '}';
     }
 
     @Override
-    public <A> VisitResult accept(Block.Visitor<A> visitor, A arg) {
-        return visitor.visitPreset(this, arg);
+    public <A> VisitResult accept(Visitor<A> visitor, A arg) {
+        return visitor.visitVariable(this, arg);
     }
 
     /**
@@ -47,22 +60,22 @@ public final class Preset extends DeclaredValue {
      * @param kind kind
      * @return builder
      */
-    public static Builder builder(BuilderInfo info, Block.Kind kind) {
+    public static Builder builder(BuilderInfo info, Kind kind) {
         return new Builder(info, kind);
     }
 
     /**
-     * Preset builder.
+     * Variable builder.
      */
     public static final class Builder extends DeclaredValue.Builder {
 
-        private Builder(BuilderInfo info, Block.Kind kind) {
+        private Builder(BuilderInfo info, Kind kind) {
             super(info, kind);
         }
 
         @Override
         protected DeclaredValue doBuild(DeclaredValue.Builder builder, List<String> values) {
-            return new Preset(builder, values);
+            return new Variable(builder, values);
         }
     }
 }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/ClientCompiler.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/ClientCompiler.java
@@ -131,11 +131,7 @@ public class ClientCompiler implements Node.Visitor<Script> {
                     }
                 } else {
                     String value = String.valueOf(declaredValue.value().unwrap());
-                    if (kind == Block.Kind.ENUM) {
-                        builder.value(value);
-                    } else {
-                        builder.addChild(Block.builder(builderInfo, Block.Kind.VALUE).value(value));
-                    }
+                    builder.value(value);
                 }
             } else if (block instanceof Step) {
                 builder = Step.builder(builderInfo(block));
@@ -177,7 +173,7 @@ public class ClientCompiler implements Node.Visitor<Script> {
 
     private String methodName(DeclaredBlock block) {
         if (obfuscate) {
-            return String.valueOf(block.nodeId());
+            return String.valueOf(block.uid());
         } else {
             return block.blockName();
         }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/ClientPredicate.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/ClientPredicate.java
@@ -18,7 +18,6 @@ package io.helidon.build.archetype.engine.v2.util;
 
 import io.helidon.build.archetype.engine.v2.ast.Block;
 import io.helidon.build.archetype.engine.v2.ast.Node;
-import io.helidon.build.archetype.engine.v2.ast.Preset;
 import io.helidon.build.archetype.engine.v2.ast.Variable;
 
 /**

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/ClientPredicate.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/ClientPredicate.java
@@ -19,6 +19,7 @@ package io.helidon.build.archetype.engine.v2.util;
 import io.helidon.build.archetype.engine.v2.ast.Block;
 import io.helidon.build.archetype.engine.v2.ast.Node;
 import io.helidon.build.archetype.engine.v2.ast.Preset;
+import io.helidon.build.archetype.engine.v2.ast.Variable;
 
 /**
  * Client predicate.
@@ -46,8 +47,8 @@ public final class ClientPredicate implements Node.Visitor<Void>, Block.Visitor<
     }
 
     @Override
-    public Node.VisitResult visitPreset(Preset preset, Void arg) {
-        if (preset.isTransient()) {
+    public Node.VisitResult visitVariable(Variable variable, Void arg) {
+        if (variable.isTransient()) {
             return Node.VisitResult.TERMINATE;
         }
         return Node.VisitResult.CONTINUE;

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputCombinations.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputCombinations.java
@@ -125,6 +125,7 @@ public class InputCombinations implements Iterable<Map<String, String>> {
          *
          * @return The count.
          */
+        @SuppressWarnings("unused")
         int iterations() {
             return iterations;
         }
@@ -235,6 +236,7 @@ public class InputCombinations implements Iterable<Map<String, String>> {
          * @param listCombiner The list combiner.
          * @return This instance, for chaining.
          */
+        @SuppressWarnings("unused")
         public Builder listCombiner(BiFunction<List<String>, List<String>, List<List<String>>> listCombiner) {
             builder.listCombiner(listCombiner);
             return this;

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputCombinations.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputCombinations.java
@@ -17,13 +17,14 @@ package io.helidon.build.archetype.engine.v2.util;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import io.helidon.build.archetype.engine.v2.util.InputTree.Node;
 import io.helidon.build.archetype.engine.v2.util.InputTree.NodeIndex;
@@ -50,6 +51,15 @@ public class InputCombinations implements Iterable<Map<String, String>> {
         this.verbose = verbose;
     }
 
+    /**
+     * Collect all the combinations as a list.
+     *
+     * @return list of combinations
+     */
+    public List<Map<String, String>> toList() {
+        return StreamSupport.stream(spliterator(), false).collect(Collectors.toList());
+    }
+
     @Override
     public Iterator<Map<String, String>> iterator() {
         return new CombinationsIterator(tree, verbose);
@@ -58,8 +68,6 @@ public class InputCombinations implements Iterable<Map<String, String>> {
     private static class CombinationsIterator implements Iterator<Map<String, String>> {
         private final Node root;
         private final boolean verbose;
-        private final Map<String, String> combinations;
-        private final Map<String, String> immutableCombinations;
         private final List<Node> currentInputs;
         private int iterations;
         private int currentIndex;
@@ -68,8 +76,6 @@ public class InputCombinations implements Iterable<Map<String, String>> {
         private CombinationsIterator(InputTree tree, boolean verbose) {
             this.root = tree.root();
             this.verbose = verbose;
-            this.combinations = new LinkedHashMap<>();
-            this.immutableCombinations = Collections.unmodifiableMap(combinations);
             this.currentInputs = root.collectCurrentInputs(new ArrayList<>());
             this.currentLeafNode = getLeafInput();
             if (verbose) {
@@ -89,6 +95,7 @@ public class InputCombinations implements Iterable<Map<String, String>> {
 
                 // Collect
 
+                Map<String, String> combinations = new LinkedHashMap<>();
                 root.collect(combinations);
 
                 // Advance the current leaf node. Did we complete it?
@@ -105,7 +112,7 @@ public class InputCombinations implements Iterable<Map<String, String>> {
 
                         // Yep
 
-                        return immutableCombinations;
+                        return combinations;
                     }
 
                     // No, so update current inputs
@@ -113,7 +120,7 @@ public class InputCombinations implements Iterable<Map<String, String>> {
                     updateCurrentInputs();
                 }
 
-                return immutableCombinations;
+                return combinations;
 
             } else {
                 throw new NoSuchElementException(root.children().get(0).script().toString() + ": iteration completed");

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputTree.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputTree.java
@@ -1093,7 +1093,7 @@ public class InputTree {
         public VisitResult visitPreset(Preset preset, Context ctx) {
             String path = preset.path();
             Value value = preset.value();
-            ctx.put(path, value, true);
+            ctx.put(path, value, false);
 
             PresetNode presets = (PresetNode) builder.current();
             presets.add(path, asString(value));

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputTree.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputTree.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.helidon.build.archetype.engine.v2.Context;
+import io.helidon.build.archetype.engine.v2.ContextValue;
 import io.helidon.build.archetype.engine.v2.ScriptLoader;
 import io.helidon.build.archetype.engine.v2.UnresolvedInputException;
 import io.helidon.build.archetype.engine.v2.VisitorAdapter;
@@ -42,7 +43,7 @@ import io.helidon.build.archetype.engine.v2.Walker;
 import io.helidon.build.archetype.engine.v2.ast.Block;
 import io.helidon.build.archetype.engine.v2.ast.Condition;
 import io.helidon.build.archetype.engine.v2.ast.Input;
-import io.helidon.build.archetype.engine.v2.ast.Input.NamedInput;
+import io.helidon.build.archetype.engine.v2.ast.Input.DeclaredInput;
 import io.helidon.build.archetype.engine.v2.ast.Location;
 import io.helidon.build.archetype.engine.v2.ast.Node.VisitResult;
 import io.helidon.build.archetype.engine.v2.ast.Preset;
@@ -1093,7 +1094,7 @@ public class InputTree {
         public VisitResult visitPreset(Preset preset, Context ctx) {
             String path = preset.path();
             Value value = preset.value();
-            ctx.put(path, value, false);
+            ctx.setValue(path, value, ContextValue.ValueKind.DEFAULT);
 
             PresetNode presets = (PresetNode) builder.current();
             presets.add(path, asString(value));
@@ -1102,7 +1103,7 @@ public class InputTree {
 
         @Override
         public VisitResult visitVariable(Variable variable, Context ctx) {
-            ctx.put(variable.path(), variable.value(), false);
+            ctx.setVariable(variable.path(), variable.value());
             return VisitResult.CONTINUE;
         }
 
@@ -1126,7 +1127,7 @@ public class InputTree {
                 ctx.pushCwd(block.scriptPath().getParent());
                 return VisitResult.CONTINUE;
             } else if (block.kind() == Block.Kind.PRESETS) {
-                builder.pushPresets(ctx.path(), block.scriptPath(), block.location());
+                builder.pushPresets(ctx.peekScope().id(), block.scriptPath(), block.location());
             }
             return super.visitBlock(block, ctx);
         }
@@ -1154,12 +1155,10 @@ public class InputTree {
                 this.builder = builder;
             }
 
-            String push(NamedInput input, Context context) {
-                String path = context.path(input.name());
-                if (!input.isGlobal()) {
-                    context.push(path, false);
-                }
-                return path;
+            String push(DeclaredInput input, Context context) {
+                Context.Scope scope = context.newScope(input.id(), input.isGlobal());
+                context.pushScope(scope);
+                return scope.id();
             }
 
             @Override
@@ -1173,7 +1172,7 @@ public class InputTree {
 
             @Override
             public VisitResult visitText(Input.Text input, Context context) {
-                String path = context.path(input.name());
+                String path = push(input, context);
                 String defaultValue = builder.externalDefault(path);
                 if (defaultValue == null) {
                     defaultValue = input.defaultValue().asString();
@@ -1183,7 +1182,6 @@ public class InputTree {
                         throw new UnresolvedInputException("text '" + path + "' requires a default value");
                     }
                 }
-                push(input, context);
                 builder.pushInput(Kind.TEXT, path, input.scriptPath(), input.location());
                 builder.pushValue(defaultValue, input.scriptPath(), input.location());
                 return VisitResult.CONTINUE;
@@ -1198,7 +1196,7 @@ public class InputTree {
 
             @Override
             public VisitResult visitList(Input.List input, Context context) {
-                String path = context.path(input.name());
+                String path = push(input, context);
                 List<String> defaultValues;
                 String defaultValue = builder.externalDefault(path);
                 if (defaultValue == null) {
@@ -1208,7 +1206,6 @@ public class InputTree {
                                           .filter(v -> !v.isEmpty())
                                           .collect(Collectors.toList());
                 }
-                path = push(input, context);
                 builder.pushInputList(path, defaultValues, input.scriptPath(), input.location());
                 return VisitResult.CONTINUE;
             }
@@ -1243,10 +1240,8 @@ public class InputTree {
                     default:
                         throw new IllegalStateException("unknown kind: " + input.kind());
                 }
-                if (input instanceof NamedInput) {
-                    if (!((NamedInput) input).isGlobal()) {
-                        context.pop();
-                    }
+                if (input instanceof DeclaredInput) {
+                    context.popScope();
                 }
                 return VisitResult.CONTINUE;
             }

--- a/archetype/engine-v2/src/main/schema/archetype.xsd
+++ b/archetype/engine-v2/src/main/schema/archetype.xsd
@@ -729,12 +729,23 @@
         </xs:simpleContent>
     </xs:complexType>
 
-    <xs:attributeGroup name="label-group">
-        <xs:attribute name="label" type="xs:string" use="required">
+    <xs:attributeGroup name="name-group">
+        <xs:attribute name="name" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation source="version">2.0</xs:documentation>
                 <xs:documentation source="description">
-                    Label: title for step or input components.
+                    Human readable name for step or input components.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="desc-group">
+        <xs:attribute name="description" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation source="version">2.0</xs:documentation>
+                <xs:documentation source="description">
+                    Input description (single line).
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -777,11 +788,11 @@
     </xs:group>
 
     <xs:attributeGroup name="input-group">
-        <xs:attribute name="name" use="required">
+        <xs:attribute name="id" use="required">
             <xs:annotation>
                 <xs:documentation source="version">2.0</xs:documentation>
                 <xs:documentation source="description">
-                    The input name. Must be unique among siblings.
+                    The input id. Must be unique among siblings.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -789,7 +800,7 @@
             <xs:annotation>
                 <xs:documentation source="version">2.0</xs:documentation>
                 <xs:documentation source="description">
-                    The prompt for this input. Defaults to the label if not defined.
+                    The prompt for this input. Defaults to the name if not defined.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -801,7 +812,8 @@
             <xs:element name="help" type="a:help-type" minOccurs="0"/>
         </xs:sequence>
         <xs:attributeGroup ref="a:input-group"/>
-        <xs:attributeGroup ref="a:label-group"/>
+        <xs:attributeGroup ref="a:name-group"/>
+        <xs:attributeGroup ref="a:desc-group"/>
         <xs:attributeGroup ref="a:optional-group"/>
         <xs:attributeGroup ref="a:global-group"/>
         <xs:attribute name="default" type="xs:string">
@@ -821,7 +833,8 @@
             <xs:element name="output" type="a:output-type" minOccurs="0"/>
         </xs:sequence>
         <xs:attributeGroup ref="a:input-group"/>
-        <xs:attributeGroup ref="a:label-group"/>
+        <xs:attributeGroup ref="a:name-group"/>
+        <xs:attributeGroup ref="a:desc-group"/>
         <xs:attributeGroup ref="a:optional-group"/>
         <xs:attributeGroup ref="a:global-group"/>
         <xs:attribute name="default" type="xs:boolean">
@@ -853,14 +866,16 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attributeGroup ref="a:label-group"/>
+                        <xs:attributeGroup ref="a:name-group"/>
+                        <xs:attributeGroup ref="a:desc-group"/>
                         <xs:attributeGroup ref="a:if-group"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
         </xs:sequence>
         <xs:attributeGroup ref="a:input-group"/>
-        <xs:attributeGroup ref="a:label-group"/>
+        <xs:attributeGroup ref="a:name-group"/>
+        <xs:attributeGroup ref="a:desc-group"/>
         <xs:attributeGroup ref="a:optional-group"/>
         <xs:attributeGroup ref="a:global-group"/>
         <xs:attribute name="default" type="xs:string">
@@ -892,7 +907,8 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attributeGroup ref="a:label-group"/>
+                        <xs:attributeGroup ref="a:name-group"/>
+                        <xs:attributeGroup ref="a:desc-group"/>
                         <xs:attributeGroup ref="a:if-group"/>
                     </xs:complexType>
                 </xs:element>
@@ -901,7 +917,8 @@
         <xs:attributeGroup ref="a:optional-group"/>
         <xs:attributeGroup ref="a:global-group"/>
         <xs:attributeGroup ref="a:input-group"/>
-        <xs:attributeGroup ref="a:label-group"/>
+        <xs:attributeGroup ref="a:name-group"/>
+        <xs:attributeGroup ref="a:desc-group"/>
         <xs:attribute name="default" type="xs:string">
             <xs:annotation>
                 <xs:documentation source="version">2.0</xs:documentation>
@@ -959,7 +976,7 @@
             <xs:element name="output" type="a:output-type" minOccurs="0"/>
         </xs:sequence>
         <xs:attributeGroup ref="a:if-group"/>
-        <xs:attributeGroup ref="a:label-group"/>
+        <xs:attributeGroup ref="a:name-group"/>
         <xs:attributeGroup ref="a:optional-group"/>
     </xs:complexType>
 

--- a/archetype/engine-v2/src/main/schema/archetype.xsd
+++ b/archetype/engine-v2/src/main/schema/archetype.xsd
@@ -171,15 +171,15 @@
             <xs:annotation>
                 <xs:documentation source="version">2.0</xs:documentation>
                 <xs:documentation source="description">
-                    Flow context path expression to guard this element.
+                    Expression to guard this element.
                     <br/>
                     <br/>
                     <p>
-                        Flow context path expressions are boolean expressions that can be used to query the flow
-                        context.
+                        Expressions are boolean expressions that can be used to query the context.
                         <br/>
                         <br/>
-                        Values can be either flow context path values or literal, and are only of the following types:
+                        Values can be either context values (<code>${path}</code>) or literal, and are only of the
+                        following types:
                     </p>
                     <ul>
                         <li><b>Boolean</b>: <code>true</code> or
@@ -260,7 +260,7 @@
                     <br/>
                     <br/>
                     <p>
-                        The template data model is shared across the flow. The key identifies the data to set.
+                        The template data model is shared. The key identifies the data to set.
 
                         The key is the identifier used when resolving data from a template. The syntax for
                         resolving data from a template is template specific. E.g. in mustache: <code>{{my-key}}</code>.
@@ -440,16 +440,27 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:attributeGroup name="preset-attribute-group">
+    <xs:attributeGroup name="transient-attribute-group">
+        <xs:attribute name="transient" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation source="version">2.0</xs:documentation>
+                <xs:documentation source="description">
+                    Indicate if a variable should be serialized to a client.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="context-attribute-group">
         <xs:attribute name="path" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation source="version">2.0</xs:documentation>
                 <xs:documentation source="description">
-                    The flow context path of the input whose value is to be set.
+                    The path of the input whose value is to be set.
                     <br/>
                     <br/>
                     <p>
-                        A path can be used to point at a node in the flow context. Path members are separated with a
+                        A path can be used to point at a node in the context. Path members are separated with a
                         dot (<code>.</code>) character.
                     </p>
                     <br/>
@@ -484,43 +495,28 @@
                             <code>${provider}</code>
                             is resolved as
                             <code>${flavor.base.security.provider}</code>
-                            if the current flow context node is
+                            if the current context node is
                             <code>flavor.base.security</code>
                         </li>
                         <li>
                             <code>${PARENT.security.provider}</code>
                             is resolved as
                             <code>${flavor.base.security.provider}</code>
-                            if the parent of the current flow context node is
+                            if the parent of the current context node is
                             <code>flavor.base.security</code>
                         </li>
                     </ul>
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="resolvable" type="xs:boolean">
-            <xs:annotation>
-                <xs:documentation source="version">2.0</xs:documentation>
-                <xs:documentation source="description">
-                    Indicate if a preset path can be resolved to an input.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="transient" type="xs:boolean">
-            <xs:annotation>
-                <xs:documentation source="version">2.0</xs:documentation>
-                <xs:documentation source="description">
-                    Indicate if a preset should be serialized to a client.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
+        <xs:attributeGroup ref="a:if-group"/>
     </xs:attributeGroup>
 
-    <xs:complexType name="presets-type">
+    <xs:complexType name="variables-type">
         <xs:annotation>
             <xs:documentation source="version">2.0</xs:documentation>
             <xs:documentation source="description">
-                Define a read-only value for an input.
+                Define a variable.
             </xs:documentation>
         </xs:annotation>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -534,7 +530,8 @@
                     </xs:annotation>
                     <xs:simpleContent>
                         <xs:extension base="xs:boolean">
-                            <xs:attributeGroup ref="a:preset-attribute-group"/>
+                            <xs:attributeGroup ref="a:context-attribute-group"/>
+                            <xs:attributeGroup ref="a:transient-attribute-group"/>
                         </xs:extension>
                     </xs:simpleContent>
                 </xs:complexType>
@@ -549,7 +546,8 @@
                     </xs:annotation>
                     <xs:simpleContent>
                         <xs:extension base="xs:string">
-                            <xs:attributeGroup ref="a:preset-attribute-group"/>
+                            <xs:attributeGroup ref="a:context-attribute-group"/>
+                            <xs:attributeGroup ref="a:transient-attribute-group"/>
                         </xs:extension>
                     </xs:simpleContent>
                 </xs:complexType>
@@ -564,7 +562,8 @@
                     </xs:annotation>
                     <xs:simpleContent>
                         <xs:extension base="xs:string">
-                            <xs:attributeGroup ref="a:preset-attribute-group"/>
+                            <xs:attributeGroup ref="a:context-attribute-group"/>
+                            <xs:attributeGroup ref="a:transient-attribute-group"/>
                         </xs:extension>
                     </xs:simpleContent>
                 </xs:complexType>
@@ -584,7 +583,82 @@
                             </xs:simpleType>
                         </xs:element>
                     </xs:sequence>
-                    <xs:attributeGroup ref="a:preset-attribute-group"/>
+                    <xs:attributeGroup ref="a:context-attribute-group"/>
+                    <xs:attributeGroup ref="a:transient-attribute-group"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="presets-type">
+        <xs:annotation>
+            <xs:documentation source="version">2.0</xs:documentation>
+            <xs:documentation source="description">
+                Define a read-only value for an input.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="boolean">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation source="version">2.0</xs:documentation>
+                        <xs:documentation source="description">
+                            Define a boolean value.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:boolean">
+                            <xs:attributeGroup ref="a:context-attribute-group"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="text">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation source="version">2.0</xs:documentation>
+                        <xs:documentation source="description">
+                            Define a text value.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attributeGroup ref="a:context-attribute-group"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="enum">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation source="version">2.0</xs:documentation>
+                        <xs:documentation source="description">
+                            Define an enum value.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attributeGroup ref="a:context-attribute-group"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="list">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation source="version">2.0</xs:documentation>
+                        <xs:documentation source="description">
+                            Define a list value.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="value">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string"/>
+                            </xs:simpleType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="a:context-attribute-group"/>
                 </xs:complexType>
             </xs:element>
         </xs:choice>
@@ -692,6 +766,7 @@
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element name="presets" type="a:presets-type"/>
+                <xs:element name="variables" type="a:variables-type"/>
                 <xs:element name="exec" type="a:exec-type"/>
                 <xs:element name="source" type="a:source-type"/>
                 <xs:element name="call" type="a:call-type"/>
@@ -718,6 +793,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attributeGroup ref="a:if-group"/>
     </xs:attributeGroup>
 
     <xs:complexType name="text-input-type">
@@ -769,7 +845,7 @@
                             <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
                             <xs:element name="output" type="a:output-type" minOccurs="0"/>
                         </xs:sequence>
-                        <xs:attribute name="value" type="xs:string">
+                        <xs:attribute name="value" type="xs:string" use="required">
                             <xs:annotation>
                                 <xs:documentation source="version">2.0</xs:documentation>
                                 <xs:documentation source="description">
@@ -778,6 +854,7 @@
                             </xs:annotation>
                         </xs:attribute>
                         <xs:attributeGroup ref="a:label-group"/>
+                        <xs:attributeGroup ref="a:if-group"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
@@ -807,7 +884,7 @@
                             <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
                             <xs:element name="output" type="a:output-type" minOccurs="0"/>
                         </xs:sequence>
-                        <xs:attribute name="value" type="xs:string">
+                        <xs:attribute name="value" type="xs:string" use="required">
                             <xs:annotation>
                                 <xs:documentation source="version">2.0</xs:documentation>
                                 <xs:documentation source="description">
@@ -816,6 +893,7 @@
                             </xs:annotation>
                         </xs:attribute>
                         <xs:attributeGroup ref="a:label-group"/>
+                        <xs:attributeGroup ref="a:if-group"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
@@ -872,6 +950,7 @@
             <xs:element name="help" type="a:help-type" minOccurs="0"/>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element name="presets" type="a:presets-type"/>
+                <xs:element name="variables" type="a:variables-type"/>
                 <xs:element name="exec" type="a:exec-type"/>
                 <xs:element name="source" type="a:source-type"/>
                 <xs:element name="call" type="a:call-type"/>

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2Test.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2Test.java
@@ -41,8 +41,7 @@ class ArchetypeEngineV2Test {
     @Test
     void testExternalDefault() {
         Path outputDir = e2eDir("testExternalDefault",
-                Map.of(
-                        "theme", "colors",
+                Map.of("theme", "colors",
                         "theme.base", "rainbow"),
                 Map.of("artifactId", "foo"));
         assertThat(outputDir.getFileName().toString(), startsWith("foo"));
@@ -163,8 +162,7 @@ class ArchetypeEngineV2Test {
     @Test
     void testExternalDefaultZip() throws IOException {
         Path outputDir = e2eZip("testExternalDefaultZip",
-                Map.of(
-                        "theme", "colors",
+                Map.of("theme", "colors",
                         "theme.base", "rainbow"),
                 Map.of("artifactId", "not-bar"));
         assertThat(outputDir.getFileName().toString(), startsWith("not-bar"));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/BatchInputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/BatchInputResolverTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.helidon.build.archetype.engine.v2.TestHelper.inputEnum;
 import static io.helidon.build.archetype.engine.v2.TestHelper.inputOption;
+import static io.helidon.build.archetype.engine.v2.TestHelper.step;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -35,8 +36,9 @@ public class BatchInputResolverTest {
 
     @Test
     void testInputEnumWithSingleOptionAndDefault() {
-        Block block = inputEnum("enum-input1", "value1",
-                inputOption("option1", "value1")).build();
+        Block block = step("step",
+                inputEnum("enum-input1", "value1",
+                        inputOption("option1", "value1"))).build();
 
         Context context = Context.create();
         Controller.walk(new BatchInputResolver(), block, context);

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ContextTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ContextTest.java
@@ -17,6 +17,7 @@ package io.helidon.build.archetype.engine.v2;
 
 import java.util.Map;
 
+import io.helidon.build.archetype.engine.v2.ContextValue.ValueKind;
 import io.helidon.build.archetype.engine.v2.ast.Value;
 
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ class ContextTest {
         Context context = Context.create();
         Context.Scope scope = context.newScope("foo", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.create("foo-value"), ValueKind.EXTERNAL);
 
         Value value;
 
@@ -66,13 +67,13 @@ class ContextTest {
         Context.Scope scope;
         scope = context.newScope("foo", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.TRUE, ValueKind.EXTERNAL);
         scope = context.newScope("bar", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.TRUE, ValueKind.EXTERNAL);
         scope = context.newScope("color", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.create("blue"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.create("blue"), ValueKind.EXTERNAL);
         context.popScope();
         Value value = context.lookup("color");
         assertThat(value, is(notNullValue()));
@@ -80,9 +81,23 @@ class ContextTest {
     }
 
     @Test
+    void testLookupGlobal() {
+        Context context = Context.create();
+        Context.Scope scope;
+        scope = context.newScope("foo", true);
+        context.pushScope(scope);
+        context.setValue("bar", Value.create("foo-value"), ValueKind.EXTERNAL);
+
+        Value value;
+        value = context.lookup("bar");
+        assertThat(value, is(notNullValue()));
+        assertThat(value.asString(), is("foo-value"));
+    }
+
+    @Test
     void testLookupInternalOnly() {
         Context context = Context.create();
-        context.setValue("foo", Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue("foo", Value.create("foo-value"), ValueKind.EXTERNAL);
 
         Value value;
 
@@ -113,10 +128,10 @@ class ContextTest {
         Context.Scope scope;
         scope = context.newScope("foo", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.create("foo-value"), ValueKind.EXTERNAL);
         scope = context.newScope("bar", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.create("bar-value"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.create("bar-value"), ValueKind.EXTERNAL);
 
         Value value;
 
@@ -156,10 +171,10 @@ class ContextTest {
         Context.Scope scope;
         scope = context.newScope("foo", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.create("foo-value"), ValueKind.EXTERNAL);
         scope = context.newScope("bar", false);
         context.pushScope(scope);
-        context.setValue(scope.id(), Value.create("bar-value"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue(scope.id(), Value.create("bar-value"), ValueKind.EXTERNAL);
         context.popScope();
 
         Value value;

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ContextTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ContextTest.java
@@ -34,7 +34,7 @@ class ContextTest {
     @Test
     void testLookup() {
         Context context = Context.create();
-        context.push("foo", Value.create("foo-value"), false);
+        context.push("foo", Value.create("foo-value"), false, true);
 
         Value value;
 
@@ -61,9 +61,9 @@ class ContextTest {
     @Test
     void testLookupInScope() {
         Context context = Context.create();
-        context.push("foo", Value.TRUE, false);
-        context.push("bar", Value.TRUE, false);
-        context.push("color", Value.create("blue"), false);
+        context.push("foo", Value.TRUE, false, true);
+        context.push("bar", Value.TRUE, false, true);
+        context.push("color", Value.create("blue"), false, true);
         context.pop();
         Value value = context.lookup("color");
         assertThat(value, is(notNullValue()));
@@ -73,7 +73,7 @@ class ContextTest {
     @Test
     void testLookupInternalOnly() {
         Context context = Context.create();
-        context.put("foo", Value.create("foo-value"));
+        context.put("foo", Value.create("foo-value"), true);
 
         Value value;
 
@@ -101,8 +101,8 @@ class ContextTest {
     @Test
     void testRelativeLookup() {
         Context context = Context.create();
-        context.push("foo", Value.create("foo-value"), false);
-        context.push("bar", Value.create("bar-value"), false);
+        context.push("foo", Value.create("foo-value"), false, true);
+        context.push("bar", Value.create("bar-value"), false, true);
 
         Value value;
 
@@ -139,8 +139,8 @@ class ContextTest {
     @Test
     void testPopInput() {
         Context context = Context.create();
-        context.push("foo", Value.create("foo-value"), false);
-        context.push("bar", Value.create("bar-value"), false);
+        context.push("foo", Value.create("foo-value"), false, true);
+        context.push("bar", Value.create("bar-value"), false, true);
         context.pop();
 
         Value value;

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ContextTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ContextTest.java
@@ -34,7 +34,9 @@ class ContextTest {
     @Test
     void testLookup() {
         Context context = Context.create();
-        context.push("foo", Value.create("foo-value"), false, true);
+        Context.Scope scope = context.newScope("foo", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
 
         Value value;
 
@@ -61,10 +63,17 @@ class ContextTest {
     @Test
     void testLookupInScope() {
         Context context = Context.create();
-        context.push("foo", Value.TRUE, false, true);
-        context.push("bar", Value.TRUE, false, true);
-        context.push("color", Value.create("blue"), false, true);
-        context.pop();
+        Context.Scope scope;
+        scope = context.newScope("foo", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        scope = context.newScope("bar", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        scope = context.newScope("color", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.create("blue"), ContextValue.ValueKind.EXTERNAL);
+        context.popScope();
         Value value = context.lookup("color");
         assertThat(value, is(notNullValue()));
         assertThat(value.asString(), is("blue"));
@@ -73,7 +82,7 @@ class ContextTest {
     @Test
     void testLookupInternalOnly() {
         Context context = Context.create();
-        context.put("foo", Value.create("foo-value"), true);
+        context.setValue("foo", Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
 
         Value value;
 
@@ -101,8 +110,13 @@ class ContextTest {
     @Test
     void testRelativeLookup() {
         Context context = Context.create();
-        context.push("foo", Value.create("foo-value"), false, true);
-        context.push("bar", Value.create("bar-value"), false, true);
+        Context.Scope scope;
+        scope = context.newScope("foo", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
+        scope = context.newScope("bar", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.create("bar-value"), ContextValue.ValueKind.EXTERNAL);
 
         Value value;
 
@@ -137,11 +151,16 @@ class ContextTest {
     }
 
     @Test
-    void testPopInput() {
+    void testPopScope() {
         Context context = Context.create();
-        context.push("foo", Value.create("foo-value"), false, true);
-        context.push("bar", Value.create("bar-value"), false, true);
-        context.pop();
+        Context.Scope scope;
+        scope = context.newScope("foo", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.create("foo-value"), ContextValue.ValueKind.EXTERNAL);
+        scope = context.newScope("bar", false);
+        context.pushScope(scope);
+        context.setValue(scope.id(), Value.create("bar-value"), ContextValue.ValueKind.EXTERNAL);
+        context.popScope();
 
         Value value;
 

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ControllerTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ControllerTest.java
@@ -71,12 +71,12 @@ class ControllerTest {
     void testConditional() {
         Script script = load("controller/conditional.xml");
         Context context = Context.create();
-        context.put("doModel", Value.TRUE);
-        context.put("doColors", Value.TRUE);
-        context.put("doRed", Value.TRUE);
-        context.put("doGreen", Value.FALSE);
-        context.put("doBlue", Value.TRUE);
-        context.put("doShapes", Value.FALSE);
+        context.put("doModel", Value.TRUE, true);
+        context.put("doColors", Value.TRUE, true);
+        context.put("doRed", Value.TRUE, true);
+        context.put("doGreen", Value.FALSE, true);
+        context.put("doBlue", Value.TRUE, true);
+        context.put("doShapes", Value.FALSE, true);
 
         List<String> values = modelValues(script, context);
         assertThat(values, contains("red", "blue"));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ControllerTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ControllerTest.java
@@ -71,12 +71,12 @@ class ControllerTest {
     void testConditional() {
         Script script = load("controller/conditional.xml");
         Context context = Context.create();
-        context.put("doModel", Value.TRUE, true);
-        context.put("doColors", Value.TRUE, true);
-        context.put("doRed", Value.TRUE, true);
-        context.put("doGreen", Value.FALSE, true);
-        context.put("doBlue", Value.TRUE, true);
-        context.put("doShapes", Value.FALSE, true);
+        context.setValue("doModel", Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        context.setValue("doColors", Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        context.setValue("doRed", Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        context.setValue("doGreen", Value.FALSE, ContextValue.ValueKind.EXTERNAL);
+        context.setValue("doBlue", Value.TRUE, ContextValue.ValueKind.EXTERNAL);
+        context.setValue("doShapes", Value.FALSE, ContextValue.ValueKind.EXTERNAL);
 
         List<String> values = modelValues(script, context);
         assertThat(values, contains("red", "blue"));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/InputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/InputResolverTest.java
@@ -196,8 +196,8 @@ public class InputResolverTest {
         Context context = Context.create();
         context.setValue("global", Value.create("value1"), ContextValue.ValueKind.EXTERNAL);
         context.setValue("nested-global", Value.create("value1"), ContextValue.ValueKind.EXTERNAL);
-        context.setValue("nested-global.nested1", Value.create("value2"), ContextValue.ValueKind.EXTERNAL);
-        context.setValue("nested-global.nested1.nested2", Value.create("value2"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue("nested1", Value.create("value2"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue("nested1.nested2", Value.create("value2"), ContextValue.ValueKind.EXTERNAL);
         List<String> resolvedInputs = resolveInputs(global, context);
         assertThat(resolvedInputs.size(), is(1));
         assertThat(resolvedInputs, contains("blue"));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MustacheSupportTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MustacheSupportTest.java
@@ -242,7 +242,7 @@ class MustacheSupportTest {
     void testModelValueWithContextVariable() {
         Block scope = model(modelValue("color", "${color}")).build();
         Context context = Context.create();
-        context.put("color", Value.create("red"));
+        context.put("color", Value.create("red"), true);
         assertThat(render("{{color}}", scope, null, context), is("red"));
     }
 
@@ -250,8 +250,8 @@ class MustacheSupportTest {
     void testModelValueWithContextVariables() {
         Block scope = model(modelValue("colors", "${red},${blue}")).build();
         Context context = Context.create();
-        context.put("red", Value.create("red"));
-        context.put("blue", Value.create("blue"));
+        context.put("red", Value.create("red"), true);
+        context.put("blue", Value.create("blue"), true);
         assertThat(render("{{colors}}", scope, null, context), is("red,blue"));
     }
 

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MustacheSupportTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MustacheSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -242,7 +242,7 @@ class MustacheSupportTest {
     void testModelValueWithContextVariable() {
         Block scope = model(modelValue("color", "${color}")).build();
         Context context = Context.create();
-        context.put("color", Value.create("red"), true);
+        context.setValue("color", Value.create("red"), ContextValue.ValueKind.EXTERNAL);
         assertThat(render("{{color}}", scope, null, context), is("red"));
     }
 
@@ -250,8 +250,8 @@ class MustacheSupportTest {
     void testModelValueWithContextVariables() {
         Block scope = model(modelValue("colors", "${red},${blue}")).build();
         Context context = Context.create();
-        context.put("red", Value.create("red"), true);
-        context.put("blue", Value.create("blue"), true);
+        context.setValue("red", Value.create("red"), ContextValue.ValueKind.EXTERNAL);
+        context.setValue("blue", Value.create("blue"), ContextValue.ValueKind.EXTERNAL);
         assertThat(render("{{colors}}", scope, null, context), is("red,blue"));
     }
 

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/OutputGeneratorTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/OutputGeneratorTest.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 
 import io.helidon.build.archetype.engine.v2.ast.Script;
 import io.helidon.build.archetype.engine.v2.ast.Value;
-import io.helidon.build.common.test.utils.TestFiles;
 
 import org.junit.jupiter.api.Test;
 
@@ -90,7 +89,7 @@ class OutputGeneratorTest {
     @Test
     void testReplacement() throws IOException {
         Path outputDir = generate("generator/replacement.xml",
-                ctx -> ctx.put("package", Value.create("com.example")));
+                ctx -> ctx.put("package", Value.create("com.example"), true));
         Path expected = outputDir.resolve("com/example/file1.txt");
         assertThat(Files.exists(expected), is(true));
         assertThat(readFile(expected), is("foo\n"));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/OutputGeneratorTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/OutputGeneratorTest.java
@@ -89,7 +89,7 @@ class OutputGeneratorTest {
     @Test
     void testReplacement() throws IOException {
         Path outputDir = generate("generator/replacement.xml",
-                ctx -> ctx.put("package", Value.create("com.example"), true));
+                ctx -> ctx.setValue("package", Value.create("com.example"), ContextValue.ValueKind.EXTERNAL));
         Path expected = outputDir.resolve("com/example/file1.txt");
         assertThat(Files.exists(expected), is(true));
         assertThat(readFile(expected), is("foo\n"));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ScriptLoaderTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ScriptLoaderTest.java
@@ -61,8 +61,9 @@ class ScriptLoaderTest {
             public VisitResult visitText(Input.Text input, Void arg) {
                 switch (++index[0]) {
                     case 1:
-                        assertThat(input.name(), is("input1"));
-                        assertThat(input.label(), is("Text input"));
+                        assertThat(input.id(), is("input1"));
+                        assertThat(input.name(), is("Text input"));
+                        assertThat(input.description(), is("A text input"));
                         assertThat(input.help(), is("Help 1"));
                         assertThat(input.isOptional(), is(true));
                         assertThat(input.defaultValue(), is(not(nullValue())));
@@ -70,8 +71,9 @@ class ScriptLoaderTest {
                         assertThat(input.prompt(), is("Enter 1"));
                         break;
                     case 5:
-                        assertThat(input.name(), is("more-input1"));
-                        assertThat(input.label(), is("More input 1"));
+                        assertThat(input.id(), is("more-input1"));
+                        assertThat(input.name(), is("More input 1"));
+                        assertThat(input.description(), is("Another text input"));
                         assertThat(input.help(), is("More Help 1"));
                         assertThat(input.isOptional(), is(true));
                         assertThat(input.defaultValue(), is(not(nullValue())));
@@ -87,8 +89,9 @@ class ScriptLoaderTest {
             @Override
             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                 assertThat(++index[0], is(2));
-                assertThat(input.name(), is("input2"));
-                assertThat(input.label(), is("Boolean input"));
+                assertThat(input.id(), is("input2"));
+                assertThat(input.name(), is("Boolean input"));
+                assertThat(input.description(), is("A boolean input"));
                 assertThat(input.help(), is("Help 2"));
                 assertThat(input.isOptional(), is(false));
                 assertThat(input.defaultValue().asBoolean(), is(true));
@@ -99,15 +102,18 @@ class ScriptLoaderTest {
             @Override
             public VisitResult visitEnum(Input.Enum input, Void arg) {
                 assertThat(++index[0], is(3));
-                assertThat(input.name(), is("input3"));
-                assertThat(input.label(), is("Enum input"));
+                assertThat(input.id(), is("input3"));
+                assertThat(input.name(), is("Enum input"));
+                assertThat(input.description(), is("An enum input"));
                 assertThat(input.help(), is("Help 3"));
                 assertThat(input.isOptional(), is(false));
                 assertThat(input.options().size(), is(2));
                 assertThat(input.options().get(0).value(), is("option3.1"));
-                assertThat(input.options().get(0).label(), is("Option 3.1"));
+                assertThat(input.options().get(0).name(), is("Option 3.1"));
+                assertThat(input.options().get(0).description(), is("An option"));
                 assertThat(input.options().get(1).value(), is("option3.2"));
-                assertThat(input.options().get(1).label(), is("Option 3.2"));
+                assertThat(input.options().get(1).name(), is("Option 3.2"));
+                assertThat(input.options().get(1).description(), is("Another option"));
                 assertThat(input.defaultValue(), is(not(nullValue())));
                 assertThat(input.defaultValue().asString(), is("option3.1"));
                 assertThat(input.prompt(), is("Enter 3"));
@@ -117,14 +123,17 @@ class ScriptLoaderTest {
             @Override
             public VisitResult visitList(Input.List input, Void arg) {
                 assertThat(++index[0], is(4));
-                assertThat(input.name(), is("input4"));
-                assertThat(input.label(), is("List input"));
+                assertThat(input.id(), is("input4"));
+                assertThat(input.name(), is("List input"));
+                assertThat(input.description(), is("A list input"));
                 assertThat(input.help(), is("Help 4"));
                 assertThat(input.isOptional(), is(false));
                 assertThat(input.options().get(0).value(), is("item4.1"));
-                assertThat(input.options().get(0).label(), is("Item 4.1"));
+                assertThat(input.options().get(0).name(), is("Item 4.1"));
+                assertThat(input.options().get(0).description(), is("An option"));
                 assertThat(input.options().get(1).value(), is("item4.2"));
-                assertThat(input.options().get(1).label(), is("Item 4.2"));
+                assertThat(input.options().get(1).name(), is("Item 4.2"));
+                assertThat(input.options().get(1).description(), is("Another option"));
                 assertThat(input.defaultValue().asList(), contains("item4.1", "item4.2"));
                 assertThat(input.prompt(), is("Enter 4"));
                 return VisitResult.CONTINUE;
@@ -141,8 +150,8 @@ class ScriptLoaderTest {
             @Override
             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                 assertThat(++index[0] <= 5, is(true));
-                assertThat(input.name(), is("input" + index[0]));
-                assertThat(input.label(), is("label" + index[0]));
+                assertThat(input.id(), is("input" + index[0]));
+                assertThat(input.name(), is("label" + index[0]));
                 return VisitResult.CONTINUE;
             }
         }, script);
@@ -616,7 +625,7 @@ class ScriptLoaderTest {
             @Override
             public VisitResult visitStep(Step step, Void arg) {
                 assertThat(++index[0], is(2));
-                assertThat(step.label(), is("Step 1"));
+                assertThat(step.name(), is("Step 1"));
                 assertThat(step.help(), is("Help about step 1"));
                 return VisitResult.CONTINUE;
             }
@@ -627,8 +636,8 @@ class ScriptLoaderTest {
                     @Override
                     public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                         assertThat(++index[0], is(3));
-                        assertThat(input.name(), is("input1"));
-                        assertThat(input.label(), is("Input 1"));
+                        assertThat(input.id(), is("input1"));
+                        assertThat(input.name(), is("Input 1"));
                         return VisitResult.CONTINUE;
                     }
                 }, arg);

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TerminalInputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TerminalInputResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TerminalInputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TerminalInputResolverTest.java
@@ -30,6 +30,7 @@ import static io.helidon.build.archetype.engine.v2.TestHelper.inputEnum;
 import static io.helidon.build.archetype.engine.v2.TestHelper.inputList;
 import static io.helidon.build.archetype.engine.v2.TestHelper.inputOption;
 import static io.helidon.build.archetype.engine.v2.TestHelper.inputText;
+import static io.helidon.build.archetype.engine.v2.TestHelper.step;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -41,9 +42,14 @@ import static org.hamcrest.Matchers.nullValue;
  */
 class TerminalInputResolverTest {
 
+    // TODO test control flow
+    //  i.e. only traverse the right branches according to user input
+
+    // TODO test output rendering
+
     @Test
     void testBooleanWithEmptyResponse() {
-        Block block = inputBoolean("boolean-input1", true).build();
+        Block block = step("step", inputBoolean("boolean-input1", true)).build();
 
         Context context = prompt(block, "");
         Value value = context.lookup("boolean-input1");
@@ -55,7 +61,7 @@ class TerminalInputResolverTest {
 
     @Test
     void testBooleanWithEmptyResponse2() {
-        Block block = inputBoolean("boolean-input2", false).build();
+        Block block = step("step", inputBoolean("boolean-input2", false)).build();
 
         Context context = prompt(block, "");
         Value value = context.lookup("boolean-input2");
@@ -67,7 +73,7 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputBoolean() {
-        Block block = inputBoolean("boolean-input3", true).build();
+        Block block = step("step", inputBoolean("boolean-input3", true)).build();
 
         Context context = prompt(block, "NO");
         Value value = context.lookup("boolean-input3");
@@ -79,9 +85,10 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputListWithEmptyResponse() {
-        Block block = inputList("list-input1", List.of("value1"),
-                inputOption("option1", "value1"),
-                inputOption("option2", "value2")).build();
+        Block block = step("step",
+                inputList("list-input1", List.of("value1"),
+                        inputOption("option1", "value1"),
+                        inputOption("option2", "value2"))).build();
 
         Context context = prompt(block, "");
         Value value = context.lookup("list-input1");
@@ -93,9 +100,10 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputListWithEmptyResponseMultipleDefault() {
-        Block block = inputList("list-input2", List.of("value1", "value2"),
-                inputOption("option1", "value1"),
-                inputOption("option2", "value2")).build();
+        Block block = step("step",
+                inputList("list-input2", List.of("value1", "value2"),
+                        inputOption("option1", "value1"),
+                        inputOption("option2", "value2"))).build();
 
         Context context = prompt(block, "");
         Value value = context.lookup("list-input2");
@@ -107,10 +115,11 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputList() {
-        Block block = inputList("list-input3", List.of(),
-                inputOption("option1", "value1"),
-                inputOption("option2", "value2"),
-                inputOption("option3", "value3")).build();
+        Block block = step("step",
+                inputList("list-input3", List.of(),
+                        inputOption("option1", "value1"),
+                        inputOption("option2", "value2"),
+                        inputOption("option3", "value3"))).build();
 
         Context context = prompt(block, "1 3");
         Value value = context.lookup("list-input3");
@@ -122,10 +131,11 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputListResponseDuplicate() {
-        Block block = inputList("list-input4", List.of(),
-                inputOption("option1", "value1"),
-                inputOption("option2", "value2"),
-                inputOption("option3", "value3")).build();
+        Block block = step("step",
+                inputList("list-input4", List.of(),
+                        inputOption("option1", "value1"),
+                        inputOption("option2", "value2"),
+                        inputOption("option3", "value3"))).build();
 
         Context context = prompt(block, "1 3 3 1");
         Value value = context.lookup("list-input4");
@@ -137,9 +147,10 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputEnumWithEmptyResponse() {
-        Block block = inputEnum("enum-input1", "value1",
-                inputOption("option1", "value1"),
-                inputOption("option2", "value2")).build();
+        Block block = step("step",
+                inputEnum("enum-input1", "value1",
+                        inputOption("option1", "value1"),
+                        inputOption("option2", "value2"))).build();
 
         Context context = prompt(block, "");
         Value value = context.lookup("enum-input1");
@@ -151,8 +162,9 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputEnumWithSingleOptionAndDefault() {
-        Block block = inputEnum("enum-input1", "value1",
-                inputOption("option1", "value1")).build();
+        Block block = step("step",
+                inputEnum("enum-input1", "value1",
+                        inputOption("option1", "value1"))).build();
 
         Context context = prompt(block, "2");
         Value value = context.lookup("enum-input1");
@@ -164,10 +176,11 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputEnum() {
-        Block block = inputEnum("enum-input2", "value3",
-                inputOption("option1", "value1"),
-                inputOption("option2", "value2"),
-                inputOption("option3", "value3")).build();
+        Block block = step("step",
+                inputEnum("enum-input2", "value3",
+                        inputOption("option1", "value1"),
+                        inputOption("option2", "value2"),
+                        inputOption("option3", "value3"))).build();
 
         Context context = prompt(block, "2");
         Value value = context.lookup("enum-input2");
@@ -179,7 +192,7 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputTextWithEmptyResponseNoDefault() {
-        Block block = inputText("text-input1", null).build();
+        Block block = step("step", inputText("text-input1", null)).build();
 
         Context context = prompt(block, "");
         Value value = context.lookup("text-input1");
@@ -189,7 +202,7 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputTextWithEmptyResult() {
-        Block block = inputText("text-input2", "value1").build();
+        Block block = step("step", inputText("text-input2", "value1")).build();
 
         Context context = prompt(block, "");
         Value value = context.lookup("text-input2");
@@ -201,7 +214,7 @@ class TerminalInputResolverTest {
 
     @Test
     void testInputText() {
-        Block block = inputText("text-input3", "value1").build();
+        Block block = step("step", inputText("text-input3", "value1")).build();
 
         Context context = prompt(block, "not-value1");
         Value value = context.lookup("text-input3");

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TestHelper.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TestHelper.java
@@ -239,13 +239,13 @@ public class TestHelper {
     /**
      * Create a new step block builder.
      *
-     * @param label    step label
+     * @param name    step name
      * @param children nested children
      * @return block builder
      */
-    public static Block.Builder step(String label, Block.Builder... children) {
+    public static Block.Builder step(String name, Block.Builder... children) {
         Block.Builder builder = Step.builder(BUILDER_INFO)
-                                    .attribute("label", Value.create(label));
+                                    .attribute("name", Value.create(name));
         for (Block.Builder child : children) {
             builder.addChild(child);
         }
@@ -255,14 +255,14 @@ public class TestHelper {
     /**
      * Create an input option block builder.
      *
-     * @param name     option name
+     * @param id     input id
      * @param value    option value
      * @param children nested children
      * @return block builder
      */
-    public static Block.Builder inputOption(String name, String value, Block.Builder... children) {
+    public static Block.Builder inputOption(String id, String value, Block.Builder... children) {
         Block.Builder builder = Input.builder(BUILDER_INFO, Block.Kind.OPTION)
-                                     .attributes(inputAttributes(name, value));
+                                     .attributes(inputAttributes(id, value));
         for (Block.Builder child : children) {
             builder.addChild(child);
         }
@@ -272,53 +272,53 @@ public class TestHelper {
     /**
      * Create an input text block builder.
      *
-     * @param name         option name
+     * @param id         input id
      * @param defaultValue default value
      * @return block builder
      */
-    public static Block.Builder inputText(String name, String defaultValue, Block.Builder... children) {
-        return inputBuilder(name, Block.Kind.TEXT, defaultValue, children);
+    public static Block.Builder inputText(String id, String defaultValue, Block.Builder... children) {
+        return inputBuilder(id, Block.Kind.TEXT, defaultValue, children);
     }
 
     /**
      * Create an input boolean block builder.
      *
-     * @param name         option name
+     * @param id         input id
      * @param defaultValue default value
      * @param children     nested children
      * @return block builder
      */
-    public static Block.Builder inputBoolean(String name, boolean defaultValue, Block.Builder... children) {
-        return inputBuilder(name, Block.Kind.BOOLEAN, String.valueOf(defaultValue), children);
+    public static Block.Builder inputBoolean(String id, boolean defaultValue, Block.Builder... children) {
+        return inputBuilder(id, Block.Kind.BOOLEAN, String.valueOf(defaultValue), children);
     }
 
     /**
      * Create an input enum block builder.
      *
-     * @param name         option name
+     * @param id           input id
      * @param defaultValue default value
      * @param children     nested children
      * @return block builder
      */
-    public static Block.Builder inputEnum(String name, String defaultValue, Block.Builder... children) {
-        return inputBuilder(name, Block.Kind.ENUM, defaultValue, children);
+    public static Block.Builder inputEnum(String id, String defaultValue, Block.Builder... children) {
+        return inputBuilder(id, Block.Kind.ENUM, defaultValue, children);
     }
 
     /**
      * Create an input list block builder.
      *
-     * @param name         option name
+     * @param id           input id`
      * @param defaultValue default value
      * @param children     nested children
      * @return block builder
      */
-    public static Block.Builder inputList(String name, List<String> defaultValue, Block.Builder... children) {
-        return inputBuilder(name, Block.Kind.LIST, String.join(",", defaultValue), children);
+    public static Block.Builder inputList(String id, List<String> defaultValue, Block.Builder... children) {
+        return inputBuilder(id, Block.Kind.LIST, String.join(",", defaultValue), children);
     }
 
-    private static Block.Builder inputBuilder(String name, Block.Kind kind, String defaultValue, Block.Builder... children) {
+    private static Block.Builder inputBuilder(String id, Block.Kind kind, String defaultValue, Block.Builder... children) {
         Block.Builder builder = Input.builder(BUILDER_INFO, kind)
-                                     .attributes(inputAttributes(name, defaultValue, name));
+                                     .attributes(inputAttributes(id, defaultValue, id));
         for (Block.Builder child : children) {
             builder.addChild(child);
         }
@@ -337,16 +337,16 @@ public class TestHelper {
         return builder;
     }
 
-    private static Map<String, Value> inputAttributes(String name, String value) {
+    private static Map<String, Value> inputAttributes(String id, String value) {
         Map<String, Value> attributes = new HashMap<>();
-        attributes.put("name", DynamicValue.create(name));
+        attributes.put("id", DynamicValue.create(id));
         attributes.put("value", DynamicValue.create(value));
         return attributes;
     }
 
-    private static Map<String, Value> inputAttributes(String name, String defaultValue, String prompt) {
+    private static Map<String, Value> inputAttributes(String id, String defaultValue, String prompt) {
         Map<String, Value> attributes = new HashMap<>();
-        attributes.put("name", DynamicValue.create(name));
+        attributes.put("id", DynamicValue.create(id));
         attributes.put("default", DynamicValue.create(defaultValue));
         attributes.put("prompt", DynamicValue.create(prompt));
         return attributes;

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TestHelper.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TestHelper.java
@@ -16,20 +16,7 @@
 
 package io.helidon.build.archetype.engine.v2;
 
-import io.helidon.build.archetype.engine.v2.ast.Block;
-import io.helidon.build.archetype.engine.v2.ast.DynamicValue;
-import io.helidon.build.archetype.engine.v2.ast.Input;
-import io.helidon.build.archetype.engine.v2.ast.Model;
-import io.helidon.build.archetype.engine.v2.ast.Node;
-import io.helidon.build.archetype.engine.v2.ast.Output;
-import io.helidon.build.archetype.engine.v2.ast.Script;
-import io.helidon.build.archetype.engine.v2.ast.Value;
-import io.helidon.build.common.Instance;
-import io.helidon.build.common.Strings;
-import io.helidon.build.common.VirtualFileSystem;
-
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,18 +24,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.helidon.build.archetype.engine.v2.ast.Block;
+import io.helidon.build.archetype.engine.v2.ast.DynamicValue;
+import io.helidon.build.archetype.engine.v2.ast.Input;
+import io.helidon.build.archetype.engine.v2.ast.Model;
+import io.helidon.build.archetype.engine.v2.ast.Node;
+import io.helidon.build.archetype.engine.v2.ast.Node.BuilderInfo;
+import io.helidon.build.archetype.engine.v2.ast.Output;
+import io.helidon.build.archetype.engine.v2.ast.Script;
+import io.helidon.build.archetype.engine.v2.ast.Step;
+import io.helidon.build.archetype.engine.v2.ast.Value;
+import io.helidon.build.common.Instance;
+import io.helidon.build.common.Strings;
+import io.helidon.build.common.VirtualFileSystem;
+
 import static io.helidon.build.common.test.utils.TestFiles.targetDir;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNull.notNullValue;
 
 /**
  * Test helper.
  */
 public class TestHelper {
 
-    private static final Path SCRIPT_PATH = Path.of("test-helper.xml");
-    private static final ScriptLoader LOADER = ScriptLoader.create();
+    private static final BuilderInfo BUILDER_INFO = BuilderInfo.of(ScriptLoader.create(), Path.of("test-helper.xml"), null);
     private static final Instance<FileSystem> FS = new Instance<>(TestHelper::createTestFileSystem);
 
     private static FileSystem createTestFileSystem() {
@@ -126,7 +123,7 @@ public class TestHelper {
      * @return block builder
      */
     public static Block.Builder block(Block.Kind kind, Block.Builder... children) {
-        Block.Builder builder = Block.builder(LOADER, SCRIPT_PATH, null, kind);
+        Block.Builder builder = Block.builder(BUILDER_INFO, kind);
         for (Block.Builder child : children) {
             builder.addChild(child);
         }
@@ -240,6 +237,22 @@ public class TestHelper {
     }
 
     /**
+     * Create a new step block builder.
+     *
+     * @param label    step label
+     * @param children nested children
+     * @return block builder
+     */
+    public static Block.Builder step(String label, Block.Builder... children) {
+        Block.Builder builder = Step.builder(BUILDER_INFO)
+                                    .attribute("label", Value.create(label));
+        for (Block.Builder child : children) {
+            builder.addChild(child);
+        }
+        return builder;
+    }
+
+    /**
      * Create an input option block builder.
      *
      * @param name     option name
@@ -248,7 +261,7 @@ public class TestHelper {
      * @return block builder
      */
     public static Block.Builder inputOption(String name, String value, Block.Builder... children) {
-        Block.Builder builder = Input.builder(LOADER, SCRIPT_PATH, null, Block.Kind.OPTION)
+        Block.Builder builder = Input.builder(BUILDER_INFO, Block.Kind.OPTION)
                                      .attributes(inputAttributes(name, value));
         for (Block.Builder child : children) {
             builder.addChild(child);
@@ -304,7 +317,7 @@ public class TestHelper {
     }
 
     private static Block.Builder inputBuilder(String name, Block.Kind kind, String defaultValue, Block.Builder... children) {
-        Block.Builder builder = Input.builder(LOADER, SCRIPT_PATH, null, kind)
+        Block.Builder builder = Input.builder(BUILDER_INFO, kind)
                                      .attributes(inputAttributes(name, defaultValue, name));
         for (Block.Builder child : children) {
             builder.addChild(child);
@@ -313,7 +326,7 @@ public class TestHelper {
     }
 
     private static Block.Builder modelBuilder(String key, Block.Kind kind, int order, Block.Builder... children) {
-        Block.Builder builder = Model.builder(LOADER, SCRIPT_PATH, null, kind)
+        Block.Builder builder = Model.builder(BUILDER_INFO, kind)
                                      .attributes(Map.of("order", DynamicValue.create(String.valueOf(order))));
         if (key != null) {
             builder.attributes(Map.of("key", DynamicValue.create(key)));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/util/ArchetypeValidatorTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/util/ArchetypeValidatorTest.java
@@ -92,12 +92,6 @@ class ArchetypeValidatorTest {
     }
 
     @Test
-    void testUnresolvablePreset() {
-        List<String> errors = validate("unresolvable-preset.xml");
-        assertThat(errors.size(), is(0));
-    }
-
-    @Test
     void testPresetTypeMismatch() {
         List<String> errors = validate("preset-type-mismatch.xml");
         assertThat(errors.size(), is(1));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/util/ClientCompilerTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/util/ClientCompilerTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class ClientCompilerTest {
 
-
     @Test
     void testEmptyScript() {
         Script script = load("compiler/empty-script/main.xml");

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/util/ClientCompilerTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/util/ClientCompilerTest.java
@@ -71,8 +71,8 @@ class ClientCompilerTest {
                             @Override
                             public VisitResult visitEnum(Input.Enum input, Void arg) {
                                 assertThat(++index[0], is(3));
-                                assertThat(input.name(), is("enum1"));
-                                assertThat(input.label(), is("Enum1"));
+                                assertThat(input.id(), is("enum1"));
+                                assertThat(input.name(), is("Enum1"));
                                 return VisitResult.CONTINUE;
                             }
 
@@ -81,11 +81,11 @@ class ClientCompilerTest {
                                 switch (++index[0]) {
                                     case 4:
                                         assertThat(option.value(), is("enum1-value1"));
-                                        assertThat(option.label(), is("Enum1Value1"));
+                                        assertThat(option.name(), is("Enum1Value1"));
                                         break;
                                     case 5:
                                         assertThat(option.value(), is("enum1-value2"));
-                                        assertThat(option.label(), is("Enum1Value2"));
+                                        assertThat(option.name(), is("Enum1Value2"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);
@@ -141,8 +141,8 @@ class ClientCompilerTest {
                             @Override
                             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                                 assertThat(++index[0], is(3));
-                                assertThat(input.name(), is("boolean1"));
-                                assertThat(input.label(), is("Boolean1"));
+                                assertThat(input.id(), is("boolean1"));
+                                assertThat(input.name(), is("Boolean1"));
                                 return VisitResult.CONTINUE;
                             }
 
@@ -194,8 +194,8 @@ class ClientCompilerTest {
                             @Override
                             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                                 assertThat(++index[0], is(3));
-                                assertThat(input.name(), is("boolean1"));
-                                assertThat(input.label(), is("Boolean1"));
+                                assertThat(input.id(), is("boolean1"));
+                                assertThat(input.name(), is("Boolean1"));
                                 return VisitResult.CONTINUE;
                             }
 
@@ -254,12 +254,12 @@ class ClientCompilerTest {
                             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                                 switch (++index[0]) {
                                     case 3:
-                                        assertThat(input.name(), is("boolean1"));
-                                        assertThat(input.label(), is("Boolean1"));
+                                        assertThat(input.id(), is("boolean1"));
+                                        assertThat(input.name(), is("Boolean1"));
                                         break;
                                     case 5:
-                                        assertThat(input.name(), is("boolean2"));
-                                        assertThat(input.label(), is("Boolean2"));
+                                        assertThat(input.id(), is("boolean2"));
+                                        assertThat(input.name(), is("Boolean2"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);
@@ -322,12 +322,12 @@ class ClientCompilerTest {
                             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                                 switch (++index[0]) {
                                     case 3:
-                                        assertThat(input.name(), is("boolean1"));
-                                        assertThat(input.label(), is("Boolean1"));
+                                        assertThat(input.id(), is("boolean1"));
+                                        assertThat(input.name(), is("Boolean1"));
                                         break;
                                     case 5:
-                                        assertThat(input.name(), is("boolean2"));
-                                        assertThat(input.label(), is("Boolean2"));
+                                        assertThat(input.id(), is("boolean2"));
+                                        assertThat(input.name(), is("Boolean2"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);
@@ -371,16 +371,16 @@ class ClientCompilerTest {
                             public VisitResult visitEnum(Input.Enum input, Void arg) {
                                 switch (++index[0]) {
                                     case 2:
-                                        assertThat(input.name(), is("fruit"));
-                                        assertThat(input.label(), is("Fruit"));
+                                        assertThat(input.id(), is("fruit"));
+                                        assertThat(input.name(), is("Fruit"));
                                         break;
                                     case 4:
-                                        assertThat(input.name(), is("berry-type"));
-                                        assertThat(input.label(), is("Berry type"));
+                                        assertThat(input.id(), is("berry-type"));
+                                        assertThat(input.name(), is("Berry type"));
                                         break;
                                     case 10:
-                                        assertThat(input.name(), is("tropical-type"));
-                                        assertThat(input.label(), is("Tropical type"));
+                                        assertThat(input.id(), is("tropical-type"));
+                                        assertThat(input.name(), is("Tropical type"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);
@@ -393,27 +393,27 @@ class ClientCompilerTest {
                                 switch (++index[0]) {
                                     case 3:
                                         assertThat(option.value(), is("berries"));
-                                        assertThat(option.label(), is("Berries"));
+                                        assertThat(option.name(), is("Berries"));
                                         break;
                                     case 5:
                                         assertThat(option.value(), is("raspberry"));
-                                        assertThat(option.label(), is("Raspberry"));
+                                        assertThat(option.name(), is("Raspberry"));
                                         break;
                                     case 7:
                                         assertThat(option.value(), is("strawberry"));
-                                        assertThat(option.label(), is("Strawberry"));
+                                        assertThat(option.name(), is("Strawberry"));
                                         break;
                                     case 9:
                                         assertThat(option.value(), is("tropical"));
-                                        assertThat(option.label(), is("Tropical"));
+                                        assertThat(option.name(), is("Tropical"));
                                         break;
                                     case 11:
                                         assertThat(option.value(), is("mango"));
-                                        assertThat(option.label(), is("Mango"));
+                                        assertThat(option.name(), is("Mango"));
                                         break;
                                     case 14:
                                         assertThat(option.value(), is("banana"));
-                                        assertThat(option.label(), is("Banana"));
+                                        assertThat(option.name(), is("Banana"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);
@@ -425,24 +425,24 @@ class ClientCompilerTest {
                             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                                 switch (++index[0]) {
                                     case 6:
-                                        assertThat(input.name(), is("organic"));
-                                        assertThat(input.label(), is("Organic"));
+                                        assertThat(input.id(), is("organic"));
+                                        assertThat(input.name(), is("Organic"));
                                         break;
                                     case 8:
-                                        assertThat(input.name(), is("frozen"));
-                                        assertThat(input.label(), is("Frozen"));
+                                        assertThat(input.id(), is("frozen"));
+                                        assertThat(input.name(), is("Frozen"));
                                         break;
                                     case 12:
-                                        assertThat(input.name(), is("fare-trade"));
-                                        assertThat(input.label(), is("Fare trade"));
+                                        assertThat(input.id(), is("fare-trade"));
+                                        assertThat(input.name(), is("Fare trade"));
                                         break;
                                     case 15:
-                                        assertThat(input.name(), is("plantain"));
-                                        assertThat(input.label(), is("Plantain"));
+                                        assertThat(input.id(), is("plantain"));
+                                        assertThat(input.name(), is("Plantain"));
                                         break;
                                     case 17:
-                                        assertThat(input.name(), is("frosting"));
-                                        assertThat(input.label(), is("Frosting"));
+                                        assertThat(input.id(), is("frosting"));
+                                        assertThat(input.name(), is("Frosting"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);
@@ -455,8 +455,8 @@ class ClientCompilerTest {
                                 switch (++index[0]) {
                                     case 13:
                                     case 16:
-                                        assertThat(input.name(), is("comment"));
-                                        assertThat(input.label(), is("Comment"));
+                                        assertThat(input.id(), is("comment"));
+                                        assertThat(input.name(), is("Comment"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);
@@ -508,19 +508,19 @@ class ClientCompilerTest {
                             public VisitResult visitBoolean(Input.Boolean input, Void arg) {
                                 switch (++index[0]) {
                                     case 1:
-                                        assertThat(input.name(), is("boolean1"));
-                                        assertThat(input.label(), is("Boolean1"));
+                                        assertThat(input.id(), is("boolean1"));
+                                        assertThat(input.name(), is("Boolean1"));
                                         break;
                                     case 2:
                                     case 6:
-                                        assertThat(input.name(), is("boolean2"));
-                                        assertThat(input.label(), is("Boolean2"));
+                                        assertThat(input.id(), is("boolean2"));
+                                        assertThat(input.name(), is("Boolean2"));
                                         break;
                                     case 3:
                                     case 7:
                                     case 10:
-                                        assertThat(input.name(), is("boolean3"));
-                                        assertThat(input.label(), is("Boolean3"));
+                                        assertThat(input.id(), is("boolean3"));
+                                        assertThat(input.name(), is("Boolean3"));
                                         break;
                                     case 4:
                                     case 5:
@@ -528,8 +528,8 @@ class ClientCompilerTest {
                                     case 9:
                                     case 11:
                                     case 12:
-                                        assertThat(input.name(), is("boolean4"));
-                                        assertThat(input.label(), is("Boolean4"));
+                                        assertThat(input.id(), is("boolean4"));
+                                        assertThat(input.name(), is("Boolean4"));
                                         break;
                                     default:
                                         fail("Unexpected index: " + index[0]);

--- a/archetype/engine-v2/src/test/resources/compiler/declarations/main.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/declarations/main.xml
@@ -23,14 +23,14 @@
     <methods>
         <method name="script1.xml">
             <inputs>
-                <boolean name="boolean2" label="Boolean2">
+                <boolean id="boolean2" name="Boolean2">
                     <exec src="script1.xml"/>
                 </boolean>
             </inputs>
         </method>
     </methods>
     <inputs>
-        <boolean name="boolean1" label="Boolean1">
+        <boolean id="boolean1" name="Boolean1">
             <call method="script1.xml"/>
         </boolean>
     </inputs>

--- a/archetype/engine-v2/src/test/resources/compiler/declarations/script1.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/declarations/script1.xml
@@ -23,12 +23,12 @@
     <methods>
         <method name="script1.xml">
             <inputs>
-                <boolean name="boolean4" label="Boolean4" />
+                <boolean id="boolean4" name="Boolean4" />
             </inputs>
         </method>
     </methods>
     <inputs>
-        <boolean name="boolean3" label="Boolean3">
+        <boolean id="boolean3" name="Boolean3">
             <call method="script1.xml"/>
         </boolean>
     </inputs>

--- a/archetype/engine-v2/src/test/resources/compiler/empty-script/main.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/empty-script/main.xml
@@ -20,13 +20,13 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <enum name="enum1" label="Enum1">
-                <option value="enum1-value1" label="Enum1Value1">
+            <enum id="enum1" name="Enum1">
+                <option value="enum1-value1" name="Enum1Value1">
                     <exec src="script1.xml"/>
                 </option>
-                <option value="enum1-value2" label="Enum1Value2"/>
+                <option value="enum1-value2" name="Enum1Value2"/>
             </enum>
         </inputs>
     </step>

--- a/archetype/engine-v2/src/test/resources/compiler/filtering/main.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/filtering/main.xml
@@ -23,16 +23,16 @@
     <variables>
         <boolean path="foo" transient="true">true</boolean>
     </variables>
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <boolean name="boolean1" label="Boolean1">
+            <boolean id="boolean1" name="Boolean1">
                 <output>
                     <file source="foo.txt" target="foo.txt"/>
                 </output>
             </boolean>
         </inputs>
     </step>
-    <step label="Step2">
+    <step name="Step2">
         <inputs></inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/compiler/filtering/main.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/filtering/main.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <presets>
+    <variables>
         <boolean path="foo" transient="true">true</boolean>
-    </presets>
+    </variables>
     <step label="Step1">
         <inputs>
             <boolean name="boolean1" label="Boolean1">

--- a/archetype/engine-v2/src/test/resources/compiler/inlined1/main.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/inlined1/main.xml
@@ -20,7 +20,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <exec src="script1.xml"/>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/compiler/inlined1/script3.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/inlined1/script3.xml
@@ -20,6 +20,6 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
     <inputs>
-        <boolean name="boolean1" label="Boolean1" />
+        <boolean id="boolean1" name="Boolean1" />
     </inputs>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/compiler/inlined2/script2.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/inlined2/script2.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <boolean name="boolean1" label="Boolean1">
+            <boolean id="boolean1" name="Boolean1">
                 <exec src="script3.xml"/>
             </boolean>
         </inputs>

--- a/archetype/engine-v2/src/test/resources/compiler/inlined2/script3.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/inlined2/script3.xml
@@ -20,6 +20,6 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
     <inputs>
-        <boolean name="boolean2" label="Boolean2"/>
+        <boolean id="boolean2" name="Boolean2"/>
     </inputs>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/compiler/inlined3/script2.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/inlined3/script2.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1">
+    <step name="Step1">
         <inputs>
-            <boolean name="boolean1" label="Boolean1">
+            <boolean id="boolean1" name="Boolean1">
                 <exec src="script3.xml"/>
             </boolean>
         </inputs>

--- a/archetype/engine-v2/src/test/resources/compiler/inlined3/script3.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/inlined3/script3.xml
@@ -23,7 +23,7 @@
     <methods>
         <method name="method3">
             <inputs>
-                <boolean name="boolean2" label="Boolean2"/>
+                <boolean id="boolean2" name="Boolean2"/>
             </inputs>
         </method>
     </methods>

--- a/archetype/engine-v2/src/test/resources/compiler/inlined4/main.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/inlined4/main.xml
@@ -22,7 +22,7 @@
 
     <methods>
         <method name="main">
-            <step label="Cake">
+            <step name="Cake">
                 <call method="fruit"/>
                 <call method="common"/>
                 <call method="customize"/>
@@ -30,11 +30,11 @@
         </method>
         <method name="fruit">
             <inputs>
-                <enum name="fruit" label="Fruit" default="berries">
-                    <option value="berries" label="Berries">
+                <enum id="fruit" name="Fruit" default="berries">
+                    <option value="berries" name="Berries">
                         <call method="berries"/>
                     </option>
-                    <option value="tropical" label="Tropical">
+                    <option value="tropical" name="Tropical">
                         <call method="tropical"/>
                     </option>
                 </enum>
@@ -42,11 +42,11 @@
         </method>
         <method name="berries">
             <inputs>
-                <enum name="berry-type" label="Berry type" default="raspberry">
-                    <option value="raspberry" label="Raspberry">
+                <enum id="berry-type" name="Berry type" default="raspberry">
+                    <option value="raspberry" name="Raspberry">
                         <call method="raspberry"/>
                     </option>
-                    <option value="strawberry" label="Strawberry">
+                    <option value="strawberry" name="Strawberry">
                         <call method="strawberry"/>
                     </option>
                 </enum>
@@ -54,11 +54,11 @@
         </method>
         <method name="tropical">
             <inputs>
-                <enum name="tropical-type" label="Tropical type" default="mango">
-                    <option value="mango" label="Mango">
+                <enum id="tropical-type" name="Tropical type" default="mango">
+                    <option value="mango" name="Mango">
                         <call method="mango"/>
                     </option>
-                    <option value="banana" label="Banana">
+                    <option value="banana" name="Banana">
                         <call method="banana"/>
                     </option>
                 </enum>
@@ -66,34 +66,34 @@
         </method>
         <method name="raspberry">
             <inputs>
-                <boolean name="organic" label="Organic"/>
+                <boolean id="organic" name="Organic"/>
             </inputs>
         </method>
         <method name="strawberry">
             <inputs>
-                <boolean name="frozen" label="Frozen"/>
+                <boolean id="frozen" name="Frozen"/>
             </inputs>
         </method>
         <method name="mango">
             <inputs>
-                <boolean name="fare-trade" label="Fare trade">
+                <boolean id="fare-trade" name="Fare trade">
                     <call method="common"/>
                 </boolean>
             </inputs>
         </method>
         <method name="banana">
             <inputs>
-                <boolean name="plantain" label="Plantain"/>
+                <boolean id="plantain" name="Plantain"/>
             </inputs>
         </method>
         <method name="common">
             <inputs>
-                <text name="comment" label="Comment"/>
+                <text id="comment" name="Comment"/>
             </inputs>
         </method>
         <method name="customize">
             <inputs>
-                <boolean name="frosting" label="Frosting"/>
+                <boolean id="frosting" name="Frosting"/>
             </inputs>
         </method>
     </methods>

--- a/archetype/engine-v2/src/test/resources/e2e/colors/colors.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/colors/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Colors">
+    <step name="Colors">
         <inputs>
-            <enum name="base" label="Select a palette">
-                <option value="custom" label="Custom palette">
+            <enum id="base" name="Select a palette">
+                <option value="custom" name="Custom palette">
                     <exec src="custom/custom.xml"/>
                 </option>
-                <option value="rainbow" label="Rainbow palette">
+                <option value="rainbow" name="Rainbow palette">
                     <exec src="rainbow/rainbow.xml"/>
                 </option>
             </enum>

--- a/archetype/engine-v2/src/test/resources/e2e/colors/custom/custom.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/colors/custom/custom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,23 +22,23 @@
 
     <exec src="../../common/common.xml"/>
     <inputs>
-        <text name="palette-name" label="Palette name" optional="true" default="My Palette"/>
-        <list name="colors" label="Select colors" optional="true" default="red,green,blue">
-            <option value="red" label="Red"/>
-            <option value="orange" label="Orange"/>
-            <option value="yellow" label="Yellow"/>
-            <option value="green" label="Green"/>
-            <option value="blue" label="Blue"/>
-            <option value="indigo" label="Indigo"/>
-            <option value="violet" label="Violet"/>
-            <option value="pink" label="Pink"/>
-            <option value="light-pink" label="LightPink"/>
-            <option value="cyan" label="Cyan"/>
-            <option value="light-salmon" label="LightSalmon"/>
-            <option value="coral" label="Coral"/>
-            <option value="tomato" label="Tomato"/>
-            <option value="lemon" label="Lemon"/>
-            <option value="khaki" label="Khaki"/>
+        <text id="palette-name" name="Palette name" optional="true" default="My Palette"/>
+        <list id="colors" name="Select colors" optional="true" default="red,green,blue">
+            <option value="red" name="Red"/>
+            <option value="orange" name="Orange"/>
+            <option value="yellow" name="Yellow"/>
+            <option value="green" name="Green"/>
+            <option value="blue" name="Blue"/>
+            <option value="indigo" name="Indigo"/>
+            <option value="violet" name="Violet"/>
+            <option value="pink" name="Pink"/>
+            <option value="light-pink" name="LightPink"/>
+            <option value="cyan" name="Cyan"/>
+            <option value="light-salmon" name="LightSalmon"/>
+            <option value="coral" name="Coral"/>
+            <option value="tomato" name="Tomato"/>
+            <option value="lemon" name="Lemon"/>
+            <option value="khaki" name="Khaki"/>
         </list>
     </inputs>
     <output>

--- a/archetype/engine-v2/src/test/resources/e2e/common/common.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/common/common.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@
 
     <source src="mustache.xml"/>
     <inputs>
-        <enum name="style" label="Select a style" optional="true" default="modern">
-            <option value="modern" label="Modern">
+        <enum id="style" name="Select a style" optional="true" default="modern">
+            <option value="modern" name="Modern">
                 <output>
                     <templates transformations="mustache" engine="mustache">
                         <directory>files</directory>
@@ -33,7 +33,7 @@
                     </templates>
                 </output>
             </option>
-            <option value="classic" label="Classic"/>
+            <option value="classic" name="Classic"/>
         </enum>
     </inputs>
     <exec src="readme.xml"/>

--- a/archetype/engine-v2/src/test/resources/e2e/common/finalize.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/common/finalize.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step optional="true" label="Customize Project">
+    <step optional="true" name="Customize Project">
         <inputs>
-            <text name="artifactId" label="Project artifactId" optional="true" default="my-project"/>
+            <text id="artifactId" name="Project artifactId" optional="true" default="my-project"/>
         </inputs>
         <output>
             <model>

--- a/archetype/engine-v2/src/test/resources/e2e/main.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Theme">
+    <step name="Theme">
         <inputs>
-            <enum name="theme" label="Select a theme">
-                <option value="colors" label="Colors">
+            <enum id="theme" name="Select a theme">
+                <option value="colors" name="Colors">
                     <exec src="colors/colors.xml"/>
                 </option>
-                <option value="shapes" label="Shapes">
+                <option value="shapes" name="Shapes">
                     <exec src="shapes/shapes.xml"/>
                 </option>
             </enum>

--- a/archetype/engine-v2/src/test/resources/e2e/shapes/custom/custom.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/shapes/custom/custom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@
 
     <exec src="../../common/common.xml"/>
     <inputs>
-        <text name="library-name" label="Library name" optional="true" default="My Shapes"/>
-        <list name="shapes" label="Select shapes" optional="true" default="circle,triangle">
-            <option value="circle" label="Circle"/>
-            <option value="triangle" label="Triangle"/>
-            <option value="rectangle" label="Rectangle"/>
-            <option value="arrow" label="Arrow"/>
-            <option value="donut" label="Donut"/>
+        <text id="library-name" name="Library name" optional="true" default="My Shapes"/>
+        <list id="shapes" name="Select shapes" optional="true" default="circle,triangle">
+            <option value="circle" name="Circle"/>
+            <option value="triangle" name="Triangle"/>
+            <option value="rectangle" name="Rectangle"/>
+            <option value="arrow" name="Arrow"/>
+            <option value="donut" name="Donut"/>
         </list>
     </inputs>
     <output>

--- a/archetype/engine-v2/src/test/resources/e2e/shapes/shapes.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/shapes/shapes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Shapes">
+    <step name="Shapes">
         <inputs>
-            <enum name="base" label="Select a shape library">
-                <option value="custom" label="Custom">
+            <enum id="base" name="Select a shape library">
+                <option value="custom" name="Custom">
                     <exec src="custom/custom.xml"/>
                 </option>
-                <option value="2d" label="2D shapes">
+                <option value="2d" name="2D shapes">
                     <exec src="2d/2d.xml"/>
                 </option>
             </enum>

--- a/archetype/engine-v2/src/test/resources/input-tree/bar.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/bar.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Bar">
+    <step name="Bar">
         <inputs>
-            <text name="bar" label="Bar" default="a-bar"/>
+            <text id="bar" name="Bar" default="a-bar"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/input-tree/foo.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/foo.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Foo">
+    <step name="Foo">
         <inputs>
-            <text name="foo" label="Foo" default="a-foo"/>
+            <text id="foo" name="Foo" default="a-foo"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/input-tree/list1.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/list1.xml
@@ -20,12 +20,12 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="colors">
+    <step name="colors">
         <inputs>
-            <list name="colors" label="Select colors" default="red,yellow">
-                <option value="red" label="Red"/>
-                <option value="orange" label="Orange"/>
-                <option value="yellow" label="Yellow"/>
+            <list id="colors" name="Select colors" default="red,yellow">
+                <option value="red" name="Red"/>
+                <option value="orange" name="Orange"/>
+                <option value="yellow" name="Yellow"/>
             </list>
         </inputs>
     </step>

--- a/archetype/engine-v2/src/test/resources/input-tree/list2.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/list2.xml
@@ -20,11 +20,11 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="colors">
+    <step name="colors">
         <inputs>
-            <list name="colors" label="Select colors">
-                <option value="red" label="Red"/>
-                <option value="orange" label="Orange"/>
+            <list id="colors" name="Select colors">
+                <option value="red" name="Red"/>
+                <option value="orange" name="Orange"/>
             </list>
         </inputs>
     </step>

--- a/archetype/engine-v2/src/test/resources/input-tree/main.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/main.xml
@@ -20,29 +20,29 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Choice">
+    <step name="Choice">
         <presets>
             <text path="choice">bar</text>
             <boolean path="include">true</boolean>
             <boolean path="include2">false</boolean>
         </presets>
         <inputs>
-            <enum name="choice" label="Choose">
-                <option value="foo" label="Foo">
+            <enum id="choice" name="Choose">
+                <option value="foo" name="Foo">
                     <exec src="foo.xml"/>
                 </option>
-                <option value="bar" label="Bar">
+                <option value="bar" name="Bar">
                     <exec src="bar.xml"/>
                 </option>
             </enum>
-            <boolean name="include" label="include me?">
+            <boolean id="include" name="include me?">
                 <inputs>
-                    <boolean name="yes" label="yep"/>
+                    <boolean id="yes" name="yep"/>
                 </inputs>
             </boolean>
-            <boolean name="include2" label="include too?">
+            <boolean id="include2" name="include too?">
                 <inputs>
-                    <boolean name="y" label="yes"/>
+                    <boolean id="y" name="yes"/>
                 </inputs>
             </boolean>
         </inputs>

--- a/archetype/engine-v2/src/test/resources/input-tree/optional-text-no-default.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/optional-text-no-default.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="optional-no-default" optional="true">
+    <step name="optional-no-default" optional="true">
         <inputs>
-            <text name="foo" label="Default is not required" optional="true"/>
+            <text id="foo" name="Default is not required" optional="true"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/input-tree/substitutions.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/substitutions.xml
@@ -20,16 +20,16 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="substitutions">
+    <step name="substitutions">
         <presets>
             <text path="foo">a-foo</text>
             <text path="bar">a-bar</text>
             <text path="preset">${foo}-${bar}</text>
         </presets>
         <inputs>
-            <text name="text" label="text" default="${preset}"/>
-            <list name="list-things" label="things" optional="true" default="${foo}">
-                <option value="${bar}" label="bar"/>
+            <text id="text" name="text" default="${preset}"/>
+            <list id="list-things" name="things" optional="true" default="${foo}">
+                <option value="${bar}" name="bar"/>
             </list>
         </inputs>
     </step>

--- a/archetype/engine-v2/src/test/resources/input-tree/text-no-default.xml
+++ b/archetype/engine-v2/src/test/resources/input-tree/text-no-default.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="no-default">
+    <step name="no-default">
         <inputs>
-            <text name="foo" label="Default is required"/>
+            <text id="foo" name="Default is required"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/loader/conditional.xml
+++ b/archetype/engine-v2/src/test/resources/loader/conditional.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
+    <presets>
+        <boolean path="path1" if="true">true</boolean>
+        <boolean path="path2" if="false">false</boolean>
+    </presets>
     <step label="Step 1" if="true">
         <help>Help about step 1</help>
         <inputs>
@@ -74,7 +78,7 @@
                 <value key="circle">lavender</value>
                 <value key="triangle" if="false">black</value>
             </map>
-            <map key="shapes2" if="false">
+            <map key="shapes2" if="false &amp;&amp; !true">
                 <value key="circle">white</value>
             </map>
         </model>

--- a/archetype/engine-v2/src/test/resources/loader/conditional.xml
+++ b/archetype/engine-v2/src/test/resources/loader/conditional.xml
@@ -24,10 +24,10 @@
         <boolean path="path1" if="true">true</boolean>
         <boolean path="path2" if="false">false</boolean>
     </presets>
-    <step label="Step 1" if="true">
+    <step name="Step 1" if="true">
         <help>Help about step 1</help>
         <inputs>
-            <boolean name="input1" label="Input 1">
+            <boolean id="input1" name="Input 1">
                 <output if="false">
                     <file source="file3.txt" target="file4.txt"/>
                 </output>

--- a/archetype/engine-v2/src/test/resources/loader/inputs.xml
+++ b/archetype/engine-v2/src/test/resources/loader/inputs.xml
@@ -20,21 +20,21 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
     <inputs>
-        <text name="input1" label="Text input" default="default#1" optional="true" prompt="Enter 1">
+        <text id="input1" name="Text input" description="A text input" default="default#1" optional="true" prompt="Enter 1">
             <help>Help 1</help>
         </text>
-        <boolean name="input2" label="Boolean input" default="true" prompt="Enter 2">
+        <boolean id="input2" name="Boolean input" description="A boolean input" default="true" prompt="Enter 2">
             <help>Help 2</help>
         </boolean>
-        <enum name="input3" label="Enum input" default="option3.1" prompt="Enter 3">
+        <enum id="input3" name="Enum input" description="An enum input" default="option3.1" prompt="Enter 3">
             <help>Help 3</help>
-            <option label="Option 3.1" value="option3.1" />
-            <option label="Option 3.2" value="option3.2" />
+            <option name="Option 3.1" value="option3.1" description="An option" />
+            <option name="Option 3.2" value="option3.2" description="Another option" />
         </enum>
-        <list name="input4" label="List input" default="item4.1,item4.2" prompt="Enter 4">
+        <list id="input4" name="List input" description="A list input" default="item4.1,item4.2" prompt="Enter 4">
             <help>Help 4</help>
-            <option label="Item 4.1" value="item4.1" />
-            <option label="Item 4.2" value="item4.2" />
+            <option name="Item 4.1" value="item4.1" description="An option" />
+            <option name="Item 4.2" value="item4.2" description="Another option" />
         </list>
         <exec src="more-inputs.xml" />
     </inputs>

--- a/archetype/engine-v2/src/test/resources/loader/methods.xml
+++ b/archetype/engine-v2/src/test/resources/loader/methods.xml
@@ -33,11 +33,11 @@
         </method>
     </methods>
     <inputs>
-        <enum name="colors" label="Colors">
-            <option value="red" label="Red">
+        <enum id="colors" name="Colors">
+            <option value="red" name="Red">
                 <call method="red" />
             </option>
-            <option value="blue" label="Blue">
+            <option value="blue" name="Blue">
                 <call method="blue" />
             </option>
         </enum>

--- a/archetype/engine-v2/src/test/resources/loader/more-inputs.xml
+++ b/archetype/engine-v2/src/test/resources/loader/more-inputs.xml
@@ -20,7 +20,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
     <inputs>
-        <text name="more-input1" label="More input 1" default="more#1" optional="true" prompt="More1">
+        <text id="more-input1" name="More input 1" description="Another text input" default="more#1" optional="true" prompt="More1">
             <help>More Help 1</help>
         </text>
     </inputs>

--- a/archetype/engine-v2/src/test/resources/loader/nested-inputs.xml
+++ b/archetype/engine-v2/src/test/resources/loader/nested-inputs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,15 +20,15 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
     <inputs>
-        <boolean name="input1" label="label1">
+        <boolean id="input1" name="label1">
             <inputs>
-                <boolean name="input2" label="label2">
+                <boolean id="input2" name="label2">
                     <inputs>
-                        <boolean name="input3" label="label3">
+                        <boolean id="input3" name="label3">
                             <inputs>
-                                <boolean name="input4" label="label4">
+                                <boolean id="input4" name="label4">
                                     <inputs>
-                                        <boolean name="input5" label="label5"/>
+                                        <boolean id="input5" name="label5"/>
                                     </inputs>
                                 </boolean>
                             </inputs>

--- a/archetype/engine-v2/src/test/resources/loader/nested-output.xml
+++ b/archetype/engine-v2/src/test/resources/loader/nested-output.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@
 <archetype-script xmlns="https://helidon.io/archetype/2.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
-    <step label="my step">
+    <step name="my step">
         <inputs>
-            <boolean name="input1" label="label1">
+            <boolean id="input1" name="label1">
                 <output>
                     <model>
                         <list key="colors">

--- a/archetype/engine-v2/src/test/resources/loader/variables.xml
+++ b/archetype/engine-v2/src/test/resources/loader/variables.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/archetype/engine-v2/src/test/resources/loader/variables.xml
+++ b/archetype/engine-v2/src/test/resources/loader/variables.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,8 +19,12 @@
 <archetype-script xmlns="https://helidon.io/archetype/2.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
-
-    <presets>
-        <text path="input1" resolvable="false">foo</text>
-    </presets>
+    <variables>
+        <boolean path="var1">true</boolean>
+        <text path="var2" transient="true">text1</text>
+        <enum path="var3">enum1</enum>
+        <list path="var4">
+            <value>list1</value>
+        </list>
+    </variables>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/expression-type-mismatch1.xml
+++ b/archetype/engine-v2/src/test/resources/validator/expression-type-mismatch1.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="My Step">
+    <step name="My Step">
         <inputs>
-            <text name="input1" label="Input 1"/>
+            <text id="input1" name="Input 1"/>
         </inputs>
     </step>
     <output if="${input1}"/>

--- a/archetype/engine-v2/src/test/resources/validator/expression-type-mismatch2.xml
+++ b/archetype/engine-v2/src/test/resources/validator/expression-type-mismatch2.xml
@@ -20,8 +20,8 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <presets>
-        <text path="input1" resolvable="false">false</text>
-    </presets>
+    <variables>
+        <text path="input1">false</text>
+    </variables>
     <output if="${input1}"/>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/input-already-declared.xml
+++ b/archetype/engine-v2/src/test/resources/validator/input-already-declared.xml
@@ -20,14 +20,14 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step1" if="true">
+    <step name="Step1" if="true">
         <inputs>
-            <text name="duplicate" label="Duplicate"/>
+            <text id="duplicate" name="Duplicate"/>
         </inputs>
     </step>
-    <step label="Step2" if="false">
+    <step name="Step2" if="false">
         <inputs>
-            <text name="duplicate" label="Duplicate"/>
+            <text id="duplicate" name="Duplicate"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/input-type-mismatch.xml
+++ b/archetype/engine-v2/src/test/resources/validator/input-type-mismatch.xml
@@ -20,17 +20,17 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="Step">
+    <step name="Step">
         <inputs>
-            <enum name="enum1" label="Enum1">
-                <option label="Foo" value="foo">
+            <enum id="enum1" name="Enum1">
+                <option name="Foo" value="foo">
                     <inputs>
-                        <text name="duplicate" label="Duplicate"/>
+                        <text id="duplicate" name="Duplicate"/>
                     </inputs>
                 </option>
-                <option label="Bar" value="bar">
+                <option name="Bar" value="bar">
                     <inputs>
-                        <boolean name="duplicate" label="Duplicate"/>
+                        <boolean id="duplicate" name="Duplicate"/>
                     </inputs>
                 </option>
             </enum>

--- a/archetype/engine-v2/src/test/resources/validator/input1.xml
+++ b/archetype/engine-v2/src/test/resources/validator/input1.xml
@@ -21,6 +21,6 @@
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
     <inputs>
-        <text name="input1" label="Input 1"/>
+        <text id="input1" name="Input 1"/>
     </inputs>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/option-value-already-declared.xml
+++ b/archetype/engine-v2/src/test/resources/validator/option-value-already-declared.xml
@@ -20,11 +20,11 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="A step">
+    <step name="A step">
         <inputs>
-            <enum name="my-enum" label="My Enum">
-                <option label="option1" value="option1"/>
-                <option label="option1.1" value="option1"/>
+            <enum id="my-enum" name="My Enum">
+                <option name="option1" value="option1"/>
+                <option name="option1.1" value="option1"/>
             </enum>
         </inputs>
     </step>

--- a/archetype/engine-v2/src/test/resources/validator/optional-input-no-default.xml
+++ b/archetype/engine-v2/src/test/resources/validator/optional-input-no-default.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="optional-step" optional="true">
+    <step name="optional-step" optional="true">
         <inputs>
-            <text name="optional" label="Default is required" optional="true"/>
+            <text id="optional" name="Default is required" optional="true"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/optional-step-required-input.xml
+++ b/archetype/engine-v2/src/test/resources/validator/optional-step-required-input.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="optional-step" optional="true">
+    <step name="optional-step" optional="true">
         <inputs>
-            <text name="non-optional" label="Default is required" default="ok"/>
+            <text id="non-optional" name="Default is required" default="ok"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/optional-step-within-required-step.xml
+++ b/archetype/engine-v2/src/test/resources/validator/optional-step-within-required-step.xml
@@ -20,22 +20,22 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="required-step">
+    <step name="required-step">
         <inputs>
-            <enum name="choice" label="Choose" default="foo">
-                <option value="foo" label="Foo">
-                    <step label="optional-step" optional="true">
+            <enum id="choice" name="Choose" default="foo">
+                <option value="foo" name="Foo">
+                    <step name="optional-step" optional="true">
                         <inputs>
-                            <text name="optional" label="Default is required" default="ok" optional="true"/>
+                            <text id="optional" name="Default is required" default="ok" optional="true"/>
                         </inputs>
                     </step>
                 </option>
-                <option value="bar" label="Bar">
+                <option value="bar" name="Bar">
                     <inputs>
-                        <list name="colors" label="Select colors" default="red,yellow" optional="true">
-                            <option value="red" label="Red"/>
-                            <option value="orange" label="Orange"/>
-                            <option value="yellow" label="Yellow"/>
+                        <list id="colors" name="Select colors" default="red,yellow" optional="true">
+                            <option value="red" name="Red"/>
+                            <option value="orange" name="Orange"/>
+                            <option value="yellow" name="Yellow"/>
                         </list>
                     </inputs>
                 </option>

--- a/archetype/engine-v2/src/test/resources/validator/preset-type-mismatch.xml
+++ b/archetype/engine-v2/src/test/resources/validator/preset-type-mismatch.xml
@@ -23,9 +23,9 @@
     <presets>
         <text path="input1">foo</text>
     </presets>
-    <step label="My Step">
+    <step name="My Step">
         <inputs>
-            <boolean name="input1" label="Input 1"/>
+            <boolean id="input1" name="Input 1"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/required-step-optional-input.xml
+++ b/archetype/engine-v2/src/test/resources/validator/required-step-optional-input.xml
@@ -20,9 +20,9 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="required-step">
+    <step name="required-step">
         <inputs>
-            <text name="non-optional" label="Default is required" default="ok" optional="true"/>
+            <text id="non-optional" name="Default is required" default="ok" optional="true"/>
         </inputs>
     </step>
 </archetype-script>

--- a/archetype/engine-v2/src/test/resources/validator/required-step-within-optional-step.xml
+++ b/archetype/engine-v2/src/test/resources/validator/required-step-within-optional-step.xml
@@ -20,22 +20,22 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="optional-step" optional="true">
+    <step name="optional-step" optional="true">
         <inputs>
-            <enum name="choice" label="Choose" optional="true" default="foo">
-                <option value="foo" label="Foo">
-                    <step label="required-step">
+            <enum id="choice" name="Choose" optional="true" default="foo">
+                <option value="foo" name="Foo">
+                    <step name="required-step">
                         <inputs>
-                            <text name="required" label="Default is required" default="ok"/>
+                            <text id="required" name="Default is required" default="ok"/>
                         </inputs>
                     </step>
                 </option>
-                <option value="bar" label="Bar">
+                <option value="bar" name="Bar">
                     <inputs>
-                        <list name="colors" label="Select colors" default="red,yellow" optional="true">
-                            <option value="red" label="Red"/>
-                            <option value="orange" label="Orange"/>
-                            <option value="yellow" label="Yellow"/>
+                        <list id="colors" name="Select colors" default="red,yellow" optional="true">
+                            <option value="red" name="Red"/>
+                            <option value="orange" name="Orange"/>
+                            <option value="yellow" name="Yellow"/>
                         </list>
                     </inputs>
                 </option>

--- a/archetype/engine-v2/src/test/resources/validator/step-with-no-inputs.xml
+++ b/archetype/engine-v2/src/test/resources/validator/step-with-no-inputs.xml
@@ -20,5 +20,5 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
 
-    <step label="empty-step"/>
+    <step name="empty-step"/>
 </archetype-script>

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeInvoker.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeInvoker.java
@@ -85,6 +85,7 @@ abstract class ArchetypeInvoker {
     private final Map<String, String> initProperties;
     private final Function<String, Path> projectDirSupplier;
     private final UserConfig userConfig;
+    private final Runnable onResolved;
 
     private ArchetypeInvoker(Builder builder) {
         metadata = builder.metadata;
@@ -92,6 +93,7 @@ abstract class ArchetypeInvoker {
         initProperties = unmodifiableMap(builder.initProperties);
         projectDirSupplier = builder.projectDirSupplier;
         userConfig = builder.userConfig;
+        onResolved = builder.onResolved;
     }
 
     /**
@@ -128,6 +130,15 @@ abstract class ArchetypeInvoker {
      */
     protected UserConfig userConfig() {
         return userConfig;
+    }
+
+    /**
+     * Get the {@code onResolved} callback.
+     *
+     * @return Runnable
+     */
+    protected Runnable onResolved() {
+        return onResolved;
     }
 
     /**
@@ -183,6 +194,7 @@ abstract class ArchetypeInvoker {
         private final Map<String, String> initProperties;
         private Function<String, Path> projectDirSupplier;
         private UserConfig userConfig;
+        private Runnable onResolved;
 
         private Builder() {
             initProperties = new HashMap<>();
@@ -229,6 +241,17 @@ abstract class ArchetypeInvoker {
          */
         Builder userConfig(UserConfig config) {
             this.userConfig = config;
+            return this;
+        }
+
+        /**
+         * Set the callback to be invoked when inputs are fully resolved.
+         *
+         * @param onResolved callback
+         * @return this builder
+         */
+        Builder onResolved(Runnable onResolved) {
+            this.onResolved = onResolved;
             return this;
         }
 
@@ -363,7 +386,7 @@ abstract class ArchetypeInvoker {
         private static final String ARTIFACT_ID_PROPERTY = "artifactId";
         private static final String PACKAGE_NAME_PROPERTY = "package";
         private static final String BUILD_SYSTEM_PROPERTY = "build-system";
-        private static final String ARCHETYPE_BASE_PROPERTY = "base";
+        private static final String ARCHETYPE_BASE_PROPERTY = "app-type";
 
         private V2Invoker(Builder builder) {
             super(builder);
@@ -401,9 +424,9 @@ abstract class ArchetypeInvoker {
                 Log.warn("--name option is not used in Helidon 3.x");
             }
 
-            InputResolver inputResolver;
+            InputResolver resolver;
             if (isInteractive()) {
-                inputResolver = new TerminalInputResolver(System.in);
+                resolver = new TerminalInputResolver(System.in);
 
                 // Set remaining command-line options as external values and user config as external defaults
                 if (initOptions.groupIdOption() != null) {
@@ -422,7 +445,7 @@ abstract class ArchetypeInvoker {
                     externalDefaults.put(PACKAGE_NAME_PROPERTY, initOptions.packageName());
                 }
             } else {
-                inputResolver = new BatchInputResolver();
+                resolver = new BatchInputResolver();
 
                 // Batch mode, so pass merged init options as external values
                 externalValues.put(GROUP_ID_PROPERTY, initOptions.groupId());
@@ -433,7 +456,7 @@ abstract class ArchetypeInvoker {
             //noinspection ConstantConditions
             ArchetypeEngineV2 engine = new ArchetypeEngineV2(archetype());
             try {
-                return engine.generate(inputResolver, externalValues, externalDefaults, projectDirSupplier());
+                return engine.generate(resolver, externalValues, externalDefaults, onResolved(), projectDirSupplier());
             } catch (InvocationException ie) {
                 Throwable cause = ie.getCause();
                 if (cause instanceof UnresolvedInputException) {

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeInvoker.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/ArchetypeInvoker.java
@@ -364,7 +364,7 @@ abstract class ArchetypeInvoker {
             }
 
             Path projectDir = projectDirSupplier().apply(initProperties.get("name"));
-            engine.generate(projectDir.toFile());
+            engine.generate(projectDir);
 
             // Create config file that includes feature information
             ProjectConfig configFile = createProjectConfig(projectDir, helidonVersion);

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/InitCommand.java
@@ -98,6 +98,7 @@ public final class InitCommand extends BaseCommand {
                 .metadata(metadata)
                 .initOptions(initOptions)
                 .userConfig(config)
+                .onResolved(Log::info)
                 .initProperties(context.properties())
                 .projectDir(this::initProjectDir)
                 .build();
@@ -134,7 +135,6 @@ public final class InitCommand extends BaseCommand {
             if (projectDirSpecified || config.failOnProjectNameCollision()) {
                 failed("$(red Directory $(plain %s) already exists)", projectDir);
             }
-            Log.info();
             Log.info("$(italic,yellow Directory $(plain %s) already exists, generating unique name)", projectDir);
             Path parentDirectory = projectDir.getParent();
             for (int i = 2; i < 128; i++) {

--- a/cli/impl/src/main/java/io/helidon/build/cli/impl/InitOptions.java
+++ b/cli/impl/src/main/java/io/helidon/build/cli/impl/InitOptions.java
@@ -49,7 +49,7 @@ public final class InitOptions {
     /**
      * The default archetype name.
      */
-    static final String DEFAULT_ARCHETYPE_NAME = "bare";
+    static final String DEFAULT_ARCHETYPE_NAME = "quickstart";
 
     private Flavor flavor;
     private String helidonVersion;
@@ -329,7 +329,7 @@ public final class InitOptions {
                     case "init_flavor":
                         return "${flavor}";
                     case "init_archetype":
-                        return "${base}";
+                        return "${app-type}";
                     case "init_build":
                         return "${build-system}";
                     default:

--- a/common/common/src/main/java/io/helidon/build/common/ConfigProperties.java
+++ b/common/common/src/main/java/io/helidon/build/common/ConfigProperties.java
@@ -16,10 +16,10 @@
 
 package io.helidon.build.common;
 
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -177,7 +177,7 @@ public class ConfigProperties {
      */
     public void load() {
         if (exists()) {
-            try (FileReader reader = new FileReader(file.toFile())) {
+            try (Reader reader = Files.newBufferedReader(file)) {
                 properties.load(reader);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -197,7 +197,7 @@ public class ConfigProperties {
      * @param comments The file comments. May be {@code null}.
      */
     public void store(String comments) {
-        try (FileWriter writer = new FileWriter(file.toFile())) {
+        try (Writer writer = Files.newBufferedWriter(file)) {
             properties.store(writer, comments);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/common/xml/src/main/java/io/helidon/build/common/xml/SimpleXMLParser.java
+++ b/common/xml/src/main/java/io/helidon/build/common/xml/SimpleXMLParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/xml/src/main/java/io/helidon/build/common/xml/SimpleXMLParser.java
+++ b/common/xml/src/main/java/io/helidon/build/common/xml/SimpleXMLParser.java
@@ -301,6 +301,20 @@ public final class SimpleXMLParser {
     }
 
     /**
+     * Replace XML entities with their non escaped values.
+     *
+     * @param input string containing XML entities
+     * @return new string with replaced values
+     */
+    public static String processXmlEscapes(String input) {
+        return input.replaceAll("&quot;", "\"")
+                    .replaceAll("&apos", "'")
+                    .replaceAll("&lt;", "<")
+                    .replaceAll("&gt;", ">")
+                    .replaceAll("&amp;", "&");
+    }
+
+    /**
      * Get the current line number.
      *
      * @return line number
@@ -568,7 +582,7 @@ public final class SimpleXMLParser {
     }
 
     private void validateAttrValueChar(char c) {
-        if (c == MARKUP_START || c == MARKUP_END || c == '&') {
+        if (c == MARKUP_START || c == MARKUP_END) {
             throw new IllegalStateException(String.format(
                     "Invalid character found in value: '%c', line: %d, char: %d", c, lineNo, charNo));
         }

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test1/src/main/archetype/main.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test1/src/main/archetype/main.xml
@@ -20,17 +20,17 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Shapes">
+    <step name="Shapes">
         <inputs>
-            <enum name="shape" label="Select a shape">
-                <option value="circle" label="Circle"/>
-                <option value="triangle" label="Triangle" />
-                <option value="square" label="Square" />
+            <enum id="shape" name="Select a shape">
+                <option value="circle" name="Circle"/>
+                <option value="triangle" name="Triangle" />
+                <option value="square" name="Square" />
             </enum>
-            <text name="package" label="Java package" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="groupId" label="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="artifactId" label="Project artifactId" default="${shape}-project"/>
-            <text name="version" label="Project version" default="0.1-SNAPSHOT"/>
+            <text id="package" name="Java package" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="groupId" name="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="artifactId" name="Project artifactId" default="${shape}-project"/>
+            <text id="version" name="Project version" default="0.1-SNAPSHOT"/>
             <output>
                 <transformation id="packaged">
                     <replace regex="__pkg__" replacement="${package/\./\/}"/>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test2/src/main/archetype/main.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test2/src/main/archetype/main.xml
@@ -20,16 +20,16 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Shapes">
+    <step name="Shapes">
         <inputs>
-            <enum name="shape" label="Select a shape">
-                <option value="circle" label="Circle"/>
-                <option value="square" label="Square" />
+            <enum id="shape" name="Select a shape">
+                <option value="circle" name="Circle"/>
+                <option value="square" name="Square" />
             </enum>
-            <text name="package" label="Java package" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="groupId" label="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="artifactId" label="Project artifactId" default="${shape}-project"/>
-            <text name="version" label="Project version" default="0.1-SNAPSHOT"/>
+            <text id="package" name="Java package" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="groupId" name="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="artifactId" name="Project artifactId" default="${shape}-project"/>
+            <text id="version" name="Project version" default="0.1-SNAPSHOT"/>
             <output>
                 <transformation id="packaged">
                     <replace regex="__pkg__" replacement="${package/\./\/}"/>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test3/src/main/archetype/shape.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test3/src/main/archetype/shape.xml
@@ -20,15 +20,15 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Shapes">
+    <step name="Shapes">
         <inputs>
-            <enum name="shape" label="Select a shape">
-                <option value="rectangle" label="Rectangle" />
+            <enum id="shape" name="Select a shape">
+                <option value="rectangle" name="Rectangle" />
             </enum>
-            <text name="package" label="Java package" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="groupId" label="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="artifactId" label="Project artifactId" default="${shape}-project"/>
-            <text name="version" label="Project version" default="0.1-SNAPSHOT"/>
+            <text id="package" name="Java package" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="groupId" name="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="artifactId" name="Project artifactId" default="${shape}-project"/>
+            <text id="version" name="Project version" default="0.1-SNAPSHOT"/>
             <output>
                 <transformation id="packaged">
                     <replace regex="__pkg__" replacement="${package/\./\/}"/>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module1/src/main/archetype/main.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test4/module1/src/main/archetype/main.xml
@@ -20,16 +20,16 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Shapes">
+    <step name="Shapes">
         <inputs>
-            <enum name="shape" label="Select a shape">
-                <option value="triangle" label="Triangle" />
-                <option value="rectangle" label="Rectangle" />
+            <enum id="shape" name="Select a shape">
+                <option value="triangle" name="Triangle" />
+                <option value="rectangle" name="Rectangle" />
             </enum>
-            <text name="package" label="Java package" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="groupId" label="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
-            <text name="artifactId" label="Project artifactId" default="${shape}-project"/>
-            <text name="version" label="Project version" default="0.1-SNAPSHOT"/>
+            <text id="package" name="Java package" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="groupId" name="Project groupId" default="io.helidon.build.maven.archetype.tests"/>
+            <text id="artifactId" name="Project artifactId" default="${shape}-project"/>
+            <text id="version" name="Project version" default="0.1-SNAPSHOT"/>
             <output>
                 <transformation id="packaged">
                     <replace regex="__pkg__" replacement="${package/\./\/}"/>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
@@ -28,6 +28,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import io.helidon.build.archetype.engine.v2.ArchetypeEngineV2;
 import io.helidon.build.archetype.engine.v2.BatchInputResolver;
@@ -210,14 +214,23 @@ public class IntegrationTestMojo extends AbstractMojo {
         try {
             if (generateCombinations) {
                 logCombinationsInput(testName);
-                InputCombinations combinations = InputCombinations.builder()
-                                                                  .archetypePath(archetypeFile.toPath())
-                                                                  .externalValues(externalValues)
-                                                                  .externalDefaults(externalDefaults)
-                                                                  .build();
+                List<Map<String, String>> combinations = InputCombinations.builder()
+                                                                          .archetypePath(archetypeFile.toPath())
+                                                                          .externalValues(externalValues)
+                                                                          .externalDefaults(externalDefaults)
+                                                                          .build()
+                                                                          .toList();
 
-                // TODO print the number of combinations
+                log.info("Total combinations: " + combinations.size());
+                for (Map<String, String> combination : combinations) {
+                    combinationNumber++;
+                    log.info(combinationNumber + ": " + combination);
+                }
 
+                // TODO add a mojo to print the combinations (helidon-archetype:combinations)
+                // TODO add an option to run a combination by id(s)
+                // TODO 'none' shows up as empty string
+                combinationNumber = 0;
                 for (Map<String, String> combination : combinations) {
                     combinationNumber++;
                     processIntegrationTest(testName, combination, archetypeFile);
@@ -368,7 +381,7 @@ public class IntegrationTestMojo extends AbstractMojo {
                 ArchetypeNotConfigured anc = (ArchetypeNotConfigured) result.getCause();
                 throw new MojoExecutionException(
                         "Missing required properties in archetype.properties: "
-                        + StringUtils.join(anc.getMissingProperties().iterator(), ", "), anc);
+                                + StringUtils.join(anc.getMissingProperties().iterator(), ", "), anc);
             }
             throw new MojoExecutionException(result.getCause().getMessage(), result.getCause());
         }
@@ -409,7 +422,7 @@ public class IntegrationTestMojo extends AbstractMojo {
             getLog().info("Post-archetype-generation invoker exit code: " + result.getExitCode());
             if (result.getExitCode() != 0) {
                 throw new MojoExecutionException("Execution failure: exit code = " + result.getExitCode(),
-                                                 result.getExecutionException());
+                        result.getExecutionException());
             }
         } catch (MavenInvocationException ex) {
             throw new MojoExecutionException(ex.getMessage(), ex);

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/IntegrationTestMojo.java
@@ -28,10 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import io.helidon.build.archetype.engine.v2.ArchetypeEngineV2;
 import io.helidon.build.archetype.engine.v2.BatchInputResolver;

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/common/common.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/common/common.xml
@@ -22,9 +22,9 @@
 
 
     <inputs>
-        <list name="build-system"
-              label="Select a build system">
-            <option value="maven" label="Apache Maven">
+        <list id="build-system"
+              name="Select a build system">
+            <option value="maven" name="Apache Maven">
                 <output>
                     <templates transformations="mustache">
                         <directory>.</directory>
@@ -34,7 +34,7 @@
                     </templates>
                 </output>
             </option>
-            <option value="gradle" label="Gradle"/>
+            <option value="gradle" name="Gradle"/>
         </list>
     </inputs>
 

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/common/customize-project.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/common/customize-project.xml
@@ -29,41 +29,41 @@
         <text path="default.helidon.version">2.3.3</text>
     </p>
 
-    <step label="Customize Project">
+    <step name="Customize Project">
 
         <inputs>
-            <text name="project.name"
-                  label="Project name"
+            <text id="project.name"
+                  name="Project name"
                   optional="true"
                   default="${default.project.name}"
             />
 
-            <text name="project.groupId"
-                  label="Project groupId"
+            <text id="project.groupId"
+                  name="Project groupId"
                   optional="true"
                   default="${default.group.id}"
             />
 
-            <text name="project.artifactId"
-                  label="Project artifactId"
+            <text id="project.artifactId"
+                  name="Project artifactId"
                   optional="true"
                   default="${default.artifact.id}"
             />
 
-            <text name="project.version"
-                  label="Project version"
+            <text id="project.version"
+                  name="Project version"
                   optional="true"
                   default="${default.project.version}"
             />
 
-            <text name="package"
-                  label="Java package name"
+            <text id="package"
+                  name="Java package name"
                   optional="true"
                   default="${default.package.name}"
             />
 
-            <text name="helidon.version"
-                  label="Helidon version"
+            <text id="helidon.version"
+                  name="Helidon version"
                   optional="true"
                   default="${default.helidon.version}"
             />

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/flavor.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/flavor.xml
@@ -20,13 +20,13 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Helidon Flavor">
+    <step name="Helidon Flavor">
         <inputs>
-            <enum name="flavor" label="Select a flavor">
-                <option value="se" label="Helidon SE">
+            <enum id="flavor" name="Select a flavor">
+                <option value="se" name="Helidon SE">
                     <source src="se/se.xml"/>
                 </option>
-                <option value="mp" label="Helidon MP">
+                <option value="mp" name="Helidon MP">
                     <source src="mp/mp.xml"/>
                 </option>
             </enum>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/se/se.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/duplicate-include/se/se.xml
@@ -20,31 +20,31 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Application Type">
+    <step name="Application Type">
         <inputs>
-            <list name="base" label="Select archetype">
+            <list id="base" name="Select archetype">
                 <option value="hello-world"
-                        label="Helidon SE Hello World project">
+                        name="Helidon SE Hello World project">
 
                     <source src="hello-world/hello-world-se.xml"/>
                 </option>
                 <option value="secure-hello-world"
-                        label="Helidon SE secure Hello World project">
+                        name="Helidon SE secure Hello World project">
 
                     <source src="secure-hello-world/secure-hello-world-se.xml"/>
                 </option>
                 <option value="quickstart"
-                        label="Sample Helidon SE project that includes multiple REST operations">
+                        name="Sample Helidon SE project that includes multiple REST operations">
 
                     <exec src="quickstart/quickstart-se.xml"/>
                 </option>
                 <option value="database"
-                        label="Helidon SE application that uses the dbclient API with an in-memory H2 database">
+                        name="Helidon SE application that uses the dbclient API with an in-memory H2 database">
 
                     <source src="database/database-se.xml"/>
                 </option>
                 <option value="bare"
-                        label="Bare Helidon SE project suitable to start from scratch">
+                        name="Bare Helidon SE project suitable to start from scratch">
 
                     <source src="bare/bare-se.xml"/>
                 </option>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/common/common.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/common/common.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
     <inputs>
-        <enum name="build-system"
-              label="Select a build system">
-            <option value="maven" label="Apache Maven">
+        <enum id="build-system"
+              name="Select a build system">
+            <option value="maven" name="Apache Maven">
                 <exec src="pom-file.xml"/>
             </option>
-            <option value="gradle" label="Gradle"/>
+            <option value="gradle" name="Gradle"/>
         </enum>
     </inputs>
 

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/common/customize-project.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/common/customize-project.xml
@@ -29,41 +29,41 @@
         <text path="default.helidon.version">2.3.3</text>
     </p>
 
-    <step label="Customize Project">
+    <step name="Customize Project">
 
         <inputs>
-            <text name="project.name"
-                  label="Project name"
+            <text id="project.name"
+                  name="Project name"
                   optional="true"
                   default="${default.project.name}"
             />
 
-            <text name="project.groupId"
-                  label="Project groupId"
+            <text id="project.groupId"
+                  name="Project groupId"
                   optional="true"
                   default="${default.group.id}"
             />
 
-            <text name="project.artifactId"
-                  label="Project artifactId"
+            <text id="project.artifactId"
+                  name="Project artifactId"
                   optional="true"
                   default="${default.artifact.id}"
             />
 
-            <text name="project.version"
-                  label="Project version"
+            <text id="project.version"
+                  name="Project version"
                   optional="true"
                   default="${default.project.version}"
             />
 
-            <text name="package"
-                  label="Java package name"
+            <text id="package"
+                  name="Java package name"
                   optional="true"
                   default="${default.package.name}"
             />
 
-            <text name="helidon.version"
-                  label="Helidon version"
+            <text id="helidon.version"
+                  name="Helidon version"
                   optional="true"
                   default="${default.helidon.version}"
             />

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/flavor.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/flavor.xml
@@ -20,13 +20,13 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Helidon Flavor">
+    <step name="Helidon Flavor">
         <inputs>
-            <enum name="flavor" label="Select a flavor">
-                <option value="se" label="Helidon SE">
+            <enum id="flavor" name="Select a flavor">
+                <option value="se" name="Helidon SE">
                     <source src="se/se.xml"/>
                 </option>
-                <option value="mp" label="Helidon MP">
+                <option value="mp" name="Helidon MP">
                 </option>
             </enum>
         </inputs>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/se/se.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/include-cycle/se/se.xml
@@ -20,19 +20,19 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Application Type">
+    <step name="Application Type">
         <inputs>
-            <enum name="base" label="Select archetype">
+            <enum id="base" name="Select archetype">
                 <option value="quickstart"
-                        label="Sample Helidon SE project that includes multiple REST operations">
+                        name="Sample Helidon SE project that includes multiple REST operations">
 
                 </option>
                 <option value="database"
-                        label="Helidon SE application that uses the dbclient API with an in-memory H2 database">
+                        name="Helidon SE application that uses the dbclient API with an in-memory H2 database">
 
                 </option>
                 <option value="bare"
-                        label="Minimal Helidon SE project suitable to start from scratch">
+                        name="Minimal Helidon SE project suitable to start from scratch">
                     <exec src="bare/bare-se.xml"/>
                 </option>
             </enum>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/schema/colors.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/schema/colors.xml
@@ -20,11 +20,11 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Colors">
+    <step name="Colors">
         <inputs>
-            <enum name="color" label="Select a color">
-                <option value="red" label="Red"/>
-                <option value="blue" label="Blue"/>
+            <enum id="color" name="Select a color">
+                <option value="red" name="Red"/>
+                <option value="blue" name="Blue"/>
             </enum>
         </inputs>
     </step>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/schema/shapes.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/schema/shapes.xml
@@ -20,11 +20,11 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Shapes">
+    <step name="Shapes">
         <input>
-            <enum name="shape" label="Select a shape">
-                <option value="circle" label="Circle"/>
-                <option value="triangle" label="Triangle"/>
+            <enum id="shape" name="Select a shape">
+                <option value="circle" name="Circle"/>
+                <option value="triangle" name="Triangle"/>
             </enum>
         </input>
     </step>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/simple/main.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/resources/simple/main.xml
@@ -20,11 +20,11 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-script-2.0.xsd">
 
-    <step label="Colors">
+    <step name="Colors">
         <inputs>
-            <enum name="color" label="Select a color">
-                <option value="red" label="Red"/>
-                <option value="blue" label="Blue"/>
+            <enum id="color" name="Select a color">
+                <option value="red" name="Red"/>
+                <option value="blue" name="Blue"/>
             </enum>
             <output>
                 <transformation id="mustache">


### PR DESCRIPTION
- Update Archetype engine v1 to use Path instead of File to allow for in-memory archive generation using FileSystem.
- Fix ScriptSerializer issues with variables and conditions
- Update XML schema and rename name to id, label to name and add a new attribute description
- Minor rework of Context and global scope
- Update AST and ScriptLoader to group loader, path and location as a single object to improve the builders
- Renamed to Node.id() to Node.uid()