### PR TITLE
Central Release Updates

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Release"
+name: "Release CLI"
 
 on:
   workflow_call:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,19 +36,16 @@ concurrency:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     environment: release
     outputs:
+      version: ${{ steps.create-tag.outputs.version }}
       tag: ${{ steps.create-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: '0'
           token: ${{ secrets.SERVICE_ACCOUNT_TOKEN }}
-      - name: Set up JDK
-        uses: actions/setup-java@v4.1.0
-        with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
       - id: create-tag
         run: ./etc/scripts/release.sh create_tag >> "${GITHUB_OUTPUT}"
   validate:
@@ -56,7 +53,7 @@ jobs:
     uses: ./.github/workflows/validate.yml
     with:
       ref: ${{ needs.create-tag.outputs.tag }}
-  release:
+  stage:
     needs: [ create-tag, validate ]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -65,19 +62,52 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.create-tag.outputs.tag }}
-      - uses: ./.github/actions/common
-        with:
+      - shell: bash
+        env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
-          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+        run: ./etc/scripts/setup-gpg.sh
+      - uses: ./.github/actions/common
+        with:
           build-cache: read-only
           artifact-name: io-helidon-build-tools-artifacts-${{ github.ref_name }}
-          artifact-path: target/nexus-staging/
-          run: etc/scripts/release.sh release_build
+          artifact-path: staging
+          run: |
+            mvn ${MVN_ARGS} \
+              -Prelease,no-snapshots \
+              -DskipTests \
+              -DaltDeploymentRepository=":::file://${PWD}/staging" \
+              deploy
+  deploy:
+    needs: [ create-tag, stage ]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          ref: ${{ needs.create-tag.outputs.tag }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: io-helidon-build-tools-artifacts-*
+          path: staging
+          merge-multiple: true
+      - shell: bash
+        env:
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+        run: |
+          etc/scripts/upload.sh upload_release \
+            --dir="staging" \
+            --description="Helidon v%{version}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: io-helidon-artifacts-${{ needs.create-tag.outputs.version }}
+          path: staging
   release-cli:
     if: ${{ startsWith(github.ref_name, 'release-cli') }}
-    needs: release
+    needs: deploy
     uses: ./.github/workflows/release-cli.yml
     with:
       tag: ${{ needs.create-tag.outputs.tag }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,8 @@ name: "Validate"
 on:
   pull_request:
   push:
+    branches-ignore: [ 'master', 'helidon-*.x', 'release-*' ]
+    tags-ignore: [ '**' ]
   workflow_call:
     inputs:
       ref:

--- a/archetype/engine-v2/pom.xml
+++ b/archetype/engine-v2/pom.xml
@@ -79,6 +79,31 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/schema</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/schema/</directory>
+                                    <includes>
+                                        <include>*.xsd</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
@@ -91,7 +116,7 @@
                         <configuration>
                             <artifacts>
                                 <artifact>
-                                    <file>src/main/schema/archetype.xsd</file>
+                                    <file>${project.build.directory}/schema/archetype.xsd</file>
                                     <type>xsd</type>
                                     <classifier>schema-2.0</classifier>
                                 </artifact>

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -20,12 +20,26 @@ set -o errtrace || true # trace ERR through commands and functions
 set -o errexit || true  # exit the script if any statement returns a non-true return value
 
 on_error(){
-    CODE="${?}" && \
-    set +x && \
-    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
-        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+    "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}" >&2
 }
 trap on_error ERR
+
+# Path to this script
+if [ -h "${0}" ] ; then
+  SCRIPT_PATH="$(readlink "${0}")"
+else
+  # shellcheck disable=SC155
+  SCRIPT_PATH="${0}"
+fi
+readonly SCRIPT_PATH
+
+# Path to the root of the workspace
+# shellcheck disable=SC2046
+WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
+readonly WS_DIR
 
 usage(){
     cat <<EOF
@@ -34,11 +48,10 @@ DESCRIPTION: Helidon Release Script
 
 USAGE:
 
-$(basename "${0}") [ --build-number=N ] CMD
+$(basename "${0}") --version=V CMD
 
   --version=V
-        Override the version to use.
-        This trumps --build-number=N
+        The version to use.
 
   --help
         Prints the usage and exits.
@@ -48,162 +61,171 @@ $(basename "${0}") [ --build-number=N ] CMD
     update_version
         Update the version in the workspace
 
-    release_version
-        Print the release version
+    get_version
+        Get the current version
 
     create_tag
-        Create and push a release tag
-
-    release_build
-        Perform a release build
-
+        Create and and push a release tag
 EOF
 }
 
 # parse command line args
 ARGS=( )
 while (( ${#} > 0 )); do
-    case ${1} in
-    "--version="*)
-        VERSION=${1#*=}
-        shift
-        ;;
-    "--help")
-        usage
-        exit 0
-        ;;
-    "update_version"|"release_version"|"create_tag"|"release_build")
-        COMMAND="${1}"
-        shift
-        ;;
-    *)
-        ARGS+=( "${1}" )
-        shift
-        ;;
-    esac
+  case ${1} in
+  "--version="*)
+    VERSION=${1#*=}
+    shift
+    ;;
+  "--help")
+    usage
+    exit 0
+    ;;
+  "update_version"|"create_tag"|"get_version")
+    COMMAND="${1}"
+    shift
+    ;;
+  *)
+    ARGS+=( "${1}" )
+    shift
+    ;;
+  esac
 done
 readonly ARGS
 readonly COMMAND
