### PR TITLE
Update copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This project welcomes contributions from the community. Before submitting a pull
 
 ## License
 
-Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This updates the copyright year in the README/license section from 2024 to 2025.