### PR TITLE
Upgrade macos runners to 14

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -178,11 +178,11 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ ubuntu-24.04, windows-2022, macos-13 ]
+        os: [ ubuntu-24.04, windows-2022, macos-14 ]
         include:
           - { os: ubuntu-24.04, platform: linux-amd64 }
           - { os: windows-2022, platform: windows-amd64, file-ext: .exe }
-          - { os: macos-13, platform: darwin-amd64 }
+          - { os: macos-14, platform: darwin-amd64 }
     runs-on: ${{ matrix.os }}
     name: cli/${{ matrix.platform }}
     steps:


### PR DESCRIPTION
The macOS 13 runner image will be retired by December 4th, 2025.  Brownouts will start in Nov.