+
+# copy stdout as fd 6 and redirect stdout to stderr
+# this allows us to use fd 6 for returning data
+exec 6>&1 1>&2
 
 if [ -z "${COMMAND+x}" ] ; then
   echo "ERROR: no command provided"
   exit 1
 fi
 
-# Path to this script
-if [ -h "${0}" ] ; then
-    SCRIPT_PATH="$(readlink "${0}")"
-else
-    SCRIPT_PATH="${0}"
-fi
-readonly SCRIPT_PATH
+case ${COMMAND} in
+"update_version")
+  if [ -z "${VERSION}" ] ; then
+    echo "ERROR: version required" >&2
+    usage
+    exit 1
+  fi
+  ;;
+"create_tag"|"get_version")
+  # no-op
+  ;;
+"")
+  echo "ERROR: no command provided" >&2
+  usage
+  exit 1
+  ;;
+*)
+  echo "ERROR: unknown command ${COMMAND}" >&2
+  usage
+  exit 1
+  ;;
+esac
 
-# Path to the root of the workspace
-# shellcheck disable=SC2046
-WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
-readonly WS_DIR
-
-# copy stdout as fd 6 and redirect stdout to stderr
-# this allows us to use fd 6 for returning data
-exec 6>&1 1>&2
-
-current_version(){
-    # shellcheck disable=SC2086
-    mvn ${MVN_ARGS} -q \
-        -f "${WS_DIR}"/pom.xml \
-        -Dexec.executable="echo" \
-        -Dexec.args="\${project.version}" \
-        --non-recursive \
-        org.codehaus.mojo:exec-maven-plugin:1.3.1:exec
+current_version() {
+  awk 'BEGIN {FS="[<>]"} ; /<version>/ {print $3; exit 0}' "${WS_DIR}"/pom.xml
 }
 
-release_version(){
-    local current_version
-    current_version=$(current_version)
-    echo "${current_version%-*}"
+# arg1: pattern
+# arg2: include pattern
+search() {
+  set +o pipefail
+  grep "${1}" -Er . --include "${2}" | cut -d ':' -f 1 | xargs git ls-files | sort | uniq
+}
+
+replace() {
+  local pattern value replace include
+  while (( ${#} > 0 )); do
+    case ${1} in
+    "--pattern="*)
+      pattern=${1#*=}
+      shift
+      ;;
+    "--include="*)
+      include=${1#*=}
+      shift
+      ;;
+    "--replace="*)
+      replace=${1#*=}
+      shift
+      ;;
+    "--value="*)
+      value=${1#*=}
+      shift
+      ;;
+    *)
+      echo "Unsupported argument: ${1}" >&2
+      return 1
+      ;;
+    esac
+  done
+
+  if [ -z "${replace}" ] && [ -n "${value}" ] ; then
+    replace=${pattern/\.\*/${value}}
+  fi
+
+  for file in $(search "${pattern}" "${include}"); do
+    echo "Updating ${file}"
+    sed -e s@"${pattern}"@"${replace}"@g "${file}" > "${file}.tmp"
+    mv "${file}.tmp" "${file}"
+  done
 }
 
 update_version(){
-    local version
-    version=${1-${VERSION}}
-    if [ -z "${version+x}" ] ; then
-        echo "ERROR: version required"
-        usage
-        exit 1
-    fi
+  local version current_version
 
-    # shellcheck disable=SC2086
-    mvn ${MVN_ARGS} "${ARGS[@]}" \
-        -f "${WS_DIR}"/pom.xml versions:set versions:set-property \
-        -DgenerateBackupPoms="false" \
-        -DnewVersion="${version}" \
-        -Dproperty="helidon.version" \
-        -DprocessFromLocalAggregationRoot="false" \
-        -DupdateMatchingVersions="false"
+  version=${1-${VERSION}}
+  if [ -z "${version+x}" ] ; then
+    echo "ERROR: version required" >&2
+    usage
+    exit 1
+  fi
+
+  # find current version
+  current_version=$(current_version)
+
+  # update poms
+  replace \
+    --pattern="<version>${current_version}</version>" \
+    --replace="<version>${version}</version>" \
+    --include="pom.xml"
 }
 
-create_tag(){
-    local git_branch version
+create_tag() {
+  local git_branch version current_version
 
-    version=$(release_version)
-    git_branch="release/${version}"
+  current_version=$(current_version)
+  version=${current_version%-SNAPSHOT}
+  git_branch="release/${version}"
 
-    # Use a separate branch
-    git branch -D "${git_branch}" > /dev/null 2>&1 || true
-    git checkout -b "${git_branch}"
+  # Use a separate branch
+  git branch -D "${git_branch}" > /dev/null 2>&1 || true
+  git checkout -b "${git_branch}"
 
-    # Invoke update_version
-    update_version "${version}"
+  # Invoke update_version
+  update_version "${version}"
 
-    # Git user info
-    git config user.email || git config --global user.email "info@helidon.io"
-    git config user.name || git config --global user.name "Helidon Robot"
+  # Git user info
+  git config user.email || git config --global user.email "info@helidon.io"
+  git config user.name || git config --global user.name "Helidon Robot"
 
-    # Commit version changes
-    git commit -a -m "Release ${version}"
+  # Commit version changes
+  git commit -a -m "Release ${version}"
 
-    # Create and push a git tag
-    git tag -f "${version}"
-    git push --force origin refs/tags/"${version}":refs/tags/"${version}"
+  # Create and push a git tag
+  git tag -f "${version}"
+  git push --force origin refs/tags/"${version}":refs/tags/"${version}"
 
-    echo "tag=refs/tags/${version}" >&6
+  echo "version=${version}" >&6
+  echo "tag=refs/tags/${version}" >&6
 }
 
-release_build(){
-    local tmpfile version
-
-    # Bootstrap credentials from environment
-    if [ -n "${MAVEN_SETTINGS}" ] ; then
-        tmpfile=$(mktemp XXXXXXsettings.xml)
-        echo "${MAVEN_SETTINGS}" > "${tmpfile}"
-        MVN_ARGS="${MVN_ARGS} -s ${tmpfile}"
-    fi
-    if [ -n "${GPG_PRIVATE_KEY}" ] ; then
-        tmpfile=$(mktemp XXXXXX.key)
-        echo "${GPG_PRIVATE_KEY}" > "${tmpfile}"
-        gpg --allow-secret-key-import --import --no-tty --batch "${tmpfile}"
-        rm "${tmpfile}"
-    fi
-    if [ -n "${GPG_PASSPHRASE}" ] ; then
-        echo "allow-preset-passphrase" >> ~/.gnupg/gpg-agent.conf
-        gpg-connect-agent reloadagent /bye
-        GPG_KEYGRIP=$(gpg --with-keygrip -K | grep "Keygrip" | head -1 | awk '{print $3}')
-        /usr/lib/gnupg/gpg-preset-passphrase --preset "${GPG_KEYGRIP}" <<< "${GPG_PASSPHRASE}"
-    fi
-
-    # Perform local deployment to filesystem
-    # shellcheck disable=SC2086
-    mvn ${MVN_ARGS} "${ARGS[@]}" \
-        deploy \
-        -Prelease \
-        -DskipTests \
-        -DaltDeploymentRepository=":::file://${PWD}/staging"
-
-    # Upload artifacts to Sonatype Central Publishing Portal
-    version=$(release_version)
-    "${WS_DIR}/etc/scripts/upload.sh" upload_release \
-                --dir="staging" \
-                --description="Helidon Build Tools v${version}"
+get_version() {
+  echo "version=$(current_version)" >&6
 }
 
 # Invoke command

--- a/etc/scripts/setup-gpg.sh
+++ b/etc/scripts/setup-gpg.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail || true  # trace ERR through pipes
+set -o errtrace || true # trace ERR through commands and functions
+set -o errexit || true  # exit the script if any statement returns a non-true return value
+
+on_error(){
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}" >&2
+}
+trap on_error ERR
+
+setup_gpg() {
+  local tmpfile
+
+  tmpfile=$(mktemp)
+  echo "${GPG_PRIVATE_KEY}" > "${tmpfile}"
+  gpg --allow-secret-key-import --import --no-tty --batch "${tmpfile}"
+  rm "${tmpfile}"
+
+  echo "allow-preset-passphrase" >> ~/.gnupg/gpg-agent.conf
+  gpg-connect-agent reloadagent /bye
+  GPG_KEYGRIP=$(gpg --with-keygrip -K | grep "Keygrip" | head -1 | awk '{print $3}')
+  "$(gpgconf --list-dirs libexecdir)"/gpg-preset-passphrase --preset "${GPG_KEYGRIP}" <<< "${GPG_PASSPHRASE}"
+
+  gpg --list-keys helidon
+}
+
+setup_gpg

--- a/etc/scripts/shellcheck.sh
+++ b/etc/scripts/shellcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 BASE_URL="https://github.com/koalaman/shellcheck/releases/download"
 readonly BASE_URL
 
-VERSION=0.9.0
+VERSION=0.10.0
 readonly VERSION
 
 CACHE_DIR="${HOME}/.shellcheck"
@@ -29,6 +29,10 @@ mkdir -p "${CACHE_DIR}"
 if [ ! -e "${CACHE_DIR}/${VERSION}/shellcheck" ] ; then
     ARCH=$(uname -m | tr "[:upper:]" "[:lower:]")
     PLATFORM=$(uname -s | tr "[:upper:]" "[:lower:]")
+    # if using Mac with a silicon chip, use aarch64 as the architecture
+    if [[ "${PLATFORM}" == "darwin" && "${ARCH}" == "arm64" ]]; then
+        ARCH=aarch64
+    fi
     curl -Lso "${CACHE_DIR}/sc.tar.xz" "${BASE_URL}/v${VERSION}/shellcheck-v${VERSION}.${PLATFORM}.${ARCH}.tar.xz"
     tar -xf "${CACHE_DIR}/sc.tar.xz" -C "${CACHE_DIR}"
     mkdir "${CACHE_DIR}/${VERSION}"

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
         <version.plugin.dependency>3.3.0</version.plugin.dependency>
         <version.plugin.dependency-check>10.0.4</version.plugin.dependency-check>
-        <version.plugin.deploy>2.8.2</version.plugin.deploy>
+        <version.plugin.deploy>3.1.1</version.plugin.deploy>
         <version.plugin.enforcer>3.4.0</version.plugin.enforcer>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
@@ -203,7 +203,7 @@
         <version.plugin.plexus>2.1.0</version.plugin.plexus>
         <version.plugin.plugin-plugin>3.10.2</version.plugin.plugin-plugin>
         <version.plugin.release-plugin>2.5.3</version.plugin.release-plugin>
-        <version.plugin.resources>2.7</version.plugin.resources>
+        <version.plugin.resources>3.3.1</version.plugin.resources>
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.surefire>3.1.2</version.plugin.surefire>
@@ -1069,27 +1069,6 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-no-snapshots</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration>
-                                    <rules>
-                                        <requireReleaseDeps>
-                                            <message>No snapshots allowed during the release build!</message>
-                                        </requireReleaseDeps>
-                                    </rules>
-                                    <fail>true</fail>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
                             <execution>
@@ -1122,6 +1101,37 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <keyname>helidon</keyname>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>no-snapshots</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseDeps>
+                                            <message>No snapshots allowed during the release build!</message>
+                                        </requireReleaseDeps>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Sync-up the release process with the main Helidon repository.

- Update release workflow to split release into stage and upload
- Update workflows to avoid double builds on release branches
- Update release.sh to have only update_version and create_tag sub commands
- Add etc/scripts/setup-gpg.sh
- Update maven-deploy-plugin to 3.1.1 (to support the file URI used in stage)
- Update etc/scripts/shellcheck.sh to support Apple Silicon (upgrade to 0.10.0)
- workaround an issue with the build-cache extension and attached artifacts in archetype/engine-v2