### PR TITLE
4.x: stager-maven-plugin - add unpack path mappers

### DIFF
--- a/maven-plugins/stager-maven-plugin/src/it/projects/unpack-artifact/pom.xml
+++ b/maven-plugins/stager-maven-plugin/src/it/projects/unpack-artifact/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/it/projects/unpack-artifact/pom.xml
+++ b/maven-plugins/stager-maven-plugin/src/it/projects/unpack-artifact/pom.xml
@@ -74,6 +74,16 @@
                                             </variables>
                                         </iterators>
                                     </unpack-artifact>
+                                    <unpack-artifact
+                                            groupId="io.helidon"
+                                            artifactId="helidon-docs"
+                                            version="1.4.3"
+                                            includes="apidocs/**"
+                                            target="apidocs/1.4.3">
+                                        <mappers>
+                                            <mapper match="^apidocs/(.*)$" replace="$1"/>
+                                        </mappers>
+                                    </unpack-artifact>
                                 </unpack-artifacts>
                             </directory>
                         </directories>

--- a/maven-plugins/stager-maven-plugin/src/it/projects/unpack/pom.xml
+++ b/maven-plugins/stager-maven-plugin/src/it/projects/unpack/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2024 Oracle and/or its affiliates.
+    Copyright (c) 2024, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/it/projects/unpack/pom.xml
+++ b/maven-plugins/stager-maven-plugin/src/it/projects/unpack/pom.xml
@@ -48,6 +48,13 @@
                                             </variables>
                                         </iterators>
                                     </unpack>
