### PR TITLE
Fix external default handling in InputResolver

### DIFF
--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/BatchInputResolver.java
@@ -59,7 +59,7 @@ public class BatchInputResolver extends InputResolver {
         ContextScope nextScope = context.scope().getOrCreate(input.id(), input.isGlobal());
         VisitResult result = onVisitInput(input, nextScope, context);
         if (result == null) {
-            Value defaultValue = defaultValue(input, context);
+            Value defaultValue = defaultValue(input, nextScope, context);
             if (input.isOptional()) {
                 if (defaultValue != null) {
                     context.putValue(input.id(), defaultValue, ContextValue.ValueKind.DEFAULT);

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/InputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/InputResolver.java
@@ -100,11 +100,15 @@ public abstract class InputResolver implements Input.Visitor<Context> {
      * Compute the default value for an input.
      *
      * @param input   input
+     * @param scope   scope
      * @param context context
      * @return default value or {@code null} if none
      */
-    public static Value defaultValue(DeclaredInput input, Context context) {
-        Value defaultValue = input.defaultValue();
+    public static Value defaultValue(DeclaredInput input, ContextScope scope, Context context) {
+        Value defaultValue = context.defaultValue(scope.path());
+        if (defaultValue == null) {
+            defaultValue = input.defaultValue();
+        }
         if (defaultValue != null) {
             GenericType<?> valueType = defaultValue.type();
             if (valueType == ValueTypes.STRING) {

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/TerminalInputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/TerminalInputResolver.java
@@ -85,7 +85,7 @@ public class TerminalInputResolver extends InputResolver {
         VisitResult result = onVisitInput(input, nextScope, context);
         while (result == null) {
             try {
-                Value defaultValue = defaultValue(input, context);
+                Value defaultValue = defaultValue(input, nextScope, context);
                 String defaultText = defaultValue != null ? BoldBlue.apply(Input.Boolean.asString(defaultValue)) : null;
                 String question = String.format("%s (yes/no)", Bold.apply(input.name()));
                 String response = prompt(question, defaultText);
@@ -128,7 +128,7 @@ public class TerminalInputResolver extends InputResolver {
         VisitResult result = onVisitInput(input, nextScope, context);
         if (result == null) {
             try {
-                String defaultValue = defaultValue(input, context).asString();
+                String defaultValue = defaultValue(input, nextScope, context).asString();
                 String defaultText = defaultValue != null ? BoldBlue.apply(defaultValue) : null;
                 String response = prompt(Bold.apply(input.name()), defaultText);
                 ContextValue.ValueKind valueKind;
@@ -157,7 +157,7 @@ public class TerminalInputResolver extends InputResolver {
         while (result == null) {
             String response = null;
             try {
-                Value defaultValue = defaultValue(input, context);
+                Value defaultValue = defaultValue(input, nextScope, context);
                 List<Input.Option> options = input.options(n -> Condition.filter(n, context::getValue));
                 int defaultIndex = optionIndex(defaultValue.asString(), options);
                 // skip prompting if there is only one option with a default value
@@ -215,7 +215,7 @@ public class TerminalInputResolver extends InputResolver {
                 printName(input);
                 printOptions(options);
 
-                Value defaultValue = defaultValue(input, context);
+                Value defaultValue = defaultValue(input, nextScope, context);
                 String defaultText = BoldBlue.apply(defaultResponse(defaultValue.asList(), options));
 
                 response = prompt(ENTER_LIST_SELECTION, defaultText);

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputPermutations.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/InputPermutations.java
@@ -304,7 +304,7 @@ public class InputPermutations {
                 String path = nextScope.path();
                 String rawValue = permutation.get(path);
                 if (rawValue == null) {
-                    Value defaultValue = InputResolver.defaultValue(input, context);
+                    Value defaultValue = defaultValue(input, nextScope, context);
                     if (defaultValue == null) {
                         throw new UnresolvedInputException(path);
                     }

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TerminalInputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TerminalInputResolverTest.java
@@ -18,6 +18,7 @@ package io.helidon.build.archetype.engine.v2;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
+import java.util.Map;
 
 import io.helidon.build.archetype.engine.v2.ast.Block;
 import io.helidon.build.archetype.engine.v2.ast.Value;
@@ -221,6 +222,22 @@ class TerminalInputResolverTest {
         assertThat(value, is(notNullValue()));
         assertThat(value.type(), is(ValueTypes.STRING));
         assertThat(value.asString(), is("not-value1"));
+    }
+
+    @Test
+    void testExternalDefault() {
+        Block block = step("step", inputText("text-input3", "value1")).build();
+
+        Context context = Context.builder()
+                                 .externalDefaults(Map.of("text-input3", "value2"))
+                                 .build();
+
+        prompt(block, "", context);
+        Value value = context.getValue("text-input3");
+
+        assertThat(value, is(notNullValue()));
+        assertThat(value.type(), is(ValueTypes.STRING));
+        assertThat(value.asString(), is("value2"));
     }
 
     private static Context prompt(Block block, String userInput) {

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TestHelper.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/TestHelper.java
@@ -346,6 +346,7 @@ public class TestHelper {
 
     private static Map<String, Value> inputAttributes(String id, String defaultValue, String prompt) {
         Map<String, Value> attributes = new HashMap<>();
+        attributes.put("name", DynamicValue.create(id));
         attributes.put("id", DynamicValue.create(id));
         attributes.put("default", DynamicValue.create(defaultValue));
         attributes.put("prompt", DynamicValue.create(prompt));


### PR DESCRIPTION
Do not store external defaults as values in the context.
The presence of a value makes the interactive prompter skip inputs, external defaults must be handled separately and a value is set in the context at resolve time.

Fixes #725 