### PR TITLE
Helidon 2.X - Add additional licensing report formats

### DIFF
--- a/helidon-maven-plugin/src/main/java/io/helidon/build/maven/report/ReportMojo.java
+++ b/helidon-maven-plugin/src/main/java/io/helidon/build/maven/report/ReportMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,12 @@ public class ReportMojo
     @Parameter(property = Report.INPUT_FILE_DIR_PROPERTY_NAME)
     private String inputFileDir;
 
-    // Output report (text) file
+    // Output report file format
+    @Parameter(property = Report.OUTPUT_FILE_FORMAT_PROPERTY_NAME,
+            defaultValue = Report.DEFAULT_OUTPUT_FILE_FORMAT, required = true)
+    private String outputFileFormat;
+
+    // Output report file
     @Parameter(property = Report.OUTPUT_FILE_NAME_PROPERTY_NAME, defaultValue = Report.DEFAULT_OUTPUT_FILE_NAME, required = true)
     private String outputFileName;
 
@@ -86,9 +91,11 @@ public class ReportMojo
                 .inputFileName(inputFileName)
                 .moduleList(modules)
                 .inputFileDir(inputFileDir)
+                .outputFileFormat(outputFileFormat)
                 .outputFileName(outputFileName)
                 .outputFileDir(outputFileDir)
-                .outputHandler((s) -> getLog().info(s));
+                .outputHandler((s) -> getLog().info(s))
+                .errorHandler((s) -> getLog().error(s));
 
         // If no modules were provided, then scan this project and get all the
         // helidon artifacts that are dependencies and use that for the module list.

--- a/licensing/pom.xml
+++ b/licensing/pom.xml
@@ -42,18 +42,6 @@
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>

--- a/licensing/pom.xml
+++ b/licensing/pom.xml
@@ -42,6 +42,22 @@
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/licensing/src/main/java/io/helidon/build/licensing/Report.java
+++ b/licensing/src/main/java/io/helidon/build/licensing/Report.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,6 @@
  */
 
 package io.helidon.build.licensing;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import io.helidon.build.licensing.model.AttributionDependency;