+                                    <unpack url="https://repo1.maven.org/maven2/io/helidon/helidon-project/3.2.10/helidon-project-3.2.10-site.jar"
+                                            includes="apidocs/**"
+                                            target="apidocs/3.2.10">
+                                        <mappers>
+                                            <mapper match="^apidocs/(.*)$" replace="$1"/>
+                                        </mappers>
+                                    </unpack>
                                 </unpacks>
                             </directory>
                         </directories>

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/Mapper.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/Mapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.stager;
+
+import java.util.Map;
+
+import io.helidon.build.common.Strings;
+
+/**
+ * Archive entry path mapper.
+ */
+record Mapper(String match, String replace) implements StagingElement {
+
+    static final String ELEMENT_NAME = "mapper";
+
+    Mapper(Map<String, String> attrs) {
+        this(
+                Strings.requireValid(attrs.get("match"), "match is required"),
+                Strings.requireValid(attrs.get("replace"), "replace is required"));
+    }
+
+    String match(Map<String, String> vars) {
+        return StagingTask.resolveVar(match, vars);
+    }
+
+    String replace(Map<String, String> vars) {
+        return StagingTask.resolveVar(replace, vars);
+    }
+
+    @Override
+    public String elementName() {
+        return ELEMENT_NAME;
+    }
+}

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/Mapper.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/Mapper.java
@@ -27,8 +27,7 @@ record Mapper(String match, String replace) implements StagingElement {
     static final String ELEMENT_NAME = "mapper";
 
     Mapper(Map<String, String> attrs) {
-        this(
-                Strings.requireValid(attrs.get("match"), "match is required"),
+        this(Strings.requireValid(attrs.get("match"), "match is required"),
                 Strings.requireValid(attrs.get("replace"), "replace is required"));
     }
 

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContext.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContext.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContext.java
@@ -18,6 +18,8 @@ package io.helidon.build.maven.stager;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 /**
@@ -56,6 +58,25 @@ interface StagingContext {
      */
     default void unpack(Path archive, Path target, String excludes, String includes) {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Unpack the given archive to a target location.
+     *
+     * @param archive  archive to unpack
+     * @param target   where to unpack the archive
+     * @param excludes exclude filters
+     * @param includes include filters
+     * @param mappers  path mappers
+     * @param vars     variables used to resolve mapper values
+     */
+    default void unpack(Path archive,
+                        Path target,
+                        String excludes,
+                        String includes,
+                        List<Mapper> mappers,
+                        Map<String, String> vars) {
+        unpack(archive, target, excludes, includes);
     }
 
     /**

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -38,6 +39,7 @@ import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
 import org.codehaus.plexus.components.io.filemappers.FileMapper;
 import org.codehaus.plexus.components.io.filemappers.RegExpFileMapper;
+import org.codehaus.plexus.components.io.fileselectors.FileSelector;
 import org.codehaus.plexus.components.io.fileselectors.IncludeExcludeFileSelector;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystem;
@@ -48,6 +50,7 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 
+import static io.helidon.build.common.Strings.isValid;
 import static io.helidon.build.common.Strings.normalizePath;
 
 /**
@@ -129,19 +132,13 @@ final class StagingContextImpl implements StagingContext {
         }
         unArchiver.setSourceFile(archiveFile);
         unArchiver.setDestDirectory(target.toFile());
+        FileMapper[] fileMappers = new FileMapper[0];
         if (!mappers.isEmpty()) {
-            unArchiver.setFileMappers(fileMappers(mappers, vars));
+            fileMappers = fileMappers(mappers, vars);
+            unArchiver.setFileMappers(fileMappers);
         }
-        if (StringUtils.isNotEmpty(excludes) || StringUtils.isNotEmpty(includes)) {
-            IncludeExcludeFileSelector[] selectors = new IncludeExcludeFileSelector[] {
-                    new IncludeExcludeFileSelector()
-            };
-            if (StringUtils.isNotEmpty(excludes)) {
-                selectors[0].setExcludes(excludes.split(","));
-            }
-            if (StringUtils.isNotEmpty(includes)) {
-                selectors[0].setIncludes(includes.split(","));
-            }
+        FileSelector[] selectors = fileSelectors(excludes, includes, fileMappers);
+        if (selectors.length > 0) {
             unArchiver.setFileSelectors(selectors);
         }
         unArchiver.extract();
@@ -274,10 +271,39 @@ final class StagingContextImpl implements StagingContext {
         return maxRetries;
     }
 
-    private static FileMapper[] fileMappers(List<Mapper> mappers, Map<String, String> vars) {
+    static FileMapper[] fileMappers(List<Mapper> mappers, Map<String, String> vars) {
         return mappers.stream()
                 .map(mapper -> fileMapper(mapper, vars))
                 .toArray(FileMapper[]::new);
+    }
+
+    static String applyFileMappers(String name, FileMapper[] fileMappers) {
+        String mappedName = normalizePath(name);
+        for (FileMapper fileMapper : fileMappers) {
+            if (mappedName == null || mappedName.isEmpty()) {
+                return mappedName;
+            }
+            mappedName = normalizePath(fileMapper.getMappedFileName(mappedName));
+        }
+        return mappedName;
+    }
+
+    static FileSelector[] fileSelectors(String excludes, String includes, FileMapper[] fileMappers) {
+        List<FileSelector> selectors = new ArrayList<>(2);
+        if (isValid(excludes) || isValid(includes)) {
+            IncludeExcludeFileSelector selector = new IncludeExcludeFileSelector();
+            if (isValid(excludes)) {
+                selector.setExcludes(excludes.split(","));
+            }
+            if (isValid(includes)) {
+                selector.setIncludes(includes.split(","));
+            }
+            selectors.add(selector);
+        }
+        if (fileMappers.length > 0) {
+            selectors.add(fileInfo -> isValid(applyFileMappers(fileInfo.getName(), fileMappers)));
+        }
+        return selectors.toArray(FileSelector[]::new);
     }
 
     static FileMapper fileMapper(Mapper mapper, Map<String, String> vars) {

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
@@ -48,6 +48,8 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 
+import static io.helidon.build.common.Strings.normalizePath;
+
 /**
  * Staging context implementation.
  */
@@ -278,10 +280,10 @@ final class StagingContextImpl implements StagingContext {
                 .toArray(FileMapper[]::new);
     }
 
-    private static FileMapper fileMapper(Mapper mapper, Map<String, String> vars) {
-        RegExpFileMapper fileMapper = new RegExpFileMapper();
-        fileMapper.setPattern(mapper.match(vars));
-        fileMapper.setReplacement(mapper.replace(vars));
-        return fileMapper;
+    static FileMapper fileMapper(Mapper mapper, Map<String, String> vars) {
+        RegExpFileMapper regexMapper = new RegExpFileMapper();
+        regexMapper.setPattern(mapper.match(vars));
+        regexMapper.setReplacement(mapper.replace(vars));
+        return name -> normalizePath(regexMapper.getMappedFileName(normalizePath(name)));
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContextImpl.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -35,6 +36,8 @@ import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
+import org.codehaus.plexus.components.io.filemappers.RegExpFileMapper;
 import org.codehaus.plexus.components.io.fileselectors.IncludeExcludeFileSelector;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystem;
@@ -105,6 +108,16 @@ final class StagingContextImpl implements StagingContext {
 
     @Override
     public void unpack(Path archive, Path target, String excludes, String includes) {
+        unpack(archive, target, excludes, includes, List.of(), Map.of());
+    }
+
+    @Override
+    public void unpack(Path archive,
+                       Path target,
+                       String excludes,
+                       String includes,
+                       List<Mapper> mappers,
+                       Map<String, String> vars) {
         File archiveFile = archive.toFile();
         UnArchiver unArchiver;
         try {
@@ -114,6 +127,9 @@ final class StagingContextImpl implements StagingContext {
         }
         unArchiver.setSourceFile(archiveFile);
         unArchiver.setDestDirectory(target.toFile());
+        if (!mappers.isEmpty()) {
+            unArchiver.setFileMappers(fileMappers(mappers, vars));
+        }
         if (StringUtils.isNotEmpty(excludes) || StringUtils.isNotEmpty(includes)) {
             IncludeExcludeFileSelector[] selectors = new IncludeExcludeFileSelector[] {
                     new IncludeExcludeFileSelector()
@@ -254,5 +270,18 @@ final class StagingContextImpl implements StagingContext {
     @Override
     public int maxRetries() {
         return maxRetries;
+    }
+
+    private static FileMapper[] fileMappers(List<Mapper> mappers, Map<String, String> vars) {
+        return mappers.stream()
+                .map(mapper -> fileMapper(mapper, vars))
+                .toArray(FileMapper[]::new);
+    }
+
+    private static FileMapper fileMapper(Mapper mapper, Map<String, String> vars) {
+        RegExpFileMapper fileMapper = new RegExpFileMapper();
+        fileMapper.setPattern(mapper.match(vars));
+        fileMapper.setReplacement(mapper.replace(vars));
+        return fileMapper;
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingElementFactory.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingElementFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingElementFactory.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingElementFactory.java
@@ -48,6 +48,7 @@ class StagingElementFactory {
     private static final Set<String> SYNTHETIC_ELEMENTS = Set.of(
             Include.ELEMENT_NAME,
             Exclude.ELEMENT_NAME,
+            Mapper.ELEMENT_NAME,
             Substitution.ELEMENT_NAME);
 
     private static final Map<String, String> WRAPPER_ELEMENTS = Stream.of(ACTION_ELEMENTS, SYNTHETIC_ELEMENTS)
@@ -96,13 +97,14 @@ class StagingElementFactory {
 
         Supplier<ActionIterators> iterators = () -> firstChild(children, ActionIterators.class, () -> null);
         Supplier<Variables> variables = () -> firstChild(children, Variables.class, Variables::new);
+        Supplier<List<Mapper>> mappers = () -> filterChildren(children, Mapper.class);
         switch (name) {
             case StagingDirectory.ELEMENT_NAME:
                 return new StagingDirectory(filterChildren(children, StagingAction.class), attrs);
             case UnpackTask.ELEMENT_NAME:
-                return new UnpackTask(iterators.get(), attrs);
+                return new UnpackTask(iterators.get(), mappers.get(), attrs);
             case UnpackArtifactTask.ELEMENT_NAME:
-                return new UnpackArtifactTask(iterators.get(), attrs);
+                return new UnpackArtifactTask(iterators.get(), mappers.get(), attrs);
             case CopyArtifactTask.ELEMENT_NAME:
                 return new CopyArtifactTask(iterators.get(), attrs);
             case SymlinkTask.ELEMENT_NAME:
@@ -186,6 +188,7 @@ class StagingElementFactory {
         return switch (name) {
             case Include.ELEMENT_NAME -> new Include(text);
             case Exclude.ELEMENT_NAME -> new Exclude(text);
+            case Mapper.ELEMENT_NAME -> new Mapper(attrs);
             case Substitution.ELEMENT_NAME -> new Substitution(attrs);
             default -> throw new IllegalStateException("Unknown element: " + name);
         };

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
@@ -17,6 +17,7 @@ package io.helidon.build.maven.stager;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -29,12 +30,14 @@ final class UnpackArtifactTask extends StagingTask {
     private final ArtifactGAV gav;
     private final String includes;
     private final String excludes;
+    private final List<Mapper> mappers;
 
-    UnpackArtifactTask(ActionIterators iterators, Map<String, String> attrs) {
+    UnpackArtifactTask(ActionIterators iterators, List<Mapper> mappers, Map<String, String> attrs) {
         super(ELEMENT_NAME, null, iterators, attrs);
         this.gav = new ArtifactGAV(attrs);
         this.includes = attrs.get("includes");
         this.excludes = attrs.get("excludes");
+        this.mappers = mappers;
     }
 
     /**
@@ -64,6 +67,15 @@ final class UnpackArtifactTask extends StagingTask {
         return includes;
     }
 
+    /**
+     * Get the mappers.
+     *
+     * @return mappers, never {@code null}
+     */
+    List<Mapper> mappers() {
+        return mappers;
+    }
+
     @Override
     protected void doExecute(StagingContext ctx, Path dir, Map<String, String> vars) throws IOException {
         ArtifactGAV resolvedGav = gav.resolve(vars);
@@ -73,6 +85,6 @@ final class UnpackArtifactTask extends StagingTask {
         Path targetDir = dir.resolve(resolvedTarget).normalize();
         ctx.logInfo("Unpacking %s to %s", artifact, targetDir);
         ctx.ensureDirectory(targetDir);
-        ctx.unpack(artifact, targetDir, excludes, includes);
+        ctx.unpack(artifact, targetDir, excludes, includes, mappers, resolvedVars);
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackTask.java
@@ -18,6 +18,7 @@ package io.helidon.build.maven.stager;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -38,14 +39,16 @@ final class UnpackTask extends StagingTask {
     private final String url;
     private final String includes;
     private final String excludes;
+    private final List<Mapper> mappers;
 
-    UnpackTask(ActionIterators iterators, Map<String, String> attrs) {
+    UnpackTask(ActionIterators iterators, List<Mapper> mappers, Map<String, String> attrs) {
         super(ELEMENT_NAME, null, iterators, attrs);
         this.url = Strings.requireValid(attrs.get("url"), "url is required");
         this.ext = Strings.requireValid(Optional.ofNullable(attrs.get("ext"))
                 .orElseGet(() -> fileExt(url)), "ext is required");
         this.includes = attrs.get("includes");
         this.excludes = attrs.get("excludes");
+        this.mappers = mappers;
     }
 
     /**
@@ -75,6 +78,15 @@ final class UnpackTask extends StagingTask {
         return includes;
     }
 
+    /**
+     * Get the mappers.
+     *
+     * @return mappers, never {@code null}
+     */
+    List<Mapper> mappers() {
+        return mappers;
+    }
+
     @Override
     protected CompletableFuture<Void> execBody(StagingContext ctx, Path dir, Map<String, String> vars) {
         return execBodyWithTimeout(ctx, dir, vars);
@@ -90,6 +102,6 @@ final class UnpackTask extends StagingTask {
         Path targetDir = dir.resolve(resolvedTarget).normalize();
         ctx.logInfo("Unpacking %s to %s", tempFile, targetDir);
         ctx.ensureDirectory(targetDir);
-        ctx.unpack(tempFile, targetDir, excludes, includes);
+        ctx.unpack(tempFile, targetDir, excludes, includes, mappers, vars);
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ConfigReaderTest.java
+++ b/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ConfigReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ConfigReaderTest.java
+++ b/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ConfigReaderTest.java
@@ -69,6 +69,10 @@ class ConfigReaderTest {
         assertThat(unpackGAV1.excludes(), is("META-INF/**"));
         assertThat(unpackGAV1.includes(), is(nullValue()));
         assertThat(unpackGAV1.target(), is("docs/{version}"));
+        assertThat(unpackGAV1.mappers().size(), is(1));
+        Mapper unpackGAV1Mapper = unpackGAV1.mappers().get(0);
+        assertThat(unpackGAV1Mapper.match(), is("^apidocs/(.*)$"));
+        assertThat(unpackGAV1Mapper.replace(), is("$1"));
         assertThat(unpackGAV1.iterators().size(), is(1));
         assertThat(unpackGAV1.iterators().get(0).next().get("version"), is("${docs.1.version}"));
         assertThat(unpackGAV1.iterators().get(0).next().get("version"), is("1.4.3"));
@@ -320,8 +324,13 @@ class ConfigReaderTest {
         assertThat(unpacks.size(), is(1));
 
         UnpackTask unpack1 = (UnpackTask) unpacks.get(0);
-        assertThat(unpack1.url(), is("https://repo1.maven.org/maven2/io/helidon/helidon-project/3.2.10/helidon-project-3.2.10-site.jar"));
-        assertThat(unpack1.target(), is("3.2.10"));
+        assertThat(unpack1.url(), is("https://repo1.maven.org/maven2/com/example/archive/1.0.0/archive-1.0.0.jar"));
+        assertThat(unpack1.target(), is("1.0.0"));
+        assertThat(unpack1.includes(), is("apidocs/**"));
+        assertThat(unpack1.mappers().size(), is(1));
+        Mapper unpack1Mapper = unpack1.mappers().get(0);
+        assertThat(unpack1Mapper.match(), is("^apidocs/(.*)$"));
+        assertThat(unpack1Mapper.replace(), is("$1"));
         assertThat(unpack1.tasks(), is(empty()));
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ProjectsTestIT.java
+++ b/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ProjectsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ProjectsTestIT.java
+++ b/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ProjectsTestIT.java
@@ -209,6 +209,10 @@ class ProjectsTestIT {
         assertThat(docsDir.resolve("1.4.3"), fileExists());
         assertThat(docsDir.resolve("1.4.4"), fileExists());
         assertThat(docsDir.resolve("2.0.0-RC1"), fileExists());
+
+        Path apidocsDir = stageDir.resolve("apidocs/1.4.3");
+        assertThat(apidocsDir.resolve("index.html"), fileExists());
+        assertThat(Files.exists(apidocsDir.resolve("apidocs/index.html")), is(false));
     }
 
     @ParameterizedTest
@@ -221,6 +225,10 @@ class ProjectsTestIT {
         assertThat(docsDir, fileExists());
         assertThat(docsDir.resolve("3.2.10"), fileExists());
         assertThat(docsDir.resolve("3.2.9"), fileExists());
+
+        Path apidocsDir = stageDir.resolve("apidocs/3.2.10");
+        assertThat(apidocsDir.resolve("index.html"), fileExists());
+        assertThat(Files.exists(apidocsDir.resolve("apidocs/index.html")), is(false));
     }
 
     private String symlinkTarget(Path file) {

--- a/maven-plugins/stager-maven-plugin/src/test/resources/test-config.xml
+++ b/maven-plugins/stager-maven-plugin/src/test/resources/test-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/maven-plugins/stager-maven-plugin/src/test/resources/test-config.xml
+++ b/maven-plugins/stager-maven-plugin/src/test/resources/test-config.xml
@@ -34,6 +34,9 @@
                     version="{version}"
                     excludes="META-INF/**"
                     target="docs/{version}">
+                <mappers>
+                    <mapper match="^apidocs/(.*)$" replace="$1"/>
+                </mappers>
                 <iterators>
                     <variables>
                         <variable ref="version" />
@@ -193,8 +196,13 @@
             </file>
         </files>
         <unpacks>
-            <unpack url="https://repo1.maven.org/maven2/io/helidon/helidon-project/3.2.10/helidon-project-3.2.10-site.jar"
-                target="3.2.10"/>
+            <unpack url="https://repo1.maven.org/maven2/com/example/archive/1.0.0/archive-1.0.0.jar"
+                    includes="apidocs/**"
+                    target="1.0.0">
+                <mappers>
+                    <mapper match="^apidocs/(.*)$" replace="$1"/>
+                </mappers>
+            </unpack>
         </unpacks>
     </directory>
 </directories>


### PR DESCRIPTION
## Description

Update stager-maven-plugin to support path mapping support for `unpack` and `unpack-artifact` tasks.

E.g.
```xml
<unpack-artifact
        groupId="io.helidon"
        artifactId="helidon-docs"
        version="1.4.3"
        includes="apidocs/**"
        target="apidocs/1.4.3">
    <mappers>
        <mapper match="^apidocs/(.*)$" replace="$1"/>
    </mappers>
</unpack-artifact>
```
