### PR TITLE
Input filters updates

### DIFF
--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/InputResolver.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/InputResolver.java
@@ -81,8 +81,7 @@ public abstract class InputResolver implements Input.Visitor<Context> {
         if (currentStep == null) {
             throw new IllegalStateException(input.location() + " Input not nested inside a step");
         }
-        boolean global = input.isGlobal();
-        if (global) {
+        if (input.isGlobal()) {
             DeclaredInput parent = parents.peek();
             if (parent != null && !parent.isGlobal()) {
                 throw new IllegalStateException(input.location() + " Parent input is not global");
@@ -162,7 +161,7 @@ public abstract class InputResolver implements Input.Visitor<Context> {
             throw new IllegalStateException("parents is empty");
         }
         DeclaredInput parent = parents.peek();
-        Value inputValue = context.scope().getValue(".." + parent.id());
+        Value inputValue = context.scope().getValue("");
         if (inputValue != null) {
             return parent.visitOption(inputValue, option);
         }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DynamicValue.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/DynamicValue.java
@@ -90,6 +90,7 @@ public final class DynamicValue implements Value {
             return (U) Arrays.stream(rawValue.split(","))
                              .map(String::trim)
                              .filter(s -> !s.isEmpty())
+                             .sorted()
                              .collect(toList());
         } else if (type.equals(ValueTypes.STRING)) {
             return (U) rawValue;

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Value.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ast/Value.java
@@ -16,6 +16,7 @@
 
 package io.helidon.build.archetype.engine.v2.ast;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -138,7 +139,9 @@ public interface Value {
      * @return Value
      */
     static Value create(List<String> value) {
-        return new TypedValue(value, ValueTypes.STRING_LIST);
+        List<String> copy = new ArrayList<>(value);
+        Collections.sort(copy);
+        return new TypedValue(copy, ValueTypes.STRING_LIST);
     }
 
     /**

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/ContextEdge.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/ContextEdge.java
@@ -65,6 +65,11 @@ public interface ContextEdge {
     }
 
     /**
+     * Clear the edge.
+     */
+    void clear();
+
+    /**
      * Context edge visitor.
      */
     interface Visitor {

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/ContextNode.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/ContextNode.java
@@ -262,6 +262,11 @@ public final class ContextNode implements ContextScope {
     }
 
     @Override
+    public void clear() {
+        edge.clear();
+    }
+
+    @Override
     public ContextValue putValue(String path, Value value, ValueKind kind) {
         String[] segments = ContextPath.parse(path);
         ContextNode node = resolve(segments, (s, sid) -> s.getOrCreate(sid, Visibility.UNSET));

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/ContextScope.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/ContextScope.java
@@ -158,6 +158,12 @@ public interface ContextScope extends ContextRegistry {
      */
     ContextScope getOrCreate(String path, Visibility visibility);
 
+
+    /**
+     * Clear the scope.
+     */
+    void clear();
+
     /**
      * Visit the edges.
      *

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/CopyOnWriteContextEdge.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/CopyOnWriteContextEdge.java
@@ -119,4 +119,14 @@ public final class CopyOnWriteContextEdge implements ContextEdge {
         }
         return result;
     }
+
+    @Override
+    public void clear() {
+        variations.forEach(CopyOnWriteContextEdge::clear0);
+    }
+
+    private void clear0() {
+        value = null;
+        children.clear();
+    }
 }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/NoValueContextEdge.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/NoValueContextEdge.java
@@ -59,6 +59,11 @@ public final class NoValueContextEdge implements ContextEdge {
     }
 
     @Override
+    public void clear() {
+        children.clear();
+    }
+
+    @Override
     public List<ContextNode> children() {
         return children;
     }

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/WriteableContextEdge.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/context/WriteableContextEdge.java
@@ -85,6 +85,12 @@ public final class WriteableContextEdge implements ContextEdge {
     }
 
     @Override
+    public void clear() {
+        value = null;
+        children.clear();
+    }
+
+    @Override
     public List<ContextNode> children() {
         return children;
     }

--- a/archetype/engine-v2/src/test/resources/e2e/colors/colors.xml
+++ b/archetype/engine-v2/src/test/resources/e2e/colors/colors.xml
@@ -24,12 +24,6 @@
         <inputs>
             <enum id="base" name="Select a palette">
                 <option value="custom" name="Custom palette">
-                    <inputs>
-
-                    </inputs>
-                    <inputs>
-
-                    </inputs>
                     <exec src="custom/custom.xml"/>
                 </option>
                 <option value="rainbow" name="Rainbow palette">

--- a/maven-plugins/helidon-archetype-maven-plugin/README.md
+++ b/maven-plugins/helidon-archetype-maven-plugin/README.md
@@ -55,7 +55,9 @@ Maven goal to test Helidon archetypes.
 | permutationsOnly         | boolean | `false`                                         | Whether to only generate input permutations                                                                                |
 | generatePermutations     | boolean | `true`                                          | Whether to auto-compute input permutations                                                                                 |
 | permutationFilters       | List    | `[]`                                            | Permutation filters to filter the computed permutations.                                                                   |
+| permutationFiltersFile   | File    | `null`                                          | Properties file that contains filters to filter the computed permutations.                                                 |
 | inputFilters             | List    | `[]`                                            | Input filters to use when computing permutations                                                                           |
+| inputFiltersFile         | File    | `null`                                          | Properties file that contains filters to use when computing permutations                                                   |
 | externalDefaults         | boolean | `false`                                         | External defaults to use when generating archetypes                                                                        |
 | externalValues           | boolean | `false`                                         | External values to use when generating archetypes                                                                          |
 | testGoal                 | String  | `package`                                       | The goal to use when building archetypes.                                                                                  |


### PR DESCRIPTION
Expression:
 - Fix array equality (lists need to be sorted)
 - Support strings with the contains operator
 - Fix parsing issues when ! is preceded with left parenthese
 - Multi-line support
 - Comment support

InputPermutations:
 - Use preset and variables to control the flow when computing permutation
 - Apply permutation filters twice, before execution and after (added default values might fail the filter)

helidon-archetype-maven-plugin:
 - Added support for filter files

Fixes #729
Fixes #730