-import io.helidon.build.licensing.model.AttributionDocument;
-import io.helidon.build.licensing.model.AttributionLicense;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -48,6 +35,18 @@ import java.util.stream.Collectors;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
+
+import io.helidon.build.licensing.model.AttributionDependency;
+import io.helidon.build.licensing.model.AttributionDocument;
+import io.helidon.build.licensing.model.AttributionLicense;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Generate a report from attribution xml file.
@@ -477,7 +476,8 @@ public class Report {
         w.write("<body>\n");
         w.write("<h1>Third Party Attributions");
         w.write("<table border=1>");
-        w.write("<tr><th>Name</th><th>Version</th><th>Licensor</th><th>License Name</th><th>Attribution</th><th>Used By</th></tr>\n");
+        w.write("<tr><th>Name</th><th>Version</th><th>Licensor</th><th>License Name</th>");
+        w.write("<th>Attribution</th><th>Used By</th></tr>\n");
         List<AttributionDependency> deps = attributionDocument.getDependencies();
         Set<String> licensesUsed = new HashSet<>();
         boolean first = true;
@@ -485,13 +485,16 @@ public class Report {
             HashSet<String> intersection = new HashSet<>(moduleList);
             intersection.retainAll(d.getConsumers());
             if (moduleList.isEmpty() || !intersection.isEmpty()) {
-                w.write(String.format("<tr valign=top><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td><textarea readonly style=\"width: 900px; height: 283px;\">%s</textarea></td><td><ul><li>%s</ul></td></tr>\n",
-                        d.getName(),
-                        d.getVersion(),
-                        d.getLicensor(),
-                        d.getLicenseName(),
-                        StringEscapeUtils.escapeHtml4(d.getAttribution()),
+                w.write("<tr valign=top>");
+                w.write(String.format("<td>%s</td>", d.getName()));
+                w.write(String.format("<td>%s</td>", d.getVersion()));
+                w.write(String.format("<td>%s</td>", d.getLicensor()));
+                w.write(String.format("<td>%s</td>", d.getLicenseName()));
+                w.write(String.format("<td><textarea readonly style=\"width: 900px; height: 283px;\">%s</textarea></td>",
+                        StringEscapeUtils.escapeHtml4(d.getAttribution())));
+                w.write(String.format("<td><ul><li>%s</ul></td>",
                         String.join("<li>", d.getConsumers())));
+                w.write("</tr>");
 
                 detectLicenses(licensesUsed, d.getAttribution());
 
@@ -518,8 +521,9 @@ public class Report {
             } else {
                 licenseText = "No license text found for " + s;
             }
-            w.write(String.format("<tr valign=top><td>%s</td><td><textarea readonly style=\"width: 900px; height: 283px;\">%s</textarea></td></tr>\n",
-                    s, StringEscapeUtils.escapeHtml4(licenseText)));
+            w.write(String.format("<tr valign=top><td>%s</td>", s));
+            w.write(String.format("<td><textarea readonly style=\"width: 900px; height: 283px;\">%s</textarea></td></tr>%n",
+                    StringEscapeUtils.escapeHtml4(licenseText)));
         }
         w.write("</table>\n");
 

--- a/licensing/src/main/java/io/helidon/build/licensing/Report.java
+++ b/licensing/src/main/java/io/helidon/build/licensing/Report.java
@@ -389,20 +389,21 @@ public class Report {
                     w.write("\t\t, {\n");
                 }
 
-                w.write(String.format("\t\t\t\"name\": \"%s\"\n", jsonEscape(d.getName())));
-                if (includeVersion)
-                    w.write(String.format("\t\t\t, \"version\": \"%s\"\n", jsonEscape(d.getVersion())));
-                w.write(String.format("\t\t\t, \"licensor\": \"%s\"\n", jsonEscape(d.getLicensor())));
-                w.write(String.format("\t\t\t, \"license-name\": \"%s\"\n", jsonEscape(d.getLicenseName())));
-                w.write(String.format("\t\t\t, \"attribution\": \"%s\"\n", jsonEscape(d.getAttribution())));
-                w.write(String.format("\t\t\t, \"used-by\": [\n"));
+                w.write(String.format("\t\t\t\"name\": \"%s\"%n", jsonEscape(d.getName())));
+                if (includeVersion) {
+                    w.write(String.format("\t\t\t, \"version\": \"%s\"%n", jsonEscape(d.getVersion())));
+                }
+                w.write(String.format("\t\t\t, \"licensor\": \"%s\"%n", jsonEscape(d.getLicensor())));
+                w.write(String.format("\t\t\t, \"license-name\": \"%s\"%n", jsonEscape(d.getLicenseName())));
+                w.write(String.format("\t\t\t, \"attribution\": \"%s\"%n", jsonEscape(d.getAttribution())));
+                w.write(String.format("\t\t\t, \"used-by\": [%n"));
                 boolean firstConsumer = true;
                 for (String consumer : d.getConsumers()) {
                     if (firstConsumer) {
-                        w.write(String.format("\t\t\t\t\"%s\"\n", jsonEscape(consumer)));
+                        w.write(String.format("\t\t\t\t\"%s\"%n", jsonEscape(consumer)));
                         firstConsumer = false;
                     } else {
-                        w.write(String.format("\t\t\t\t, \"%s\"\n", jsonEscape(consumer)));
+                        w.write(String.format("\t\t\t\t, \"%s\"%n", jsonEscape(consumer)));
                     }
                 }
                 w.write("\t\t\t]\n");
@@ -431,9 +432,9 @@ public class Report {
             AttributionLicense license = getLicense(attributionDocument, s);
             String sJson = jsonEscape(s);
             if (license != null) {
-                w.write(String.format("\t\t%s\"%s\": \"%s\"\n", (first ? "":", "), sJson, jsonEscape(license.getText())));
+                w.write(String.format("\t\t%s\"%s\": \"%s\"%n", (first ? "" : ", "), sJson, jsonEscape(license.getText())));
             } else {
-                w.write(String.format("\t\t%s\"%s\": \"\"No license text found for %s\"\n", (first ? "":", "), sJson, sJson));
+                w.write(String.format("\t\t%s\"%s\": \"\"No license text found for %s\"%n", (first ? "" : ", "), sJson, sJson));
             }
 
             first = false;
@@ -446,6 +447,10 @@ public class Report {
     }
 
     private static String jsonEscape(String str) {
+        if (str == null) {
+            return "";
+        }
+
         return str
                 .replaceAll("\\\\", "\\\\\\\\")
                 .replaceAll("\n", "\\\\n")
@@ -465,7 +470,8 @@ public class Report {
         w.write("<body>\n");
         w.write("<h1>Third Party Attributions");
         w.write("<table border=1>");
-        w.write(String.format("<tr><th>Name</th>%s<th>Licensor</th><th>License Name</th>", includeVersion ? "<th>Version</th>":""));
+        w.write(String.format("<tr><th>Name</th>%s<th>Licensor</th><th>License Name</th>",
+                includeVersion ? "<th>Version</th>" : ""));
         w.write("<th>Attribution</th><th>Used By</th></tr>\n");
         List<AttributionDependency> deps = attributionDocument.getDependencies();
         Set<String> licensesUsed = new HashSet<>();
@@ -476,8 +482,9 @@ public class Report {
             if (moduleList.isEmpty() || !intersection.isEmpty()) {
                 w.write("<tr valign=top>");
                 w.write(String.format("<td>%s</td>", d.getName()));
-                if (includeVersion)
+                if (includeVersion) {
                     w.write(String.format("<td>%s</td>", d.getVersion()));
+                }
                 w.write(String.format("<td>%s</td>", d.getLicensor()));
                 w.write(String.format("<td>%s</td>", d.getLicenseName()));
                 w.write(String.format("<td><textarea readonly style=\"width: 900px; height: 283px;\">%s</textarea></td>",

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
         <version.lib.mock-server>5.10.0</version.lib.mock-server>
         <version.lib.jackson>2.11.0</version.lib.jackson>
         <version.lib.wagon-http>3.3.4</version.lib.wagon-http>
-        <version.lib.commons-csv>1.9.0</version.lib.commons-csv>
         <version.lib.commons-text>1.9</version.lib.commons-text>
 
         <!--
@@ -741,13 +740,9 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${version.lib.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${version.lib.jackson}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -793,11 +788,6 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-embedder</artifactId>
                 <version>${version.lib.maven-embedder}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-csv</artifactId>
-                <version>${version.lib.commons-csv}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,8 @@
         <version.lib.mock-server>5.10.0</version.lib.mock-server>
         <version.lib.jackson>2.11.0</version.lib.jackson>
         <version.lib.wagon-http>3.3.4</version.lib.wagon-http>
+        <version.lib.commons-csv>1.9.0</version.lib.commons-csv>
+        <version.lib.commons-text>1.9</version.lib.commons-text>
 
         <!--
             !Version statement! - end
@@ -739,15 +741,18 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.lib.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${version.lib.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${version.lib.apache.commons}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>
@@ -788,6 +793,16 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-embedder</artifactId>
                 <version>${version.lib.maven-embedder}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-csv</artifactId>
+                <version>${version.lib.commons-csv}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${version.lib.commons-text}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Currently, the licensing report is generated in a text format. Oracle documents the attributions in a different format. You can see an example here....
https://docs.oracle.com/en/cloud/paas/app-builder-cloud/abcsl/index.html#ABCSL-GUID-125BCD30-51FC-4049-A8AB-1FDED99A0486

HTML format is provided so that the documentation team can open it in a browser and use it to copy-paste specific portions.

CSV format was originally provided to do the same. This is the process they follow for other content where the documentation team was reading this into Excel and performing copy-paste activity. However, Excel has a limit of 32767 bytes for a cell and netty's attribution exceeded that. They were unable to open this in Excel because of this. This could be removed -- if desired.

JSON format is provided so that if - in the future - they decide they want to just automate the generation of the document, they have an easily parseable format. 

I have run the following commands on both helidon-maven-plugin and licensing module.
- mvn validate -Pcheckstyle
- mvn validate -Pcopyright
- mvn verify -Pspotbugs

licensing still has violations from the spotbugs check but they are preexisting violations. 