### PR TITLE
Do not allow trailing EOLs in copyright in Java files.

### DIFF
--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Copyright.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/Copyright.java
@@ -79,6 +79,7 @@ public class Copyright {
         builtIns.add(new ValidatorAsciidoc(builder.validatorConfig, builder.templateLines));
         builtIns.add(new ValidatorBat(builder.validatorConfig, builder.templateLines));
         builtIns.add(new ValidatorJsp(builder.validatorConfig, builder.templateLines));
+        builtIns.add(new ValidatorHandlebars(builder.validatorConfig, builder.templateLines));
         this.textValidator = new ValidatorText(builder.validatorConfig, builder.templateLines);
         builtIns.add(this.textValidator);
 

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorHandlebars.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorHandlebars.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.build.maven.enforcer.copyright;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+class ValidatorHandlebars extends ValidatorBase {
+    protected ValidatorHandlebars(ValidatorConfig validatorConfig, List<TemplateLine> templateLines) {
+        super(validatorConfig, templateLines);
+    }
+
+    @Override
+    public Set<String> supportedSuffixes() {
+        return Set.of(".hbs",
+                      ".handlebars");
+    }
+
+    @Override
+    public boolean supports(Path path) {
+        return super.startsWith(path, "{{!\n");
+    }
+
+    @Override
+    protected boolean supportsBlockComments() {
+        return true;
+    }
+
+    @Override
+    protected String blockCommentStart() {
+        return "{{!";
+    }
+
+    @Override
+    protected String blockCommentEnd() {
+        return "}}";
+    }
+}

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorJava.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorJava.java
@@ -73,9 +73,7 @@ class ValidatorJava extends ValidatorBase {
 
     @Override
     protected boolean allowTrailEmptyLine(String modifiedYear) {
-        // we have a leeway here - for files modified before current year, we allow a trailing line
-        //return !currentYear().equals(modifiedYear);
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Support for Handlebars files.

Trailing EOLs in java files was causing a lot of warnings and new files were added to the repo quite often triggering them.
This change forbids trailing lines in copyright comments.